### PR TITLE
Make speculos setup code more robust in e2e tests

### DIFF
--- a/apps/sadik/client/tests/test_common/mod.rs
+++ b/apps/sadik/client/tests/test_common/mod.rs
@@ -22,25 +22,9 @@ impl TestSetup {
             "../app/target/riscv32i-unknown-none-elf/release/vnd-sadik".to_string()
         });
 
-        let child = Command::new("speculos")
-            .arg(vanadium_binary)
-            .arg("--display")
-            .arg("headless")
-            .spawn()
-            .expect("Failed to start speculos process");
+        let (child, transport) = spawn_speculos_and_transport(&vanadium_binary).await;
 
-        sleep(Duration::from_secs(1));
-
-        let transport_raw: Arc<
-            dyn Transport<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync,
-        > = Arc::new(
-            TransportTcp::new()
-                .await
-                .expect("Unable to get TCP transport. Is speculos running?"),
-        );
-        let transport = TransportWrapper::new(transport_raw.clone());
-
-        let (vanadium_client, _) = VanadiumAppClient::new(&vapp_binary, Arc::new(transport), None)
+        let (vanadium_client, _) = VanadiumAppClient::new(&vapp_binary, transport, None)
             .await
             .expect("Failed to create client");
 
@@ -56,6 +40,81 @@ impl Drop for TestSetup {
         self.child
             .wait()
             .expect("Failed to wait on speculos process");
+    }
+}
+
+/// Helper function to:
+/// 1) Spawn speculos
+/// 2) Poll for a running TCP transport (readiness)
+/// 3) If speculos dies prematurely, relaunch once
+async fn spawn_speculos_and_transport(
+    vanadium_binary: &str,
+) -> (
+    Child,
+    Arc<dyn Transport<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync>,
+) {
+    const MAX_LAUNCH_ATTEMPTS: usize = 2;
+    const MAX_POLL_ATTEMPTS: usize = 5;
+
+    let mut launch_attempts = 0;
+
+    loop {
+        // --- 1) Spawn speculos ---
+        let mut child = Command::new("speculos")
+            .arg(vanadium_binary)
+            .arg("--display")
+            .arg("headless")
+            .spawn()
+            .expect("Failed to spawn speculos process");
+
+        // --- 2) Poll for readiness ---
+        let mut transport: Option<Arc<_>> = None;
+
+        for _ in 0..MAX_POLL_ATTEMPTS {
+            // Check if speculos died
+            if let Ok(Some(status)) = child.try_wait() {
+                eprintln!(
+                    "Speculos exited early with status: {}",
+                    status.code().unwrap_or(-1)
+                );
+                break; // break out of poll loop, we'll relaunch if attempts remain
+            }
+
+            // If it's still alive, try to connect
+            match TransportTcp::new().await {
+                Ok(tcp) => {
+                    // If we succeed, wrap it up and return
+                    transport = Some(Arc::new(TransportWrapper::new(Arc::new(tcp))));
+                    break;
+                }
+                Err(_) => {
+                    // Wait a little before retrying
+                    sleep(Duration::from_millis(500));
+                }
+            }
+        }
+
+        // Did we succeed in getting a transport?
+        if let Some(t) = transport {
+            // Return on success
+            return (child, t);
+        }
+
+        // Otherwise, kill child and try again if we have attempts left
+        let _ = child.kill();
+        let _ = child.wait();
+
+        launch_attempts += 1;
+        if launch_attempts >= MAX_LAUNCH_ATTEMPTS {
+            panic!(
+                "Speculos did not become ready after {} launch attempts.",
+                launch_attempts
+            );
+        }
+        eprintln!(
+            "Retrying speculos launch (attempt {})...",
+            launch_attempts + 1
+        );
     }
 }
 

--- a/apps/test/client/tests/common/mod.rs
+++ b/apps/test/client/tests/common/mod.rs
@@ -22,31 +22,90 @@ impl TestSetup {
             "../app/target/riscv32i-unknown-none-elf/release/vnd-test".to_string()
         });
 
-        let child = Command::new("speculos")
-            .arg(vanadium_binary)
-            .arg("--display")
-            .arg("headless")
-            .spawn()
-            .expect("Failed to start speculos process");
+        let (child, transport) = spawn_speculos_and_transport(&vanadium_binary).await;
 
-        sleep(Duration::from_secs(1));
-
-        let transport_raw: Arc<
-            dyn Transport<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync,
-        > = Arc::new(
-            TransportTcp::new()
-                .await
-                .expect("Unable to get TCP transport. Is speculos running?"),
-        );
-        let transport = TransportWrapper::new(transport_raw.clone());
-
-        let (vanadium_client, _) = VanadiumAppClient::new(&vapp_binary, Arc::new(transport), None)
+        let (vanadium_client, _) = VanadiumAppClient::new(&vapp_binary, transport, None)
             .await
             .expect("Failed to create client");
 
         let client = TestClient::new(Box::new(vanadium_client));
 
         TestSetup { client, child }
+    }
+}
+
+/// Helper function to:
+/// 1) Spawn speculos
+/// 2) Poll for a running TCP transport (readiness)
+/// 3) If speculos dies prematurely, relaunch once
+async fn spawn_speculos_and_transport(
+    vanadium_binary: &str,
+) -> (
+    Child,
+    Arc<dyn Transport<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync>,
+) {
+    const MAX_LAUNCH_ATTEMPTS: usize = 2;
+    const MAX_POLL_ATTEMPTS: usize = 5;
+
+    let mut launch_attempts = 0;
+
+    loop {
+        // --- 1) Spawn speculos ---
+        let mut child = Command::new("speculos")
+            .arg(vanadium_binary)
+            .arg("--display")
+            .arg("headless")
+            .spawn()
+            .expect("Failed to spawn speculos process");
+
+        // --- 2) Poll for readiness ---
+        let mut transport: Option<Arc<_>> = None;
+
+        for _ in 0..MAX_POLL_ATTEMPTS {
+            // Check if speculos died
+            if let Ok(Some(status)) = child.try_wait() {
+                eprintln!(
+                    "Speculos exited early with status: {}",
+                    status.code().unwrap_or(-1)
+                );
+                break; // break out of poll loop, we'll relaunch if attempts remain
+            }
+
+            // If it's still alive, try to connect
+            match TransportTcp::new().await {
+                Ok(tcp) => {
+                    // If we succeed, wrap it up and return
+                    transport = Some(Arc::new(TransportWrapper::new(Arc::new(tcp))));
+                    break;
+                }
+                Err(_) => {
+                    // Wait a little before retrying
+                    sleep(Duration::from_millis(500));
+                }
+            }
+        }
+
+        // Did we succeed in getting a transport?
+        if let Some(t) = transport {
+            // Return on success
+            return (child, t);
+        }
+
+        // Otherwise, kill child and try again if we have attempts left
+        let _ = child.kill();
+        let _ = child.wait();
+
+        launch_attempts += 1;
+        if launch_attempts >= MAX_LAUNCH_ATTEMPTS {
+            panic!(
+                "Speculos did not become ready after {} launch attempts.",
+                launch_attempts
+            );
+        }
+        eprintln!(
+            "Retrying speculos launch (attempt {})...",
+            launch_attempts + 1
+        );
     }
 }
 


### PR DESCRIPTION
This avoids the e2e tests from failing in CI if setting up speculos fails on the first attempt.

Some shared code to setup/teardown speculos and the transport should probably be moved into the `client_sdk`, possibly gated in a feature only used in the e2e tests.

Closes: #50 