### PR TITLE
Added initial version of vlib-bitcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This repository is organized in a monorepo structure.
   * [test](apps/test) - Simple V-App to test the Vanadium VM, implementing various computational tasks.
   * [sadik](apps/sadik) - A V-App specifically designed to test the various functionality of the Vanadium V-App SDK, and particularly the ECALLs.
   * [bitcoin](apps/bitcoin) - Grandiose things will happen here, but it's mostly empty at this stage.
+* [libs](libs) - General purpos libraries that can be used by V-Apps
+  * [bitcoin](libs/bitcoin) - A custom clone of the [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) library
+
 
 In VSCode, opening the [vanadium.code-workspace](vanadium.code-workspace) is the most convenient way to work with this repository.
 

--- a/apps/bitcoin/app/Cargo.toml
+++ b/apps/bitcoin/app/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitcoin = { package = "vlib-bitcoin", path = "../../../libs/bitcoin", default-features = false}
 common = { package = "vnd-bitcoin-common", path = "../common"}
 quick-protobuf = { version = "0.8.1", default-features = false }
 sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}

--- a/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
+++ b/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 use common::message::{RequestGetExtendedPubkey, ResponseGetExtendedPubkey};
 use sdk::{

--- a/libs/bitcoin/Cargo.toml
+++ b/libs/bitcoin/Cargo.toml
@@ -14,7 +14,7 @@ name = "bitcoin"
 # TODO: get rid of these; need to replace with our reimplementations
 #       TBD if we replece completely, or only 'hijack' the slow bits
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "io"] }
-secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
+secp256k1 = { git = "https://github.com/LedgerHQ/vanadium-rust-secp256k1", branch="reloaded", default-features = false, features = ["hashes", "alloc"] }
 
 # TBD if we need to replace these with implementantions based on ecalls
 base58 = { package = "base58ck", version = "0.1.0", default-features = false }

--- a/libs/bitcoin/Cargo.toml
+++ b/libs/bitcoin/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "vlib-bitcoin"
+version = "0.32.5"
+edition = "2021"
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
+documentation = "https://docs.rs/bitcoin/"
+
+[lib]
+name = "bitcoin"
+
+[dependencies]
+
+# TODO: get rid of these; need to replace with our reimplementations
+#       TBD if we replece completely, or only 'hijack' the slow bits
+hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "io"] }
+secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
+
+# TBD if we need to replace these with implementantions based on ecalls
+base58 = { package = "base58ck", version = "0.1.0", default-features = false }
+bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
+
+# The following dependencies are left unchanged, as we do not need to change anything
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
+hex_lit = "0.1.1"
+internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
+io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
+sdk = { package = "vanadium-app-sdk", path = "../../app-sdk"}
+units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
+
+
+[dev-dependencies]
+serde_json = "1.0.0"
+
+[workspace]

--- a/libs/bitcoin/README.md
+++ b/libs/bitcoin/README.md
@@ -1,0 +1,15 @@
+This crate is mostly a clone of [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin), but modified in order to use the Vanadium V-App SDK for cryptography-related code.
+
+## Rationale
+
+`rust-bitcoin` natively implements all the necessary cryptographic primitives, and can be compiled to Risc-V. However, this would lose the benefits of the cryptographic accelerator available in signing devices, and made accessible to V-Apps via the Vanadium V-App SDK.
+
+By implementing a subset of `rust-bitcoin` while keeping the public API of this library as compatible as possible, we aim to minimize the burden of porting existing code using `rust-bitcoin` into Vanadium V-Apps.
+
+## Compatibility
+
+The reference implementation of `rust-bitcoin` is [release 0.32.5](https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-0.32.5) (commit [17ce61c171905ec0a23155a1a31b0c67776ee436](https://github.com/rust-bitcoin/rust-bitcoin/tree/17ce61c171905ec0a23155a1a31b0c67776ee436)).
+
+## Licence
+
+The code in this crate is liberally adapted from rust-bitcoin, and dual-licensed as Apache License v2, and Creative Commons Zero v1.0 Universal.

--- a/libs/bitcoin/src/address/error.rs
+++ b/libs/bitcoin/src/address/error.rs
@@ -1,0 +1,300 @@
+//! Error code for the address module.
+
+use core::fmt;
+
+use internals::write_err;
+
+use crate::address::{Address, NetworkUnchecked};
+use crate::blockdata::script::{witness_program, witness_version};
+use crate::prelude::*;
+use crate::Network;
+
+/// Error while generating address from script.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FromScriptError {
+    /// Script is not a p2pkh, p2sh or witness program.
+    UnrecognizedScript,
+    /// A witness program error.
+    WitnessProgram(witness_program::Error),
+    /// A witness version construction error.
+    WitnessVersion(witness_version::TryFromError),
+}
+
+internals::impl_from_infallible!(FromScriptError);
+
+impl fmt::Display for FromScriptError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FromScriptError::*;
+
+        match *self {
+            WitnessVersion(ref e) => write_err!(f, "witness version construction error"; e),
+            WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
+            UnrecognizedScript => write!(f, "script is not a p2pkh, p2sh or witness program"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromScriptError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromScriptError::*;
+
+        match *self {
+            UnrecognizedScript => None,
+            WitnessVersion(ref e) => Some(e),
+            WitnessProgram(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<witness_program::Error> for FromScriptError {
+    fn from(e: witness_program::Error) -> Self { Self::WitnessProgram(e) }
+}
+
+impl From<witness_version::TryFromError> for FromScriptError {
+    fn from(e: witness_version::TryFromError) -> Self { Self::WitnessVersion(e) }
+}
+
+/// Error while generating address from a p2sh script.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum P2shError {
+    /// Address size more than 520 bytes is not allowed.
+    ExcessiveScriptSize,
+}
+
+internals::impl_from_infallible!(P2shError);
+
+impl fmt::Display for P2shError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use P2shError::*;
+
+        match *self {
+            ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for P2shError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use P2shError::*;
+
+        match self {
+            ExcessiveScriptSize => None,
+        }
+    }
+}
+
+/// Address type is either invalid or not supported in rust-bitcoin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnknownAddressTypeError(pub String);
+
+impl fmt::Display for UnknownAddressTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "failed to parse {} as address type", self.0; self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnknownAddressTypeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// Address parsing error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseError {
+    /// Base58 error.
+    Base58(base58::Error),
+    /// Bech32 segwit decoding error.
+    Bech32(bech32::segwit::DecodeError),
+    /// A witness version conversion/parsing error.
+    WitnessVersion(witness_version::TryFromError),
+    /// A witness program error.
+    WitnessProgram(witness_program::Error),
+    /// Tried to parse an unknown HRP.
+    UnknownHrp(UnknownHrpError),
+    /// Legacy address is too long.
+    LegacyAddressTooLong(LegacyAddressTooLongError),
+    /// Invalid base58 payload data length for legacy address.
+    InvalidBase58PayloadLength(InvalidBase58PayloadLengthError),
+    /// Invalid legacy address prefix in base58 data payload.
+    InvalidLegacyPrefix(InvalidLegacyPrefixError),
+    /// Address's network differs from required one.
+    NetworkValidation(NetworkValidationError),
+}
+
+internals::impl_from_infallible!(ParseError);
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParseError::*;
+
+        match *self {
+            Base58(ref e) => write_err!(f, "base58 error"; e),
+            Bech32(ref e) => write_err!(f, "bech32 segwit decoding error"; e),
+            WitnessVersion(ref e) => write_err!(f, "witness version conversion/parsing error"; e),
+            WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
+            UnknownHrp(ref e) => write_err!(f, "tried to parse an unknown hrp"; e),
+            LegacyAddressTooLong(ref e) => write_err!(f, "legacy address base58 string"; e),
+            InvalidBase58PayloadLength(ref e) => write_err!(f, "legacy address base58 data"; e),
+            InvalidLegacyPrefix(ref e) => write_err!(f, "legacy address base58 prefix"; e),
+            NetworkValidation(ref e) => write_err!(f, "validation error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ParseError::*;
+
+        match *self {
+            Base58(ref e) => Some(e),
+            Bech32(ref e) => Some(e),
+            WitnessVersion(ref e) => Some(e),
+            WitnessProgram(ref e) => Some(e),
+            UnknownHrp(ref e) => Some(e),
+            LegacyAddressTooLong(ref e) => Some(e),
+            InvalidBase58PayloadLength(ref e) => Some(e),
+            InvalidLegacyPrefix(ref e) => Some(e),
+            NetworkValidation(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<base58::Error> for ParseError {
+    fn from(e: base58::Error) -> Self { Self::Base58(e) }
+}
+
+impl From<bech32::segwit::DecodeError> for ParseError {
+    fn from(e: bech32::segwit::DecodeError) -> Self { Self::Bech32(e) }
+}
+
+impl From<witness_version::TryFromError> for ParseError {
+    fn from(e: witness_version::TryFromError) -> Self { Self::WitnessVersion(e) }
+}
+
+impl From<witness_program::Error> for ParseError {
+    fn from(e: witness_program::Error) -> Self { Self::WitnessProgram(e) }
+}
+
+impl From<UnknownHrpError> for ParseError {
+    fn from(e: UnknownHrpError) -> Self { Self::UnknownHrp(e) }
+}
+
+impl From<LegacyAddressTooLongError> for ParseError {
+    fn from(e: LegacyAddressTooLongError) -> Self { Self::LegacyAddressTooLong(e) }
+}
+
+impl From<InvalidBase58PayloadLengthError> for ParseError {
+    fn from(e: InvalidBase58PayloadLengthError) -> Self { Self::InvalidBase58PayloadLength(e) }
+}
+
+impl From<InvalidLegacyPrefixError> for ParseError {
+    fn from(e: InvalidLegacyPrefixError) -> Self { Self::InvalidLegacyPrefix(e) }
+}
+
+impl From<NetworkValidationError> for ParseError {
+    fn from(e: NetworkValidationError) -> Self { Self::NetworkValidation(e) }
+}
+
+/// Unknown HRP error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnknownHrpError(pub String);
+
+impl fmt::Display for UnknownHrpError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "unknown hrp: {}", self.0) }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnknownHrpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// Address's network differs from required one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkValidationError {
+    /// Network that was required.
+    pub(crate) required: Network,
+    /// The address itself.
+    pub(crate) address: Address<NetworkUnchecked>,
+}
+
+impl fmt::Display for NetworkValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "address ")?;
+        fmt::Display::fmt(&self.address.0, f)?;
+        write!(f, " is not valid on {}", self.required)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NetworkValidationError {}
+
+/// Decoded base58 data was an invalid length.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidBase58PayloadLengthError {
+    /// The base58 payload length we got after decoding address string.
+    pub(crate) length: usize,
+}
+
+impl InvalidBase58PayloadLengthError {
+    /// Returns the invalid payload length.
+    pub fn invalid_base58_payload_length(&self) -> usize { self.length }
+}
+
+impl fmt::Display for InvalidBase58PayloadLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "decoded base58 data was an invalid length: {} (expected 21)", self.length)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidBase58PayloadLengthError {}
+
+/// Legacy base58 address was too long, max 50 characters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyAddressTooLongError {
+    /// The length of the legacy address.
+    pub(crate) length: usize,
+}
+
+impl LegacyAddressTooLongError {
+    /// Returns the invalid legacy address length.
+    pub fn invalid_legcay_address_length(&self) -> usize { self.length }
+}
+
+impl fmt::Display for LegacyAddressTooLongError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "legacy address is too long: {} (max 50 characters)", self.length)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for LegacyAddressTooLongError {}
+
+/// Invalid legacy address prefix in decoded base58 data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidLegacyPrefixError {
+    /// The invalid prefix byte.
+    pub(crate) invalid: u8,
+}
+
+impl InvalidLegacyPrefixError {
+    /// Returns the invalid prefix.
+    pub fn invalid_legacy_address_prefix(&self) -> u8 { self.invalid }
+}
+
+impl fmt::Display for InvalidLegacyPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid legacy address prefix in decoded base58 data {}", self.invalid)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidLegacyPrefixError {}

--- a/libs/bitcoin/src/address/mod.rs
+++ b/libs/bitcoin/src/address/mod.rs
@@ -1,0 +1,1370 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin addresses.
+//!
+//! Support for ordinary base58 Bitcoin addresses and private keys.
+//!
+//! # Example: creating a new address from a randomly-generated key pair
+//!
+//! ```rust
+//! # #[cfg(feature = "rand-std")] {
+//! use bitcoin::{Address, PublicKey, Network};
+//! use bitcoin::secp256k1::{rand, Secp256k1};
+//!
+//! // Generate random key pair.
+//! let s = Secp256k1::new();
+//! let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
+//!
+//! // Generate pay-to-pubkey-hash address.
+//! let address = Address::p2pkh(&public_key, Network::Bitcoin);
+//! # }
+//! ```
+//!
+//! # Note: creating a new address requires the rand-std feature flag
+//!
+//! ```toml
+//! bitcoin = { version = "...", features = ["rand-std"] }
+//! ```
+
+pub mod error;
+
+use core::fmt;
+use core::marker::PhantomData;
+use core::str::FromStr;
+
+use bech32::primitives::hrp::Hrp;
+use hashes::{sha256, Hash, HashEngine};
+use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
+
+use crate::blockdata::constants::{
+    MAX_SCRIPT_ELEMENT_SIZE, PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST,
+    SCRIPT_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_TEST,
+};
+use crate::blockdata::script::witness_program::WitnessProgram;
+use crate::blockdata::script::witness_version::WitnessVersion;
+use crate::blockdata::script::{self, Script, ScriptBuf, ScriptHash};
+use crate::consensus::Params;
+use crate::crypto::key::{
+    CompressedPublicKey, PubkeyHash, PublicKey, TweakedPublicKey, UntweakedPublicKey,
+};
+use crate::network::{Network, NetworkKind};
+use crate::prelude::*;
+use crate::taproot::TapNodeHash;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    error::{
+        FromScriptError, InvalidBase58PayloadLengthError, InvalidLegacyPrefixError, LegacyAddressTooLongError,
+        NetworkValidationError, ParseError, P2shError, UnknownAddressTypeError, UnknownHrpError
+    },
+};
+
+/// The different types of addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum AddressType {
+    /// Pay to pubkey hash.
+    P2pkh,
+    /// Pay to script hash.
+    P2sh,
+    /// Pay to witness pubkey hash.
+    P2wpkh,
+    /// Pay to witness script hash.
+    P2wsh,
+    /// Pay to taproot.
+    P2tr,
+}
+
+impl fmt::Display for AddressType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match *self {
+            AddressType::P2pkh => "p2pkh",
+            AddressType::P2sh => "p2sh",
+            AddressType::P2wpkh => "p2wpkh",
+            AddressType::P2wsh => "p2wsh",
+            AddressType::P2tr => "p2tr",
+        })
+    }
+}
+
+impl FromStr for AddressType {
+    type Err = UnknownAddressTypeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "p2pkh" => Ok(AddressType::P2pkh),
+            "p2sh" => Ok(AddressType::P2sh),
+            "p2wpkh" => Ok(AddressType::P2wpkh),
+            "p2wsh" => Ok(AddressType::P2wsh),
+            "p2tr" => Ok(AddressType::P2tr),
+            _ => Err(UnknownAddressTypeError(s.to_owned())),
+        }
+    }
+}
+
+mod sealed {
+    pub trait NetworkValidation {}
+    impl NetworkValidation for super::NetworkChecked {}
+    impl NetworkValidation for super::NetworkUnchecked {}
+}
+
+/// Marker of status of address's network validation. See section [*Parsing addresses*](Address#parsing-addresses)
+/// on [`Address`] for details.
+pub trait NetworkValidation: sealed::NetworkValidation + Sync + Send + Sized + Unpin {
+    /// Indicates whether this `NetworkValidation` is `NetworkChecked` or not.
+    const IS_CHECKED: bool;
+}
+
+/// Marker that address's network has been successfully validated. See section [*Parsing addresses*](Address#parsing-addresses)
+/// on [`Address`] for details.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NetworkChecked {}
+
+/// Marker that address's network has not yet been validated. See section [*Parsing addresses*](Address#parsing-addresses)
+/// on [`Address`] for details.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NetworkUnchecked {}
+
+impl NetworkValidation for NetworkChecked {
+    const IS_CHECKED: bool = true;
+}
+impl NetworkValidation for NetworkUnchecked {
+    const IS_CHECKED: bool = false;
+}
+
+/// The inner representation of an address, without the network validation tag.
+///
+/// This struct represents the inner representation of an address without the network validation
+/// tag, which is used to ensure that addresses are used only on the appropriate network.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum AddressInner {
+    P2pkh { hash: PubkeyHash, network: NetworkKind },
+    P2sh { hash: ScriptHash, network: NetworkKind },
+    Segwit { program: WitnessProgram, hrp: KnownHrp },
+}
+
+/// Formats bech32 as upper case if alternate formatting is chosen (`{:#}`).
+impl fmt::Display for AddressInner {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use AddressInner::*;
+        match self {
+            P2pkh { hash, network } => {
+                let mut prefixed = [0; 21];
+                prefixed[0] = match network {
+                    NetworkKind::Main => PUBKEY_ADDRESS_PREFIX_MAIN,
+                    NetworkKind::Test => PUBKEY_ADDRESS_PREFIX_TEST,
+                };
+                prefixed[1..].copy_from_slice(&hash[..]);
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
+            }
+            P2sh { hash, network } => {
+                let mut prefixed = [0; 21];
+                prefixed[0] = match network {
+                    NetworkKind::Main => SCRIPT_ADDRESS_PREFIX_MAIN,
+                    NetworkKind::Test => SCRIPT_ADDRESS_PREFIX_TEST,
+                };
+                prefixed[1..].copy_from_slice(&hash[..]);
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
+            }
+            Segwit { program, hrp } => {
+                let hrp = hrp.to_hrp();
+                let version = program.version().to_fe();
+                let program = program.program().as_ref();
+
+                if fmt.alternate() {
+                    bech32::segwit::encode_upper_to_fmt_unchecked(fmt, hrp, version, program)
+                } else {
+                    bech32::segwit::encode_lower_to_fmt_unchecked(fmt, hrp, version, program)
+                }
+            }
+        }
+    }
+}
+
+/// Known bech32 human-readable parts.
+///
+/// This is the human-readable part before the separator (`1`) in a bech32 encoded address e.g.,
+/// the "bc" in "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5".
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum KnownHrp {
+    /// The main Bitcoin network.
+    Mainnet,
+    /// The test networks, testnet (testnet3), testnet4, and signet.
+    Testnets,
+    /// The regtest network.
+    Regtest,
+}
+
+impl KnownHrp {
+    /// Creates a `KnownHrp` from `network`.
+    fn from_network(network: Network) -> Self {
+        use Network::*;
+
+        match network {
+            Bitcoin => Self::Mainnet,
+            Testnet | Testnet4 | Signet => Self::Testnets,
+            Regtest => Self::Regtest,
+        }
+    }
+
+    /// Creates a `KnownHrp` from a [`bech32::Hrp`].
+    fn from_hrp(hrp: Hrp) -> Result<Self, UnknownHrpError> {
+        if hrp == bech32::hrp::BC {
+            Ok(Self::Mainnet)
+        } else if hrp.is_valid_on_testnet() || hrp.is_valid_on_signet() {
+            Ok(Self::Testnets)
+        } else if hrp == bech32::hrp::BCRT {
+            Ok(Self::Regtest)
+        } else {
+            Err(UnknownHrpError(hrp.to_lowercase()))
+        }
+    }
+
+    /// Converts, infallibly a known HRP to a [`bech32::Hrp`].
+    fn to_hrp(self) -> Hrp {
+        match self {
+            Self::Mainnet => bech32::hrp::BC,
+            Self::Testnets => bech32::hrp::TB,
+            Self::Regtest => bech32::hrp::BCRT,
+        }
+    }
+}
+
+impl From<Network> for KnownHrp {
+    fn from(n: Network) -> Self { Self::from_network(n) }
+}
+
+/// The data encoded by an `Address`.
+///
+/// This is the data used to encumber an output that pays to this address i.e., it is the address
+/// excluding the network information.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum AddressData {
+    /// Data encoded by a P2PKH address.
+    P2pkh {
+        /// The pubkey hash used to encumber outputs to this address.
+        pubkey_hash: PubkeyHash
+    },
+    /// Data encoded by a P2SH address.
+    P2sh {
+        /// The script hash used to encumber outputs to this address.
+        script_hash: ScriptHash
+    },
+    /// Data encoded by a Segwit address.
+    Segwit {
+        /// The witness program used to encumber outputs to this address.
+        witness_program: WitnessProgram
+    },
+}
+
+/// A Bitcoin address.
+///
+/// ### Parsing addresses
+///
+/// When parsing string as an address, one has to pay attention to the network, on which the parsed
+/// address is supposed to be valid. For the purpose of this validation, `Address` has
+/// [`is_valid_for_network`](Address<NetworkUnchecked>::is_valid_for_network) method. In order to provide more safety,
+/// enforced by compiler, `Address` also contains a special marker type, which indicates whether network of the parsed
+/// address has been checked. This marker type will prevent from calling certain functions unless the network
+/// verification has been successfully completed.
+///
+/// The result of parsing an address is `Address<NetworkUnchecked>` suggesting that network of the parsed address
+/// has not yet been verified. To perform this verification, method [`require_network`](Address<NetworkUnchecked>::require_network)
+/// can be called, providing network on which the address is supposed to be valid. If the verification succeeds,
+/// `Address<NetworkChecked>` is returned.
+///
+/// The types `Address` and `Address<NetworkChecked>` are synonymous, i. e. they can be used interchangeably.
+///
+/// ```rust
+/// use std::str::FromStr;
+/// use bitcoin::{Address, Network};
+/// use bitcoin::address::{NetworkUnchecked, NetworkChecked};
+///
+/// // variant 1
+/// let address: Address<NetworkUnchecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse().unwrap();
+/// let address: Address<NetworkChecked> = address.require_network(Network::Bitcoin).unwrap();
+///
+/// // variant 2
+/// let address: Address = Address::from_str("32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf").unwrap()
+///                .require_network(Network::Bitcoin).unwrap();
+///
+/// // variant 3
+/// let address: Address<NetworkChecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse::<Address<_>>()
+///                .unwrap().require_network(Network::Bitcoin).unwrap();
+/// ```
+///
+/// ### Formatting addresses
+///
+/// To format address into its textual representation, both `Debug` (for usage in programmer-facing,
+/// debugging context) and `Display` (for user-facing output) can be used, with the following caveats:
+///
+/// 1. `Display` is implemented only for `Address<NetworkChecked>`:
+///
+/// ```
+/// # use std::str::FromStr;
+/// # use bitcoin::address::{Address, NetworkChecked};
+/// let address: Address<NetworkChecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+///                .unwrap().assume_checked();
+/// assert_eq!(address.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
+/// ```
+///
+/// ```ignore
+/// # use std::str::FromStr;
+/// # use bitcoin::address::{Address, NetworkChecked};
+/// let address: Address<NetworkUnchecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+///                .unwrap();
+/// let s = address.to_string(); // does not compile
+/// ```
+///
+/// 2. `Debug` on `Address<NetworkUnchecked>` does not produce clean address but address wrapped by
+///    an indicator that its network has not been checked. This is to encourage programmer to properly
+///    check the network and use `Display` in user-facing context.
+///
+/// ```
+/// # use std::str::FromStr;
+/// # use bitcoin::address::{Address, NetworkUnchecked};
+/// let address: Address<NetworkUnchecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+///                .unwrap();
+/// assert_eq!(format!("{:?}", address), "Address<NetworkUnchecked>(132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM)");
+/// ```
+///
+/// ```
+/// # use std::str::FromStr;
+/// # use bitcoin::address::{Address, NetworkChecked};
+/// let address: Address<NetworkChecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+///                .unwrap().assume_checked();
+/// assert_eq!(format!("{:?}", address), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
+/// ```
+///
+/// ### Relevant BIPs
+///
+/// * [BIP13 - Address Format for pay-to-script-hash](https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki)
+/// * [BIP16 - Pay to Script Hash](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki)
+/// * [BIP141 - Segregated Witness (Consensus layer)](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
+/// * [BIP142 - Address Format for Segregated Witness](https://github.com/bitcoin/bips/blob/master/bip-0142.mediawiki)
+/// * [BIP341 - Taproot: SegWit version 1 spending rules](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)
+/// * [BIP350 - Bech32m format for v1+ witness addresses](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// The `#[repr(transparent)]` attribute is used to guarantee the layout of the `Address` struct. It
+// is an implementation detail and users should not rely on it in their code.
+#[repr(transparent)]
+pub struct Address<V = NetworkChecked>(AddressInner, PhantomData<V>)
+where
+    V: NetworkValidation;
+
+#[cfg(feature = "serde")]
+struct DisplayUnchecked<'a, N: NetworkValidation>(&'a Address<N>);
+
+#[cfg(feature = "serde")]
+impl<N: NetworkValidation> fmt::Display for DisplayUnchecked<'_, N> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0 .0, fmt) }
+}
+
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_deserialize_impl!(Address<NetworkUnchecked>, "a Bitcoin address");
+
+#[cfg(feature = "serde")]
+impl<N: NetworkValidation> serde::Serialize for Address<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&DisplayUnchecked(self))
+    }
+}
+
+/// Methods on [`Address`] that can be called on both `Address<NetworkChecked>` and
+/// `Address<NetworkUnchecked>`.
+impl<V: NetworkValidation> Address<V> {
+    /// Returns a reference to the address as if it was unchecked.
+    pub fn as_unchecked(&self) -> &Address<NetworkUnchecked> {
+        unsafe { &*(self as *const Address<V> as *const Address<NetworkUnchecked>) }
+    }
+
+    /// Marks the network of this address as unchecked.
+    pub fn into_unchecked(self) -> Address<NetworkUnchecked> { Address(self.0, PhantomData) }
+}
+
+/// Methods and functions that can be called only on `Address<NetworkChecked>`.
+impl Address {
+    /// Creates a pay to (compressed) public key hash address from a public key.
+    ///
+    /// This is the preferred non-witness type address.
+    #[inline]
+    pub fn p2pkh(pk: impl Into<PubkeyHash>, network: impl Into<NetworkKind>) -> Address {
+        let hash = pk.into();
+        Self(AddressInner::P2pkh { hash, network: network.into() }, PhantomData)
+    }
+
+    /// Creates a pay to script hash P2SH address from a script.
+    ///
+    /// This address type was introduced with BIP16 and is the popular type to implement multi-sig
+    /// these days.
+    #[inline]
+    pub fn p2sh(script: &Script, network: impl Into<NetworkKind>) -> Result<Address, P2shError> {
+        if script.len() > MAX_SCRIPT_ELEMENT_SIZE {
+            return Err(P2shError::ExcessiveScriptSize);
+        }
+        let hash = script.script_hash();
+        Ok(Address::p2sh_from_hash(hash, network))
+    }
+
+    /// Creates a pay to script hash P2SH address from a script hash.
+    ///
+    /// # Warning
+    ///
+    /// The `hash` pre-image (redeem script) must not exceed 520 bytes in length
+    /// otherwise outputs created from the returned address will be un-spendable.
+    pub fn p2sh_from_hash(hash: ScriptHash, network: impl Into<NetworkKind>) -> Address {
+        Self(AddressInner::P2sh { hash, network: network.into() }, PhantomData)
+    }
+
+    /// Creates a witness pay to public key address from a public key.
+    ///
+    /// This is the native segwit address type for an output redeemable with a single signature.
+    pub fn p2wpkh(pk: &CompressedPublicKey, hrp: impl Into<KnownHrp>) -> Self {
+        let program = WitnessProgram::p2wpkh(pk);
+        Address::from_witness_program(program, hrp)
+    }
+
+    /// Creates a pay to script address that embeds a witness pay to public key.
+    ///
+    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
+    pub fn p2shwpkh(pk: &CompressedPublicKey, network: impl Into<NetworkKind>) -> Address {
+        let builder = script::Builder::new().push_int(0).push_slice(pk.wpubkey_hash());
+        let script_hash = builder.as_script().script_hash();
+        Address::p2sh_from_hash(script_hash, network)
+    }
+
+    /// Creates a witness pay to script hash address.
+    pub fn p2wsh(script: &Script, hrp: impl Into<KnownHrp>) -> Address {
+        let program = WitnessProgram::p2wsh(script);
+        Address::from_witness_program(program, hrp)
+    }
+
+    /// Creates a pay to script address that embeds a witness pay to script hash address.
+    ///
+    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
+    pub fn p2shwsh(script: &Script, network: impl Into<NetworkKind>) -> Address {
+        let builder = script::Builder::new().push_int(0).push_slice(script.wscript_hash());
+        let script_hash = builder.as_script().script_hash();
+        Address::p2sh_from_hash(script_hash, network)
+    }
+
+    /// Creates a pay to taproot address from an untweaked key.
+    pub fn p2tr<C: Verification>(
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+        merkle_root: Option<TapNodeHash>,
+        hrp: impl Into<KnownHrp>,
+    ) -> Address {
+        let program = WitnessProgram::p2tr(secp, internal_key, merkle_root);
+        Address::from_witness_program(program, hrp)
+    }
+
+    /// Creates a pay to taproot address from a pre-tweaked output key.
+    pub fn p2tr_tweaked(output_key: TweakedPublicKey, hrp: impl Into<KnownHrp>) -> Address {
+        let program = WitnessProgram::p2tr_tweaked(output_key);
+        Address::from_witness_program(program, hrp)
+    }
+
+    /// Creates an address from an arbitrary witness program.
+    ///
+    /// This only exists to support future witness versions. If you are doing normal mainnet things
+    /// then you likely do not need this constructor.
+    pub fn from_witness_program(program: WitnessProgram, hrp: impl Into<KnownHrp>) -> Address {
+        let inner = AddressInner::Segwit { program, hrp: hrp.into() };
+        Address(inner, PhantomData)
+    }
+
+    /// Gets the address type of the address.
+    ///
+    /// # Returns
+    ///
+    /// None if unknown, non-standard or related to the future witness version.
+    #[inline]
+    pub fn address_type(&self) -> Option<AddressType> {
+        match self.0 {
+            AddressInner::P2pkh { .. } => Some(AddressType::P2pkh),
+            AddressInner::P2sh { .. } => Some(AddressType::P2sh),
+            AddressInner::Segwit { ref program, hrp: _ } =>
+                if program.is_p2wpkh() {
+                    Some(AddressType::P2wpkh)
+                } else if program.is_p2wsh() {
+                    Some(AddressType::P2wsh)
+                } else if program.is_p2tr() {
+                    Some(AddressType::P2tr)
+                } else {
+                    None
+                },
+        }
+    }
+
+    /// Gets the address data from this address.
+    pub fn to_address_data(&self) -> AddressData {
+        use AddressData::*;
+
+        match self.0 {
+            AddressInner::P2pkh { hash, network: _ } => P2pkh { pubkey_hash: hash },
+            AddressInner::P2sh { hash, network: _ } => P2sh { script_hash: hash },
+            AddressInner::Segwit { program, hrp: _ } => Segwit { witness_program: program },
+        }
+    }
+
+    /// Gets the pubkey hash for this address if this is a P2PKH address.
+    pub fn pubkey_hash(&self) -> Option<PubkeyHash> {
+        use AddressInner::*;
+
+        match self.0 {
+            P2pkh { ref hash, network: _ } => Some(*hash),
+            _ => None,
+        }
+    }
+
+    /// Gets the script hash for this address if this is a P2SH address.
+    pub fn script_hash(&self) -> Option<ScriptHash> {
+        use AddressInner::*;
+
+        match self.0 {
+            P2sh { ref hash, network: _ } => Some(*hash),
+            _ => None,
+        }
+    }
+
+    /// Gets the witness program for this address if this is a segwit address.
+    pub fn witness_program(&self) -> Option<WitnessProgram> {
+        use AddressInner::*;
+
+        match self.0 {
+            Segwit { ref program, hrp: _ } => Some(*program),
+            _ => None,
+        }
+    }
+
+    /// Checks whether or not the address is following Bitcoin standardness rules when
+    /// *spending* from this address. *NOT* to be called by senders.
+    ///
+    /// <details>
+    /// <summary>Spending Standardness</summary>
+    ///
+    /// For forward compatibility, the senders must send to any [`Address`]. Receivers
+    /// can use this method to check whether or not they can spend from this address.
+    ///
+    /// SegWit addresses with unassigned witness versions or non-standard program sizes are
+    /// considered non-standard.
+    /// </details>
+    ///
+    pub fn is_spend_standard(&self) -> bool { self.address_type().is_some() }
+
+    /// Constructs an [`Address`] from an output script (`scriptPubkey`).
+    pub fn from_script(script: &Script, params: impl AsRef<Params>) -> Result<Address, FromScriptError> {
+        let network = params.as_ref().network;
+        if script.is_p2pkh() {
+            let bytes = script.as_bytes()[3..23].try_into().expect("statically 20B long");
+            let hash = PubkeyHash::from_byte_array(bytes);
+            Ok(Address::p2pkh(hash, network))
+        } else if script.is_p2sh() {
+            let bytes = script.as_bytes()[2..22].try_into().expect("statically 20B long");
+            let hash = ScriptHash::from_byte_array(bytes);
+            Ok(Address::p2sh_from_hash(hash, network))
+        } else if script.is_witness_program() {
+            let opcode = script.first_opcode().expect("is_witness_program guarantees len > 4");
+
+            let version = WitnessVersion::try_from(opcode)?;
+            let program = WitnessProgram::new(version, &script.as_bytes()[2..])?;
+            Ok(Address::from_witness_program(program, network))
+        } else {
+            Err(FromScriptError::UnrecognizedScript)
+        }
+    }
+
+    /// Generates a script pubkey spending to this address.
+    pub fn script_pubkey(&self) -> ScriptBuf {
+        use AddressInner::*;
+        match self.0 {
+            P2pkh { ref hash, network: _ } => ScriptBuf::new_p2pkh(hash),
+            P2sh { ref hash, network: _ } => ScriptBuf::new_p2sh(hash),
+            Segwit { ref program, hrp: _ } => {
+                let prog = program.program();
+                let version = program.version();
+                ScriptBuf::new_witness_program_unchecked(version, prog)
+            }
+        }
+    }
+
+    /// Creates a URI string *bitcoin:address* optimized to be encoded in QR codes.
+    ///
+    /// If the address is bech32, the address becomes uppercase.
+    /// If the address is base58, the address is left mixed case.
+    ///
+    /// Quoting BIP 173 "inside QR codes uppercase SHOULD be used, as those permit the use of
+    /// alphanumeric mode, which is 45% more compact than the normal byte mode."
+    ///
+    /// Note however that despite BIP21 explicitly stating that the `bitcoin:` prefix should be
+    /// parsed as case-insensitive many wallets got this wrong and don't parse correctly.
+    /// [See compatibility table.](https://github.com/btcpayserver/btcpayserver/issues/2110)
+    ///
+    /// If you want to avoid allocation you can use alternate display instead:
+    /// ```
+    /// # use core::fmt::Write;
+    /// # const ADDRESS: &str = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4";
+    /// # let address = ADDRESS.parse::<bitcoin::Address<_>>().unwrap().assume_checked();
+    /// # let mut writer = String::new();
+    /// # // magic trick to make error handling look better
+    /// # (|| -> Result<(), core::fmt::Error> {
+    ///
+    /// write!(writer, "{:#}", address)?;
+    ///
+    /// # Ok(())
+    /// # })().unwrap();
+    /// # assert_eq!(writer, ADDRESS);
+    /// ```
+    pub fn to_qr_uri(&self) -> String { format!("bitcoin:{:#}", self) }
+
+    /// Returns true if the given pubkey is directly related to the address payload.
+    ///
+    /// This is determined by directly comparing the address payload with either the
+    /// hash of the given public key or the segwit redeem hash generated from the
+    /// given key. For taproot addresses, the supplied key is assumed to be tweaked
+    pub fn is_related_to_pubkey(&self, pubkey: &PublicKey) -> bool {
+        let pubkey_hash = pubkey.pubkey_hash();
+        let payload = self.payload_as_bytes();
+        let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
+
+        (*pubkey_hash.as_byte_array() == *payload)
+            || (xonly_pubkey.serialize() == *payload)
+            || (*segwit_redeem_hash(&pubkey_hash).as_byte_array() == *payload)
+    }
+
+    /// Returns true if the supplied xonly public key can be used to derive the address.
+    ///
+    /// This will only work for Taproot addresses. The Public Key is
+    /// assumed to have already been tweaked.
+    pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: &XOnlyPublicKey) -> bool {
+        xonly_pubkey.serialize() == *self.payload_as_bytes()
+    }
+
+    /// Returns true if the address creates a particular script
+    /// This function doesn't make any allocations.
+    pub fn matches_script_pubkey(&self, script: &Script) -> bool {
+        use AddressInner::*;
+        match self.0 {
+            P2pkh { ref hash, network: _ } if script.is_p2pkh() =>
+                &script.as_bytes()[3..23] == <PubkeyHash as AsRef<[u8; 20]>>::as_ref(hash),
+            P2sh { ref hash, network: _ } if script.is_p2sh() =>
+                &script.as_bytes()[2..22] == <ScriptHash as AsRef<[u8; 20]>>::as_ref(hash),
+            Segwit { ref program, hrp: _ } if script.is_witness_program() =>
+                &script.as_bytes()[2..] == program.program().as_bytes(),
+            P2pkh { .. } | P2sh { .. } | Segwit { .. } => false,
+        }
+    }
+
+    /// Returns the "payload" for this address.
+    ///
+    /// The "payload" is the useful stuff excluding serialization prefix, the exact payload is
+    /// dependent on the inner address:
+    ///
+    /// - For p2sh, the payload is the script hash.
+    /// - For p2pkh, the payload is the pubkey hash.
+    /// - For segwit addresses, the payload is the witness program.
+    fn payload_as_bytes(&self) -> &[u8] {
+        use AddressInner::*;
+        match self.0 {
+            P2sh { ref hash, network: _ } => hash.as_ref(),
+            P2pkh { ref hash, network: _ } => hash.as_ref(),
+            Segwit { ref program, hrp: _ } => program.program().as_bytes(),
+        }
+    }
+}
+
+/// Methods that can be called only on `Address<NetworkUnchecked>`.
+impl Address<NetworkUnchecked> {
+    /// Returns a reference to the checked address.
+    ///
+    /// This function is dangerous in case the address is not a valid checked address.
+    pub fn assume_checked_ref(&self) -> &Address {
+        unsafe { &*(self as *const Address<NetworkUnchecked> as *const Address) }
+    }
+
+    /// Parsed addresses do not always have *one* network. The problem is that legacy testnet,
+    /// regtest and signet addresse use the same prefix instead of multiple different ones. When
+    /// parsing, such addresses are always assumed to be testnet addresses (the same is true for
+    /// bech32 signet addresses). So if one wants to check if an address belongs to a certain
+    /// network a simple comparison is not enough anymore. Instead this function can be used.
+    ///
+    /// ```rust
+    /// use bitcoin::{Address, Network};
+    /// use bitcoin::address::NetworkUnchecked;
+    ///
+    /// let address: Address<NetworkUnchecked> = "2N83imGV3gPwBzKJQvWJ7cRUY2SpUyU6A5e".parse().unwrap();
+    /// assert!(address.is_valid_for_network(Network::Testnet));
+    /// assert!(address.is_valid_for_network(Network::Regtest));
+    /// assert!(address.is_valid_for_network(Network::Signet));
+    ///
+    /// assert_eq!(address.is_valid_for_network(Network::Bitcoin), false);
+    ///
+    /// let address: Address<NetworkUnchecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse().unwrap();
+    /// assert!(address.is_valid_for_network(Network::Bitcoin));
+    /// assert_eq!(address.is_valid_for_network(Network::Testnet4), false);
+    /// ```
+    pub fn is_valid_for_network(&self, n: Network) -> bool {
+        use AddressInner::*;
+        match self.0 {
+            P2pkh { hash: _, ref network } => *network == NetworkKind::from(n),
+            P2sh { hash: _, ref network } => *network == NetworkKind::from(n),
+            Segwit { program: _, ref hrp } => *hrp == KnownHrp::from_network(n),
+        }
+    }
+
+    /// Checks whether network of this address is as required.
+    ///
+    /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
+    /// on [`Address`].
+    ///
+    /// # Errors
+    ///
+    /// This function only ever returns the [`ParseError::NetworkValidation`] variant of
+    /// `ParseError`. This is not how we normally implement errors in this library but
+    /// `require_network` is not a typical function, it is conceptually part of string parsing.
+    ///
+    ///  # Examples
+    ///
+    /// ```
+    /// use bitcoin::address::{NetworkChecked, NetworkUnchecked, ParseError};
+    /// use bitcoin::{Address, Network};
+    ///
+    /// const ADDR: &str = "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs";
+    ///
+    /// fn parse_and_validate_address(network: Network) -> Result<Address, ParseError> {
+    ///     let address = ADDR.parse::<Address<_>>()?
+    ///                       .require_network(network)?;
+    ///     Ok(address)
+    /// }
+    ///
+    /// fn parse_and_validate_address_combinator(network: Network) -> Result<Address, ParseError> {
+    ///     let address = ADDR.parse::<Address<_>>()
+    ///                       .and_then(|a| a.require_network(network))?;
+    ///     Ok(address)
+    /// }
+    ///
+    /// fn parse_and_validate_address_show_types(network: Network) -> Result<Address, ParseError> {
+    ///     let address: Address<NetworkChecked> = ADDR.parse::<Address<NetworkUnchecked>>()?
+    ///                                                .require_network(network)?;
+    ///     Ok(address)
+    /// }
+    ///
+    /// let network = Network::Bitcoin;  // Don't hard code network in applications.
+    /// let _ = parse_and_validate_address(network).unwrap();
+    /// let _ = parse_and_validate_address_combinator(network).unwrap();
+    /// let _ = parse_and_validate_address_show_types(network).unwrap();
+    /// ```
+    #[inline]
+    pub fn require_network(self, required: Network) -> Result<Address, ParseError> {
+        if self.is_valid_for_network(required) {
+            Ok(self.assume_checked())
+        } else {
+            Err(NetworkValidationError { required, address: self }.into())
+        }
+    }
+
+    /// Marks, without any additional checks, network of this address as checked.
+    ///
+    /// Improper use of this method may lead to loss of funds. Reader will most likely prefer
+    /// [`require_network`](Address<NetworkUnchecked>::require_network) as a safe variant.
+    /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
+    /// on [`Address`].
+    #[inline]
+    pub fn assume_checked(self) -> Address { Address(self.0, PhantomData) }
+}
+
+impl From<Address> for script::ScriptBuf {
+    fn from(a: Address) -> Self { a.script_pubkey() }
+}
+
+// Alternate formatting `{:#}` is used to return uppercase version of bech32 addresses which should
+// be used in QR codes, see [`Address::to_qr_uri`].
+impl fmt::Display for Address {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, fmt) }
+}
+
+impl<V: NetworkValidation> fmt::Debug for Address<V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if V::IS_CHECKED {
+            fmt::Display::fmt(&self.0, f)
+        } else {
+            write!(f, "Address<NetworkUnchecked>(")?;
+            fmt::Display::fmt(&self.0, f)?;
+            write!(f, ")")
+        }
+    }
+}
+
+/// Address can be parsed only with `NetworkUnchecked`.
+impl FromStr for Address<NetworkUnchecked> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Address<NetworkUnchecked>, ParseError> {
+        if let Ok((hrp, witness_version, data)) = bech32::segwit::decode(s) {
+            let version = WitnessVersion::try_from(witness_version)?;
+            let program = WitnessProgram::new(version, &data)
+                .expect("bech32 guarantees valid program length for witness");
+
+            let hrp = KnownHrp::from_hrp(hrp)?;
+            let inner = AddressInner::Segwit { program, hrp };
+            return Ok(Address(inner, PhantomData));
+        }
+
+        // If segwit decoding fails, assume its a legacy address.
+
+        if s.len() > 50 {
+            return Err(LegacyAddressTooLongError { length: s.len() }.into());
+        }
+        let data = base58::decode_check(s)?;
+        if data.len() != 21 {
+            return Err(InvalidBase58PayloadLengthError { length: s.len() }.into());
+        }
+
+        let (prefix, data) = data.split_first().expect("length checked above");
+        let data: [u8; 20] = data.try_into().expect("length checked above");
+
+        let inner = match *prefix {
+            PUBKEY_ADDRESS_PREFIX_MAIN => {
+                let hash = PubkeyHash::from_byte_array(data);
+                AddressInner::P2pkh { hash, network: NetworkKind::Main }
+            }
+            PUBKEY_ADDRESS_PREFIX_TEST => {
+                let hash = PubkeyHash::from_byte_array(data);
+                AddressInner::P2pkh { hash, network: NetworkKind::Test }
+            }
+            SCRIPT_ADDRESS_PREFIX_MAIN => {
+                let hash = ScriptHash::from_byte_array(data);
+                AddressInner::P2sh { hash, network: NetworkKind::Main }
+            }
+            SCRIPT_ADDRESS_PREFIX_TEST => {
+                let hash = ScriptHash::from_byte_array(data);
+                AddressInner::P2sh { hash, network: NetworkKind::Test }
+            }
+            invalid => return Err(InvalidLegacyPrefixError { invalid }.into()),
+        };
+
+        Ok(Address(inner, PhantomData))
+    }
+}
+
+/// Convert a byte array of a pubkey hash into a segwit redeem hash
+fn segwit_redeem_hash(pubkey_hash: &PubkeyHash) -> crate::hashes::hash160::Hash {
+    let mut sha_engine = sha256::Hash::engine();
+    sha_engine.input(&[0, 20]);
+    sha_engine.input(pubkey_hash.as_ref());
+    crate::hashes::hash160::Hash::from_engine(sha_engine)
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_lit::hex;
+
+    use super::*;
+    use crate::consensus::params;
+    use crate::network::Network::{Bitcoin, Testnet};
+
+    fn roundtrips(addr: &Address, network: Network) {
+        assert_eq!(
+            Address::from_str(&addr.to_string()).unwrap().assume_checked(),
+            *addr,
+            "string round-trip failed for {}",
+            addr,
+        );
+        assert_eq!(
+            Address::from_script(&addr.script_pubkey(), network)
+                .expect("failed to create inner address from script_pubkey"),
+            *addr,
+            "script round-trip failed for {}",
+            addr,
+        );
+
+        #[cfg(feature = "serde")]
+        {
+            let ser = serde_json::to_string(addr).expect("failed to serialize address");
+            let back: Address<NetworkUnchecked> =
+                serde_json::from_str(&ser).expect("failed to deserialize address");
+            assert_eq!(back.assume_checked(), *addr, "serde round-trip failed for {}", addr)
+        }
+    }
+
+    #[test]
+    fn test_p2pkh_address_58() {
+        let hash = "162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse::<PubkeyHash>().unwrap();
+        let addr = Address::p2pkh(hash, NetworkKind::Main);
+
+        assert_eq!(
+            addr.script_pubkey(),
+            ScriptBuf::from_hex("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac").unwrap()
+        );
+        assert_eq!(&addr.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
+        assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_p2pkh_from_key() {
+        let key = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183".parse::<PublicKey>().unwrap();
+        let addr = Address::p2pkh(key, NetworkKind::Main);
+        assert_eq!(&addr.to_string(), "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY");
+
+        let key = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f"
+            .parse::<PublicKey>()
+            .unwrap();
+        let addr = Address::p2pkh(key, NetworkKind::Test);
+        assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
+        assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
+        roundtrips(&addr, Testnet);
+    }
+
+    #[test]
+    fn test_p2sh_address_58() {
+        let hash = "162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse::<ScriptHash>().unwrap();
+        let addr = Address::p2sh_from_hash(hash, NetworkKind::Main);
+
+        assert_eq!(
+            addr.script_pubkey(),
+            ScriptBuf::from_hex("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087").unwrap(),
+        );
+        assert_eq!(&addr.to_string(), "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_p2sh_parse() {
+        let script = ScriptBuf::from_hex("552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae").unwrap();
+        let addr = Address::p2sh(&script, NetworkKind::Test).unwrap();
+        assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr, Testnet);
+    }
+
+    #[test]
+    fn test_p2sh_parse_for_large_script() {
+        let script = ScriptBuf::from_hex("552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123").unwrap();
+        assert_eq!(Address::p2sh(&script, NetworkKind::Test), Err(P2shError::ExcessiveScriptSize));
+    }
+
+    #[test]
+    fn test_p2wpkh() {
+        // stolen from Bitcoin transaction: b3c8c2b6cfc335abbcb2c7823a8453f55d64b2b5125a9a61e8737230cdb8ce20
+        let key = "033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc"
+            .parse::<CompressedPublicKey>()
+            .unwrap();
+        let addr = Address::p2wpkh(&key, KnownHrp::Mainnet);
+        assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
+        assert_eq!(addr.address_type(), Some(AddressType::P2wpkh));
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_p2wsh() {
+        // stolen from Bitcoin transaction 5df912fda4becb1c29e928bec8d64d93e9ba8efa9b5b405bd683c86fd2c65667
+        let script = ScriptBuf::from_hex("52210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae").unwrap();
+        let addr = Address::p2wsh(&script, KnownHrp::Mainnet);
+        assert_eq!(
+            &addr.to_string(),
+            "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej"
+        );
+        assert_eq!(addr.address_type(), Some(AddressType::P2wsh));
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_p2shwpkh() {
+        // stolen from Bitcoin transaction: ad3fd9c6b52e752ba21425435ff3dd361d6ac271531fc1d2144843a9f550ad01
+        let key = "026c468be64d22761c30cd2f12cbc7de255d592d7904b1bab07236897cc4c2e766"
+            .parse::<CompressedPublicKey>()
+            .unwrap();
+        let addr = Address::p2shwpkh(&key, NetworkKind::Main);
+        assert_eq!(&addr.to_string(), "3QBRmWNqqBGme9er7fMkGqtZtp4gjMFxhE");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_p2shwsh() {
+        // stolen from Bitcoin transaction f9ee2be4df05041d0e0a35d7caa3157495ca4f93b233234c9967b6901dacf7a9
+        let script = ScriptBuf::from_hex("522103e5529d8eaa3d559903adb2e881eb06c86ac2574ffa503c45f4e942e2a693b33e2102e5f10fcdcdbab211e0af6a481f5532536ec61a5fdbf7183770cf8680fe729d8152ae").unwrap();
+        let addr = Address::p2shwsh(&script, NetworkKind::Main);
+        assert_eq!(&addr.to_string(), "36EqgNnsWW94SreZgBWc1ANC6wpFZwirHr");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_non_existent_segwit_version() {
+        // 40-byte program
+        let program = hex!(
+            "654f6ea368e0acdfd92976b7c2103a1b26313f430654f6ea368e0acdfd92976b7c2103a1b26313f4"
+        );
+        let program = WitnessProgram::new(WitnessVersion::V13, &program).expect("valid program");
+
+        let addr = Address::from_witness_program(program, KnownHrp::Mainnet);
+        roundtrips(&addr, Bitcoin);
+    }
+
+    #[test]
+    fn test_address_debug() {
+        // This is not really testing output of Debug but the ability and proper functioning
+        // of Debug derivation on structs generic in NetworkValidation.
+        #[derive(Debug)]
+        #[allow(unused)]
+        struct Test<V: NetworkValidation> {
+            address: Address<V>,
+        }
+
+        let addr_str = "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k";
+        let unchecked = Address::from_str(addr_str).unwrap();
+
+        assert_eq!(
+            format!("{:?}", Test { address: unchecked.clone() }),
+            format!("Test {{ address: Address<NetworkUnchecked>({}) }}", addr_str)
+        );
+
+        assert_eq!(
+            format!("{:?}", Test { address: unchecked.assume_checked() }),
+            format!("Test {{ address: {} }}", addr_str)
+        );
+    }
+
+    #[test]
+    fn test_address_type() {
+        let addresses = [
+            ("1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY", Some(AddressType::P2pkh)),
+            ("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k", Some(AddressType::P2sh)),
+            ("bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw", Some(AddressType::P2wpkh)),
+            (
+                "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej",
+                Some(AddressType::P2wsh),
+            ),
+            (
+                "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr",
+                Some(AddressType::P2tr),
+            ),
+            // Related to future extensions, addresses are valid but have no type
+            // segwit v1 and len != 32
+            ("bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y", None),
+            // segwit v2
+            ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", None),
+        ];
+        for (address, expected_type) in &addresses {
+            let addr = Address::from_str(address)
+                .unwrap()
+                .require_network(Network::Bitcoin)
+                .expect("mainnet");
+            assert_eq!(&addr.address_type(), expected_type);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_json_serialize() {
+        use serde_json;
+
+        let addr =
+            Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM").unwrap().assume_checked();
+        let json = serde_json::to_value(&addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".to_owned())
+        );
+        let into: Address = serde_json::from_value::<Address<_>>(json).unwrap().assume_checked();
+        assert_eq!(addr.to_string(), into.to_string());
+        assert_eq!(
+            into.script_pubkey(),
+            ScriptBuf::from_hex("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac").unwrap()
+        );
+
+        let addr =
+            Address::from_str("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k").unwrap().assume_checked();
+        let json = serde_json::to_value(&addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k".to_owned())
+        );
+        let into: Address = serde_json::from_value::<Address<_>>(json).unwrap().assume_checked();
+        assert_eq!(addr.to_string(), into.to_string());
+        assert_eq!(
+            into.script_pubkey(),
+            ScriptBuf::from_hex("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087").unwrap()
+        );
+
+        let addr: Address<NetworkUnchecked> =
+            Address::from_str("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
+                .unwrap();
+        let json = serde_json::to_value(addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String(
+                "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7".to_owned()
+            )
+        );
+
+        let addr =
+            Address::from_str("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
+                .unwrap()
+                .assume_checked();
+        let json = serde_json::to_value(&addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String(
+                "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7".to_owned()
+            )
+        );
+        let into: Address = serde_json::from_value::<Address<_>>(json).unwrap().assume_checked();
+        assert_eq!(addr.to_string(), into.to_string());
+        assert_eq!(
+            into.script_pubkey(),
+            ScriptBuf::from_hex(
+                "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"
+            )
+            .unwrap()
+        );
+
+        let addr = Address::from_str("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl")
+            .unwrap()
+            .assume_checked();
+        let json = serde_json::to_value(&addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl".to_owned())
+        );
+        let into: Address = serde_json::from_value::<Address<_>>(json).unwrap().assume_checked();
+        assert_eq!(addr.to_string(), into.to_string());
+        assert_eq!(
+            into.script_pubkey(),
+            ScriptBuf::from_hex("001454d26dddb59c7073c6a197946ea1841951fa7a74").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_qr_string() {
+        for el in
+            ["132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM", "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k"].iter()
+        {
+            let addr =
+                Address::from_str(el).unwrap().require_network(Network::Bitcoin).expect("mainnet");
+            assert_eq!(addr.to_qr_uri(), format!("bitcoin:{}", el));
+        }
+
+        for el in [
+            "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl",
+            "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej",
+        ]
+        .iter()
+        {
+            let addr = Address::from_str(el).unwrap().assume_checked();
+            assert_eq!(addr.to_qr_uri(), format!("bitcoin:{}", el.to_ascii_uppercase()));
+        }
+    }
+
+    #[test]
+    fn p2tr_from_untweaked() {
+        //Test case from BIP-086
+        let internal_key = XOnlyPublicKey::from_str(
+            "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115",
+        )
+        .unwrap();
+        let secp = Secp256k1::verification_only();
+        let address = Address::p2tr(&secp, internal_key, None, KnownHrp::Mainnet);
+        assert_eq!(
+            address.to_string(),
+            "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"
+        );
+        assert_eq!(address.address_type(), Some(AddressType::P2tr));
+        roundtrips(&address, Bitcoin);
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2wpkh() {
+        let address_string = "bc1qhvd6suvqzjcu9pxjhrwhtrlj85ny3n2mqql5w4";
+        let address = Address::from_str(address_string)
+            .expect("address")
+            .require_network(Network::Bitcoin)
+            .expect("mainnet");
+
+        let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2shwpkh() {
+        let address_string = "3EZQk4F8GURH5sqVMLTFisD17yNeKa7Dfs";
+        let address = Address::from_str(address_string)
+            .expect("address")
+            .require_network(Network::Bitcoin)
+            .expect("mainnet");
+
+        let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2pkh() {
+        let address_string = "1J4LVanjHMu3JkXbVrahNuQCTGCRRgfWWx";
+        let address = Address::from_str(address_string)
+            .expect("address")
+            .require_network(Network::Bitcoin)
+            .expect("mainnet");
+
+        let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2pkh_uncompressed_key() {
+        let address_string = "msvS7KzhReCDpQEJaV2hmGNvuQqVUDuC6p";
+        let address = Address::from_str(address_string)
+            .expect("address")
+            .require_network(Network::Testnet)
+            .expect("testnet");
+
+        let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2tr() {
+        let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
+        let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
+        let address = Address::p2tr_tweaked(tweaked_pubkey, KnownHrp::Mainnet);
+
+        assert_eq!(
+            address,
+            Address::from_str("bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e")
+                .expect("address")
+                .require_network(Network::Bitcoin)
+                .expect("mainnet")
+        );
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey));
+    }
+
+    #[test]
+    fn test_is_related_to_xonly_pubkey() {
+        let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
+        let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
+        let address = Address::p2tr_tweaked(tweaked_pubkey, KnownHrp::Mainnet);
+
+        assert_eq!(
+            address,
+            Address::from_str("bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e")
+                .expect("address")
+                .require_network(Network::Bitcoin)
+                .expect("mainnet")
+        );
+
+        let result = address.is_related_to_xonly_pubkey(&xonly_pubkey);
+        assert!(result);
+    }
+
+    #[test]
+    fn test_fail_address_from_script() {
+        use crate::witness_program;
+
+        let bad_p2wpkh = ScriptBuf::from_hex("0014dbc5b0a8f9d4353b4b54c3db48846bb15abfec").unwrap();
+        let bad_p2wsh = ScriptBuf::from_hex(
+            "00202d4fa2eb233d008cc83206fa2f4f2e60199000f5b857a835e3172323385623",
+        )
+        .unwrap();
+        let invalid_segwitv0_script =
+            ScriptBuf::from_hex("001161458e330389cd0437ee9fe3641d70cc18").unwrap();
+        let expected = Err(FromScriptError::UnrecognizedScript);
+
+        assert_eq!(Address::from_script(&bad_p2wpkh, Network::Bitcoin), expected);
+        assert_eq!(Address::from_script(&bad_p2wsh, Network::Bitcoin), expected);
+        assert_eq!(
+            Address::from_script(&invalid_segwitv0_script, &params::MAINNET),
+            Err(FromScriptError::WitnessProgram(witness_program::Error::InvalidSegwitV0Length(17)))
+        );
+    }
+
+    #[test]
+    fn valid_address_parses_correctly() {
+        let addr = AddressType::from_str("p2tr").expect("false negative while parsing address");
+        assert_eq!(addr, AddressType::P2tr);
+    }
+
+    #[test]
+    fn invalid_address_parses_error() {
+        let got = AddressType::from_str("invalid");
+        let want = Err(UnknownAddressTypeError("invalid".to_string()));
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_matches_script_pubkey() {
+        let addresses = [
+            "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY",
+            "1J4LVanjHMu3JkXbVrahNuQCTGCRRgfWWx",
+            "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k",
+            "3QBRmWNqqBGme9er7fMkGqtZtp4gjMFxhE",
+            "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs",
+            "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw",
+            "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr",
+            "bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e",
+        ];
+        for addr in &addresses {
+            let addr = Address::from_str(addr).unwrap().require_network(Network::Bitcoin).unwrap();
+            for another in &addresses {
+                let another =
+                    Address::from_str(another).unwrap().require_network(Network::Bitcoin).unwrap();
+                assert_eq!(addr.matches_script_pubkey(&another.script_pubkey()), addr == another);
+            }
+        }
+    }
+}

--- a/libs/bitcoin/src/bip152.rs
+++ b/libs/bitcoin/src/bip152.rs
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! BIP152 Compact Blocks
+//!
+//! Implementation of compact blocks data structure and algorithms.
+//!
+
+use core::{convert, fmt, mem};
+#[cfg(feature = "std")]
+use std::error;
+
+use hashes::{sha256, siphash24, Hash};
+use internals::impl_array_newtype;
+use io::{Read, Write};
+
+use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
+use crate::internal_macros::{impl_bytes_newtype, impl_consensus_encoding};
+use crate::prelude::*;
+use crate::{block, Block, BlockHash, Transaction};
+
+/// A BIP-152 error
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// An unknown version number was used.
+    UnknownVersion,
+    /// The prefill slice provided was invalid.
+    InvalidPrefill,
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::UnknownVersion => write!(f, "an unknown version number was used"),
+            Error::InvalidPrefill => write!(f, "the prefill slice provided was invalid"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match *self {
+            UnknownVersion | InvalidPrefill => None,
+        }
+    }
+}
+
+/// A [PrefilledTransaction] structure is used in [HeaderAndShortIds] to
+/// provide a list of a few transactions explicitly.
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct PrefilledTransaction {
+    /// The index of the transaction in the block.
+    ///
+    /// This field is differentially encoded relative to the previous
+    /// prefilled transaction as described as follows:
+    ///
+    /// > Several uses of CompactSize below are "differentially encoded". For
+    /// > these, instead of using raw indexes, the number encoded is the
+    /// > difference between the current index and the previous index, minus one.
+    /// > For example, a first index of 0 implies a real index of 0, a second
+    /// > index of 0 thereafter refers to a real index of 1, etc.
+    pub idx: u16,
+    /// The actual transaction.
+    pub tx: Transaction,
+}
+
+impl convert::AsRef<Transaction> for PrefilledTransaction {
+    fn as_ref(&self) -> &Transaction { &self.tx }
+}
+
+impl Encodable for PrefilledTransaction {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        Ok(VarInt::from(self.idx).consensus_encode(w)? + self.tx.consensus_encode(w)?)
+    }
+}
+
+impl Decodable for PrefilledTransaction {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let idx = VarInt::consensus_decode(r)?.0;
+        let idx = u16::try_from(idx)
+            .map_err(|_| encode::Error::ParseFailed("BIP152 prefilled tx index out of bounds"))?;
+        let tx = Transaction::consensus_decode(r)?;
+        Ok(PrefilledTransaction { idx, tx })
+    }
+}
+
+/// Short transaction IDs are used to represent a transaction without sending a full 256-bit hash.
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Default, PartialOrd, Ord)]
+pub struct ShortId([u8; 6]);
+impl_array_newtype!(ShortId, u8, 6);
+impl_bytes_newtype!(ShortId, 6);
+
+impl ShortId {
+    /// Calculate the SipHash24 keys used to calculate short IDs.
+    pub fn calculate_siphash_keys(header: &block::Header, nonce: u64) -> (u64, u64) {
+        // 1. single-SHA256 hashing the block header with the nonce appended (in little-endian)
+        let h = {
+            let mut engine = sha256::Hash::engine();
+            header.consensus_encode(&mut engine).expect("engines don't error");
+            nonce.consensus_encode(&mut engine).expect("engines don't error");
+            sha256::Hash::from_engine(engine)
+        };
+
+        // 2. Running SipHash-2-4 with the input being the transaction ID and the keys (k0/k1)
+        // set to the first two little-endian 64-bit integers from the above hash, respectively.
+        (
+            u64::from_le_bytes(h[0..8].try_into().expect("8 byte slice")),
+            u64::from_le_bytes(h[8..16].try_into().expect("8 byte slice")),
+        )
+    }
+
+    /// Calculate the short ID with the given (w)txid and using the provided SipHash keys.
+    pub fn with_siphash_keys<T: AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> ShortId {
+        // 2. Running SipHash-2-4 with the input being the transaction ID and the keys (k0/k1)
+        // set to the first two little-endian 64-bit integers from the above hash, respectively.
+        let hash = siphash24::Hash::hash_with_keys(siphash_keys.0, siphash_keys.1, txid.as_ref());
+
+        // 3. Dropping the 2 most significant bytes from the SipHash output to make it 6 bytes.
+        let mut id = ShortId([0; 6]);
+        id.0.copy_from_slice(&hash[0..6]);
+        id
+    }
+}
+
+impl Encodable for ShortId {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for ShortId {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<ShortId, encode::Error> {
+        Ok(ShortId(Decodable::consensus_decode(r)?))
+    }
+}
+
+/// A structure to relay a block header, short IDs, and a select few transactions.
+///
+/// A [HeaderAndShortIds] structure is used to relay a block header, the short
+/// transactions IDs used for matching already-available transactions, and a
+/// select few transactions which we expect a peer may be missing.
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct HeaderAndShortIds {
+    /// The header of the block being provided.
+    pub header: block::Header,
+    ///  A nonce for use in short transaction ID calculations.
+    pub nonce: u64,
+    ///  The short transaction IDs calculated from the transactions
+    ///  which were not provided explicitly in prefilled_txs.
+    pub short_ids: Vec<ShortId>,
+    ///  Used to provide the coinbase transaction and a select few
+    ///  which we expect a peer may be missing.
+    pub prefilled_txs: Vec<PrefilledTransaction>,
+}
+impl_consensus_encoding!(HeaderAndShortIds, header, nonce, short_ids, prefilled_txs);
+
+impl HeaderAndShortIds {
+    /// Create a new [HeaderAndShortIds] from a full block.
+    ///
+    /// The version number must be either 1 or 2.
+    ///
+    /// The `prefill` slice indicates which transactions should be prefilled in
+    /// the block. It should contain the indexes in the block of the txs to
+    /// prefill. It must be ordered. 0 should not be included as the
+    /// coinbase tx is always prefilled.
+    ///
+    /// > Nodes SHOULD NOT use the same nonce across multiple different blocks.
+    pub fn from_block(
+        block: &Block,
+        nonce: u64,
+        version: u32,
+        mut prefill: &[usize],
+    ) -> Result<HeaderAndShortIds, Error> {
+        if version != 1 && version != 2 {
+            return Err(Error::UnknownVersion);
+        }
+
+        let siphash_keys = ShortId::calculate_siphash_keys(&block.header, nonce);
+
+        let mut prefilled = Vec::with_capacity(prefill.len() + 1); // +1 for coinbase tx
+        let mut short_ids = Vec::with_capacity(block.txdata.len() - prefill.len());
+        let mut last_prefill = 0;
+        for (idx, tx) in block.txdata.iter().enumerate() {
+            // Check if we should prefill this tx.
+            let prefill_tx = if prefill.first() == Some(&idx) {
+                prefill = &prefill[1..];
+                true
+            } else {
+                idx == 0 // Always prefill coinbase.
+            };
+
+            if prefill_tx {
+                let diff_idx = idx - last_prefill;
+                last_prefill = idx + 1;
+                prefilled.push(PrefilledTransaction {
+                    idx: diff_idx as u16,
+                    tx: match version {
+                        // >  As encoded in "tx" messages sent in response to getdata MSG_TX
+                        1 => {
+                            // strip witness for version 1
+                            let mut no_witness = tx.clone();
+                            no_witness.input.iter_mut().for_each(|i| i.witness.clear());
+                            no_witness
+                        }
+                        // > Transactions inside cmpctblock messages (both those used as direct
+                        // > announcement and those in response to getdata) and in blocktxn should
+                        // > include witness data, using the same format as responses to getdata
+                        // > MSG_WITNESS_TX, specified in BIP144.
+                        2 => tx.clone(),
+                        _ => unreachable!(),
+                    },
+                });
+            } else {
+                short_ids.push(ShortId::with_siphash_keys(
+                    &match version {
+                        1 => tx.compute_txid().to_raw_hash(),
+                        2 => tx.compute_wtxid().to_raw_hash(),
+                        _ => unreachable!(),
+                    },
+                    siphash_keys,
+                ));
+            }
+        }
+
+        if !prefill.is_empty() {
+            return Err(Error::InvalidPrefill);
+        }
+
+        Ok(HeaderAndShortIds {
+            header: block.header,
+            nonce,
+            // Provide coinbase prefilled.
+            prefilled_txs: prefilled,
+            short_ids,
+        })
+    }
+}
+
+/// A [BlockTransactionsRequest] structure is used to list transaction indexes
+/// in a block being requested.
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct BlockTransactionsRequest {
+    ///  The blockhash of the block which the transactions being requested are in.
+    pub block_hash: BlockHash,
+    ///  The indexes of the transactions being requested in the block.
+    ///
+    ///  Warning: Encoding panics with [`u64::MAX`] values. See [`BlockTransactionsRequest::consensus_encode()`]
+    pub indexes: Vec<u64>,
+}
+
+impl Encodable for BlockTransactionsRequest {
+    /// # Panics
+    ///
+    /// Panics if the index overflows [`u64::MAX`]. This happens when [`BlockTransactionsRequest::indexes`]
+    /// contains an entry with the value [`u64::MAX`] as `u64` overflows during differential encoding.
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.block_hash.consensus_encode(w)?;
+        // Manually encode indexes because they are differentially encoded VarInts.
+        len += VarInt(self.indexes.len() as u64).consensus_encode(w)?;
+        let mut last_idx = 0;
+        for idx in &self.indexes {
+            len += VarInt(*idx - last_idx).consensus_encode(w)?;
+            last_idx = *idx + 1; // can panic here
+        }
+        Ok(len)
+    }
+}
+
+impl Decodable for BlockTransactionsRequest {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(BlockTransactionsRequest {
+            block_hash: BlockHash::consensus_decode(r)?,
+            indexes: {
+                // Manually decode indexes because they are differentially encoded VarInts.
+                let nb_indexes = VarInt::consensus_decode(r)?.0 as usize;
+
+                // Since the number of indices ultimately represent transactions,
+                // we can limit the number of indices to the maximum number of
+                // transactions that would be allowed in a vector.
+                let byte_size = (nb_indexes)
+                    .checked_mul(mem::size_of::<Transaction>())
+                    .ok_or(encode::Error::ParseFailed("Invalid length"))?;
+                if byte_size > encode::MAX_VEC_SIZE {
+                    return Err(encode::Error::OversizedVectorAllocation {
+                        requested: byte_size,
+                        max: encode::MAX_VEC_SIZE,
+                    });
+                }
+
+                let mut indexes = Vec::with_capacity(nb_indexes);
+                let mut last_index: u64 = 0;
+                for _ in 0..nb_indexes {
+                    let differential: VarInt = Decodable::consensus_decode(r)?;
+                    last_index = match last_index.checked_add(differential.0) {
+                        Some(i) => i,
+                        None => return Err(encode::Error::ParseFailed("block index overflow")),
+                    };
+                    indexes.push(last_index);
+                    last_index = match last_index.checked_add(1) {
+                        Some(i) => i,
+                        None => return Err(encode::Error::ParseFailed("block index overflow")),
+                    };
+                }
+                indexes
+            },
+        })
+    }
+}
+
+/// A transaction index is requested that is out of range from the
+/// corresponding block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TxIndexOutOfRangeError(u64);
+
+impl fmt::Display for TxIndexOutOfRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "a transaction index is requested that is \
+            out of range from the corresponding block: {}",
+            self.0,
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for TxIndexOutOfRangeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// A [BlockTransactions] structure is used to provide some of the transactions
+/// in a block, as requested.
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct BlockTransactions {
+    ///  The blockhash of the block which the transactions being provided are in.
+    pub block_hash: BlockHash,
+    ///  The transactions provided.
+    pub transactions: Vec<Transaction>,
+}
+impl_consensus_encoding!(BlockTransactions, block_hash, transactions);
+
+impl BlockTransactions {
+    /// Construct a [BlockTransactions] from a [BlockTransactionsRequest] and
+    /// the corresponding full [Block] by providing all requested transactions.
+    pub fn from_request(
+        request: &BlockTransactionsRequest,
+        block: &Block,
+    ) -> Result<BlockTransactions, TxIndexOutOfRangeError> {
+        Ok(BlockTransactions {
+            block_hash: request.block_hash,
+            transactions: {
+                let mut txs = Vec::with_capacity(request.indexes.len());
+                for idx in &request.indexes {
+                    if *idx >= block.txdata.len() as u64 {
+                        return Err(TxIndexOutOfRangeError(*idx));
+                    }
+                    txs.push(block.txdata[*idx as usize].clone());
+                }
+                txs
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use hex::FromHex;
+
+    use super::*;
+    use crate::blockdata::block::TxMerkleNode;
+    use crate::blockdata::locktime::absolute;
+    use crate::blockdata::transaction;
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::{Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid, Witness};
+
+    fn dummy_tx(nonce: &[u8]) -> Transaction {
+        Transaction {
+            version: transaction::Version::ONE,
+            lock_time: absolute::LockTime::from_consensus(2),
+            input: vec![TxIn {
+                previous_output: OutPoint::new(Txid::hash(nonce), 0),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence(1),
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut { value: Amount::ONE_SAT, script_pubkey: ScriptBuf::new() }],
+        }
+    }
+
+    fn dummy_block() -> Block {
+        Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: BlockHash::hash(&[0]),
+                merkle_root: TxMerkleNode::hash(&[1]),
+                time: 2,
+                bits: CompactTarget::from_consensus(3),
+                nonce: 4,
+            },
+            txdata: vec![dummy_tx(&[2]), dummy_tx(&[3]), dummy_tx(&[4])],
+        }
+    }
+
+    #[test]
+    fn test_header_and_short_ids_from_block() {
+        let block = dummy_block();
+
+        let compact = HeaderAndShortIds::from_block(&block, 42, 2, &[]).unwrap();
+        assert_eq!(compact.nonce, 42);
+        assert_eq!(compact.short_ids.len(), 2);
+        assert_eq!(compact.prefilled_txs.len(), 1);
+        assert_eq!(compact.prefilled_txs[0].idx, 0);
+        assert_eq!(&compact.prefilled_txs[0].tx, &block.txdata[0]);
+
+        let compact = HeaderAndShortIds::from_block(&block, 42, 2, &[0, 1, 2]).unwrap();
+        let idxs = compact.prefilled_txs.iter().map(|t| t.idx).collect::<Vec<_>>();
+        assert_eq!(idxs, vec![0, 0, 0]);
+
+        let compact = HeaderAndShortIds::from_block(&block, 42, 2, &[2]).unwrap();
+        let idxs = compact.prefilled_txs.iter().map(|t| t.idx).collect::<Vec<_>>();
+        assert_eq!(idxs, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_compact_block_vector() {
+        // Tested with Elements implementation of compact blocks.
+        let raw_block = Vec::<u8>::from_hex("000000206c750a364035aefd5f81508a08769975116d9195312ee4520dceac39e1fdc62c4dc67473b8e354358c1e610afeaff7410858bd45df43e2940f8a62bd3d5e3ac943c2975cffff7f200000000002020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff04016b0101ffffffff020006062a0100000001510000000000000000266a24aa21a9ed4a3d9f3343dafcc0d6f6d4310f2ee5ce273ed34edca6c75db3a73e7f368734200120000000000000000000000000000000000000000000000000000000000000000000000000020000000001021fc20ba2bd745507b8e00679e3b362558f9457db374ca28ffa5243f4c23a4d5f00000000171600147c9dea14ffbcaec4b575e03f05ceb7a81cd3fcbffdffffff915d689be87b43337f42e26033df59807b768223368f189a023d0242d837768900000000171600147c9dea14ffbcaec4b575e03f05ceb7a81cd3fcbffdffffff0200cdf5050000000017a9146803c72d9154a6a20f404bed6d3dcee07986235a8700e1f5050000000017a9144e6a4c7cb5b5562904843bdf816342f4db9f5797870247304402205e9bf6e70eb0e4b495bf483fd8e6e02da64900f290ef8aaa64bb32600d973c450220670896f5d0e5f33473e5f399ab680cc1d25c2d2afd15abd722f04978f28be887012103e4e4d9312b2261af508b367d8ba9be4f01b61d6d6e78bec499845b4f410bcf2702473044022045ac80596a6ac9c8c572f94708709adaf106677221122e08daf8b9741a04f66a022003ccd52a3b78f8fd08058fc04fc0cffa5f4c196c84eae9e37e2a85babe731b57012103e4e4d9312b2261af508b367d8ba9be4f01b61d6d6e78bec499845b4f410bcf276a000000").unwrap();
+        let raw_compact = Vec::<u8>::from_hex("000000206c750a364035aefd5f81508a08769975116d9195312ee4520dceac39e1fdc62c4dc67473b8e354358c1e610afeaff7410858bd45df43e2940f8a62bd3d5e3ac943c2975cffff7f2000000000a4df3c3744da89fa010a6979e971450100020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff04016b0101ffffffff020006062a0100000001510000000000000000266a24aa21a9ed4a3d9f3343dafcc0d6f6d4310f2ee5ce273ed34edca6c75db3a73e7f368734200120000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+
+        let block: Block = deserialize(&raw_block).unwrap();
+        let nonce = 18053200567810711460;
+        let compact = HeaderAndShortIds::from_block(&block, nonce, 2, &[]).unwrap();
+        let compact_expected = deserialize(&raw_compact).unwrap();
+
+        assert_eq!(compact, compact_expected);
+    }
+
+    #[test]
+    fn test_getblocktx_differential_encoding_de_and_serialization() {
+        let testcases = vec![
+            // differentially encoded VarInts, indicies
+            (vec![4, 0, 5, 1, 10], vec![0, 6, 8, 19]),
+            (vec![1, 0], vec![0]),
+            (vec![5, 0, 0, 0, 0, 0], vec![0, 1, 2, 3, 4]),
+            (vec![3, 1, 1, 1], vec![1, 3, 5]),
+            (vec![3, 0, 0, 253, 0, 1], vec![0, 1, 258]), // .., 253, 0, 1] == VarInt(256)
+        ];
+        let deser_errorcases = vec![
+            vec![2, 255, 254, 255, 255, 255, 255, 255, 255, 255, 0], // .., 255, 254, .., 255] == VarInt(u64::MAX-1)
+            vec![1, 255, 255, 255, 255, 255, 255, 255, 255, 255], // .., 255, 255, .., 255] == VarInt(u64::MAX)
+        ];
+        for testcase in testcases {
+            {
+                // test deserialization
+                let mut raw: Vec<u8> = [0u8; 32].to_vec();
+                raw.extend(testcase.0.clone());
+                let btr: BlockTransactionsRequest = deserialize(&raw.to_vec()).unwrap();
+                assert_eq!(testcase.1, btr.indexes);
+            }
+            {
+                // test serialization
+                let raw: Vec<u8> = serialize(&BlockTransactionsRequest {
+                    block_hash: Hash::all_zeros(),
+                    indexes: testcase.1,
+                });
+                let mut expected_raw: Vec<u8> = [0u8; 32].to_vec();
+                expected_raw.extend(testcase.0);
+                assert_eq!(expected_raw, raw);
+            }
+        }
+        for errorcase in deser_errorcases {
+            {
+                // test that we return Err() if deserialization fails (and don't panic)
+                let mut raw: Vec<u8> = [0u8; 32].to_vec();
+                raw.extend(errorcase);
+                assert!(deserialize::<BlockTransactionsRequest>(&raw.to_vec()).is_err());
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic] // 'attempt to add with overflow' in consensus_encode()
+    fn test_getblocktx_panic_when_encoding_u64_max() {
+        serialize(&BlockTransactionsRequest {
+            block_hash: Hash::all_zeros(),
+            indexes: vec![u64::MAX],
+        });
+    }
+}

--- a/libs/bitcoin/src/bip158.rs
+++ b/libs/bitcoin/src/bip158.rs
@@ -1,0 +1,792 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// This module was largely copied from https://github.com/rust-bitcoin/murmel/blob/master/src/blockfilter.rs
+// on 11. June 2019 which is licensed under Apache, that file specifically
+// was written entirely by Tamas Blummer, who is re-licensing its contents here as CC0.
+
+//! BIP 158 Compact Block Filters for Light Clients.
+//!
+//! This module implements a structure for compact filters on block data, for
+//! use in the BIP 157 light client protocol. The filter construction proposed
+//! is an alternative to Bloom filters, as used in BIP 37, that minimizes filter
+//! size by using Golomb-Rice coding for compression.
+//!
+//! ### Relevant BIPS
+//!
+//! * [BIP 157 - Client Side Block Filtering](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki)
+//! * [BIP 158 - Compact Block Filters for Light Clients](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki)
+//!
+//! # Examples
+//!
+//! ```ignore
+//! fn get_script_for_coin(coin: &OutPoint) -> Result<ScriptBuf, BlockFilterError> {
+//!   // get utxo ...
+//! }
+//!
+//! // create a block filter for a block (server side)
+//! let filter = BlockFilter::new_script_filter(&block, get_script_for_coin)?;
+//!
+//! // or create a filter from known raw data
+//! let filter = BlockFilter::new(content);
+//!
+//! // read and evaluate a filter
+//!
+//! let query: Iterator<Item=ScriptBuf> = // .. some scripts you care about
+//! if filter.match_any(&block_hash, &mut query.map(|s| s.as_bytes())) {
+//!   // get this block
+//! }
+//!  ```
+//!
+
+use core::cmp::{self, Ordering};
+use core::fmt::{self, Display, Formatter};
+
+use hashes::{sha256d, siphash24, Hash};
+use internals::write_err;
+use io::{Read, Write};
+
+use crate::blockdata::block::{Block, BlockHash};
+use crate::blockdata::script::Script;
+use crate::blockdata::transaction::OutPoint;
+use crate::consensus::encode::VarInt;
+use crate::consensus::{Decodable, Encodable};
+use crate::internal_macros::impl_hashencode;
+use crate::prelude::*;
+
+/// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
+const P: u8 = 19;
+const M: u64 = 784931;
+
+hashes::hash_newtype! {
+    /// Filter hash, as defined in BIP-157
+    pub struct FilterHash(sha256d::Hash);
+    /// Filter header, as defined in BIP-157
+    pub struct FilterHeader(sha256d::Hash);
+}
+
+impl_hashencode!(FilterHash);
+impl_hashencode!(FilterHeader);
+
+/// Errors for blockfilter.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Missing UTXO, cannot calculate script filter.
+    UtxoMissing(OutPoint),
+    /// IO error reading or writing binary serialization of the filter.
+    Io(io::Error),
+}
+
+internals::impl_from_infallible!(Error);
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        use Error::*;
+
+        match *self {
+            UtxoMissing(ref coin) => write!(f, "unresolved UTXO {}", coin),
+            Io(ref e) => write_err!(f, "IO error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            UtxoMissing(_) => None,
+            Io(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(io: io::Error) -> Self {
+        Error::Io(io)
+    }
+}
+
+/// A block filter, as described by BIP 158.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockFilter {
+    /// Golomb encoded filter
+    pub content: Vec<u8>,
+}
+
+impl FilterHash {
+    /// Computes the filter header from a filter hash and previous filter header.
+    pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
+        let mut header_data = [0u8; 64];
+        header_data[0..32].copy_from_slice(&self[..]);
+        header_data[32..64].copy_from_slice(&previous_filter_header[..]);
+        FilterHeader::hash(&header_data)
+    }
+}
+
+impl BlockFilter {
+    /// Creates a new filter from pre-computed data.
+    pub fn new(content: &[u8]) -> BlockFilter {
+        BlockFilter {
+            content: content.to_vec(),
+        }
+    }
+
+    /// Computes a SCRIPT_FILTER that contains spent and output scripts.
+    pub fn new_script_filter<M, S>(block: &Block, script_for_coin: M) -> Result<BlockFilter, Error>
+    where
+        M: Fn(&OutPoint) -> Result<S, Error>,
+        S: Borrow<Script>,
+    {
+        let mut out = Vec::new();
+        let mut writer = BlockFilterWriter::new(&mut out, block);
+
+        writer.add_output_scripts();
+        writer.add_input_scripts(script_for_coin)?;
+        writer.finish()?;
+
+        Ok(BlockFilter { content: out })
+    }
+
+    /// Computes this filter's ID in a chain of filters (see [BIP 157]).
+    ///
+    /// [BIP 157]: <https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#Filter_Headers>
+    pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
+        let filter_hash = FilterHash::hash(self.content.as_slice());
+        filter_hash.filter_header(previous_filter_header)
+    }
+
+    /// Returns true if any query matches against this [`BlockFilter`].
+    pub fn match_any<I>(&self, block_hash: &BlockHash, query: I) -> Result<bool, Error>
+    where
+        I: Iterator,
+        I::Item: Borrow<[u8]>,
+    {
+        let filter_reader = BlockFilterReader::new(block_hash);
+        filter_reader.match_any(&mut self.content.as_slice(), query)
+    }
+
+    /// Returns true if all queries match against this [`BlockFilter`].
+    pub fn match_all<I>(&self, block_hash: &BlockHash, query: I) -> Result<bool, Error>
+    where
+        I: Iterator,
+        I::Item: Borrow<[u8]>,
+    {
+        let filter_reader = BlockFilterReader::new(block_hash);
+        filter_reader.match_all(&mut self.content.as_slice(), query)
+    }
+}
+
+/// Compiles and writes a block filter.
+pub struct BlockFilterWriter<'a, W> {
+    block: &'a Block,
+    writer: GcsFilterWriter<'a, W>,
+}
+
+impl<'a, W: Write> BlockFilterWriter<'a, W> {
+    /// Creates a new [`BlockFilterWriter`] from `block`.
+    pub fn new(writer: &'a mut W, block: &'a Block) -> BlockFilterWriter<'a, W> {
+        let block_hash_as_int = block.block_hash().to_byte_array();
+        let k0 = u64::from_le_bytes(block_hash_as_int[0..8].try_into().expect("8 byte slice"));
+        let k1 = u64::from_le_bytes(block_hash_as_int[8..16].try_into().expect("8 byte slice"));
+        let writer = GcsFilterWriter::new(writer, k0, k1, M, P);
+        BlockFilterWriter { block, writer }
+    }
+
+    /// Adds output scripts of the block to filter (excluding OP_RETURN scripts).
+    pub fn add_output_scripts(&mut self) {
+        for transaction in &self.block.txdata {
+            for output in &transaction.output {
+                if !output.script_pubkey.is_op_return() {
+                    self.add_element(output.script_pubkey.as_bytes());
+                }
+            }
+        }
+    }
+
+    /// Adds consumed output scripts of a block to filter.
+    pub fn add_input_scripts<M, S>(&mut self, script_for_coin: M) -> Result<(), Error>
+    where
+        M: Fn(&OutPoint) -> Result<S, Error>,
+        S: Borrow<Script>,
+    {
+        for script in self
+            .block
+            .txdata
+            .iter()
+            .skip(1) // skip coinbase
+            .flat_map(|t| t.input.iter().map(|i| &i.previous_output))
+            .map(script_for_coin)
+        {
+            match script {
+                Ok(script) => self.add_element(script.borrow().as_bytes()),
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Adds an arbitrary element to filter.
+    pub fn add_element(&mut self, data: &[u8]) {
+        self.writer.add_element(data);
+    }
+
+    /// Writes the block filter.
+    pub fn finish(&mut self) -> Result<usize, io::Error> {
+        self.writer.finish()
+    }
+}
+
+/// Reads and interprets a block filter.
+pub struct BlockFilterReader {
+    reader: GcsFilterReader,
+}
+
+impl BlockFilterReader {
+    /// Creates a new [`BlockFilterReader`] from `block_hash`.
+    pub fn new(block_hash: &BlockHash) -> BlockFilterReader {
+        let block_hash_as_int = block_hash.to_byte_array();
+        let k0 = u64::from_le_bytes(block_hash_as_int[0..8].try_into().expect("8 byte slice"));
+        let k1 = u64::from_le_bytes(block_hash_as_int[8..16].try_into().expect("8 byte slice"));
+        BlockFilterReader {
+            reader: GcsFilterReader::new(k0, k1, M, P),
+        }
+    }
+
+    /// Returns true if any query matches against this [`BlockFilterReader`].
+    pub fn match_any<I, R>(&self, reader: &mut R, query: I) -> Result<bool, Error>
+    where
+        I: Iterator,
+        I::Item: Borrow<[u8]>,
+        R: Read + ?Sized,
+    {
+        self.reader.match_any(reader, query)
+    }
+
+    /// Returns true if all queries match against this [`BlockFilterReader`].
+    pub fn match_all<I, R>(&self, reader: &mut R, query: I) -> Result<bool, Error>
+    where
+        I: Iterator,
+        I::Item: Borrow<[u8]>,
+        R: Read + ?Sized,
+    {
+        self.reader.match_all(reader, query)
+    }
+}
+
+/// Golomb-Rice encoded filter reader.
+pub struct GcsFilterReader {
+    filter: GcsFilter,
+    m: u64,
+}
+
+impl GcsFilterReader {
+    /// Creates a new [`GcsFilterReader`] with specific seed to siphash.
+    pub fn new(k0: u64, k1: u64, m: u64, p: u8) -> GcsFilterReader {
+        GcsFilterReader {
+            filter: GcsFilter::new(k0, k1, p),
+            m,
+        }
+    }
+
+    /// Returns true if any query matches against this [`GcsFilterReader`].
+    pub fn match_any<I, R>(&self, reader: &mut R, query: I) -> Result<bool, Error>
+    where
+        I: Iterator,
+        I::Item: Borrow<[u8]>,
+        R: Read + ?Sized,
+    {
+        let n_elements: VarInt = Decodable::consensus_decode(reader).unwrap_or(VarInt(0));
+        // map hashes to [0, n_elements << grp]
+        let nm = n_elements.0 * self.m;
+        let mut mapped = query
+            .map(|e| map_to_range(self.filter.hash(e.borrow()), nm))
+            .collect::<Vec<_>>();
+        // sort
+        mapped.sort_unstable();
+        if mapped.is_empty() {
+            return Ok(true);
+        }
+        if n_elements.0 == 0 {
+            return Ok(false);
+        }
+
+        // find first match in two sorted arrays in one read pass
+        let mut reader = BitStreamReader::new(reader);
+        let mut data = self.filter.golomb_rice_decode(&mut reader)?;
+        let mut remaining = n_elements.0 - 1;
+        for p in mapped {
+            loop {
+                match data.cmp(&p) {
+                    Ordering::Equal => return Ok(true),
+                    Ordering::Less => {
+                        if remaining > 0 {
+                            data += self.filter.golomb_rice_decode(&mut reader)?;
+                            remaining -= 1;
+                        } else {
+                            return Ok(false);
+                        }
+                    }
+                    Ordering::Greater => break,
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns true if all queries match against this [`GcsFilterReader`].
+    pub fn match_all<I, R>(&self, reader: &mut R, query: I) -> Result<bool, Error>
+    where
+        I: Iterator,
+        I::Item: Borrow<[u8]>,
+        R: Read + ?Sized,
+    {
+        let n_elements: VarInt = Decodable::consensus_decode(reader).unwrap_or(VarInt(0));
+        // map hashes to [0, n_elements << grp]
+        let nm = n_elements.0 * self.m;
+        let mut mapped = query
+            .map(|e| map_to_range(self.filter.hash(e.borrow()), nm))
+            .collect::<Vec<_>>();
+        // sort
+        mapped.sort_unstable();
+        mapped.dedup();
+        if mapped.is_empty() {
+            return Ok(true);
+        }
+        if n_elements.0 == 0 {
+            return Ok(false);
+        }
+
+        // figure if all mapped are there in one read pass
+        let mut reader = BitStreamReader::new(reader);
+        let mut data = self.filter.golomb_rice_decode(&mut reader)?;
+        let mut remaining = n_elements.0 - 1;
+        for p in mapped {
+            loop {
+                match data.cmp(&p) {
+                    Ordering::Equal => break,
+                    Ordering::Less => {
+                        if remaining > 0 {
+                            data += self.filter.golomb_rice_decode(&mut reader)?;
+                            remaining -= 1;
+                        } else {
+                            return Ok(false);
+                        }
+                    }
+                    Ordering::Greater => return Ok(false),
+                }
+            }
+        }
+        Ok(true)
+    }
+}
+
+/// Fast reduction of hash to [0, nm) range.
+fn map_to_range(hash: u64, nm: u64) -> u64 {
+    ((hash as u128 * nm as u128) >> 64) as u64
+}
+
+/// Golomb-Rice encoded filter writer.
+pub struct GcsFilterWriter<'a, W> {
+    filter: GcsFilter,
+    writer: &'a mut W,
+    elements: BTreeSet<Vec<u8>>,
+    m: u64,
+}
+
+impl<'a, W: Write> GcsFilterWriter<'a, W> {
+    /// Creates a new [`GcsFilterWriter`] wrapping a generic writer, with specific seed to siphash.
+    pub fn new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> GcsFilterWriter<'a, W> {
+        GcsFilterWriter {
+            filter: GcsFilter::new(k0, k1, p),
+            writer,
+            elements: BTreeSet::new(),
+            m,
+        }
+    }
+
+    /// Adds data to the filter.
+    pub fn add_element(&mut self, element: &[u8]) {
+        if !element.is_empty() {
+            self.elements.insert(element.to_vec());
+        }
+    }
+
+    /// Writes the filter to the wrapped writer.
+    pub fn finish(&mut self) -> Result<usize, io::Error> {
+        let nm = self.elements.len() as u64 * self.m;
+
+        // map hashes to [0, n_elements * M)
+        let mut mapped: Vec<_> = self
+            .elements
+            .iter()
+            .map(|e| map_to_range(self.filter.hash(e.as_slice()), nm))
+            .collect();
+        mapped.sort_unstable();
+
+        // write number of elements as varint
+        let mut wrote = VarInt::from(mapped.len()).consensus_encode(self.writer)?;
+
+        // write out deltas of sorted values into a Golonb-Rice coded bit stream
+        let mut writer = BitStreamWriter::new(self.writer);
+        let mut last = 0;
+        for data in mapped {
+            wrote += self.filter.golomb_rice_encode(&mut writer, data - last)?;
+            last = data;
+        }
+        wrote += writer.flush()?;
+        Ok(wrote)
+    }
+}
+
+/// Golomb Coded Set Filter.
+struct GcsFilter {
+    k0: u64, // sip hash key
+    k1: u64, // sip hash key
+    p: u8,
+}
+
+impl GcsFilter {
+    /// Creates a new [`GcsFilter`].
+    fn new(k0: u64, k1: u64, p: u8) -> GcsFilter {
+        GcsFilter { k0, k1, p }
+    }
+
+    /// Golomb-Rice encodes a number `n` to a bit stream (parameter 2^k).
+    fn golomb_rice_encode<W>(
+        &self,
+        writer: &mut BitStreamWriter<'_, W>,
+        n: u64,
+    ) -> Result<usize, io::Error>
+    where
+        W: Write,
+    {
+        let mut wrote = 0;
+        let mut q = n >> self.p;
+        while q > 0 {
+            let nbits = cmp::min(q, 64);
+            wrote += writer.write(!0u64, nbits as u8)?;
+            q -= nbits;
+        }
+        wrote += writer.write(0, 1)?;
+        wrote += writer.write(n, self.p)?;
+        Ok(wrote)
+    }
+
+    /// Golomb-Rice decodes a number from a bit stream (parameter 2^k).
+    fn golomb_rice_decode<R>(&self, reader: &mut BitStreamReader<R>) -> Result<u64, io::Error>
+    where
+        R: Read + ?Sized,
+    {
+        let mut q = 0u64;
+        while reader.read(1)? == 1 {
+            q += 1;
+        }
+        let r = reader.read(self.p)?;
+        Ok((q << self.p) + r)
+    }
+
+    /// Hashes an arbitrary slice with siphash using parameters of this filter.
+    fn hash(&self, element: &[u8]) -> u64 {
+        siphash24::Hash::hash_to_u64_with_keys(self.k0, self.k1, element)
+    }
+}
+
+/// Bitwise stream reader.
+pub struct BitStreamReader<'a, R: ?Sized> {
+    buffer: [u8; 1],
+    offset: u8,
+    reader: &'a mut R,
+}
+
+impl<'a, R: Read + ?Sized> BitStreamReader<'a, R> {
+    /// Creates a new [`BitStreamReader`] that reads bitwise from a given `reader`.
+    pub fn new(reader: &'a mut R) -> BitStreamReader<'a, R> {
+        BitStreamReader {
+            buffer: [0u8],
+            reader,
+            offset: 8,
+        }
+    }
+
+    /// Reads nbit bits, returning the bits in a `u64` starting with the rightmost bit.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::bip158::BitStreamReader;
+    /// # let data = vec![0xff];
+    /// # let mut input = data.as_slice();
+    /// let mut reader = BitStreamReader::new(&mut input); // input contains all 1's
+    /// let res = reader.read(1).expect("read failed");
+    /// assert_eq!(res, 1_u64);
+    /// ```
+    pub fn read(&mut self, mut nbits: u8) -> Result<u64, io::Error> {
+        if nbits > 64 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "can not read more than 64 bits at once",
+            ));
+        }
+        let mut data = 0u64;
+        while nbits > 0 {
+            if self.offset == 8 {
+                self.reader.read_exact(&mut self.buffer)?;
+                self.offset = 0;
+            }
+            let bits = cmp::min(8 - self.offset, nbits);
+            data <<= bits;
+            data |= ((self.buffer[0] << self.offset) >> (8 - bits)) as u64;
+            self.offset += bits;
+            nbits -= bits;
+        }
+        Ok(data)
+    }
+}
+
+/// Bitwise stream writer.
+pub struct BitStreamWriter<'a, W> {
+    buffer: [u8; 1],
+    offset: u8,
+    writer: &'a mut W,
+}
+
+impl<'a, W: Write> BitStreamWriter<'a, W> {
+    /// Creates a new [`BitStreamWriter`] that writes bitwise to a given `writer`.
+    pub fn new(writer: &'a mut W) -> BitStreamWriter<'a, W> {
+        BitStreamWriter {
+            buffer: [0u8],
+            writer,
+            offset: 0,
+        }
+    }
+
+    /// Writes nbits bits from data.
+    pub fn write(&mut self, data: u64, mut nbits: u8) -> Result<usize, io::Error> {
+        if nbits > 64 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "can not write more than 64 bits at once",
+            ));
+        }
+        let mut wrote = 0;
+        while nbits > 0 {
+            let bits = cmp::min(8 - self.offset, nbits);
+            self.buffer[0] |= ((data << (64 - nbits)) >> (64 - 8 + self.offset)) as u8;
+            self.offset += bits;
+            nbits -= bits;
+            if self.offset == 8 {
+                wrote += self.flush()?;
+            }
+        }
+        Ok(wrote)
+    }
+
+    /// flush bits not yet written.
+    pub fn flush(&mut self) -> Result<usize, io::Error> {
+        if self.offset > 0 {
+            self.writer.write_all(&self.buffer)?;
+            self.buffer[0] = 0u8;
+            self.offset = 0;
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use hex::test_hex_unwrap as hex;
+    // use serde_json::Value;
+
+    use super::*;
+    use crate::consensus::encode::deserialize;
+    use crate::ScriptBuf;
+
+    // #[test]
+    // fn test_blockfilters() {
+    //     // test vectors from: https://github.com/jimpo/bitcoin/blob/c7efb652f3543b001b4dd22186a354605b14f47e/src/test/data/blockfilters.json
+    //     let data = include_str!("../tests/data/blockfilters.json");
+
+    //     let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
+    //     for t in testdata.iter().skip(1) {
+    //         let block_hash = t.get(1).unwrap().as_str().unwrap().parse::<BlockHash>().unwrap();
+    //         let block: Block = deserialize(&hex!(t.get(2).unwrap().as_str().unwrap())).unwrap();
+    //         assert_eq!(block.block_hash(), block_hash);
+    //         let scripts = t.get(3).unwrap().as_array().unwrap();
+    //         let previous_filter_header =
+    //             t.get(4).unwrap().as_str().unwrap().parse::<FilterHeader>().unwrap();
+    //         let filter_content = hex!(t.get(5).unwrap().as_str().unwrap());
+    //         let filter_header =
+    //             t.get(6).unwrap().as_str().unwrap().parse::<FilterHeader>().unwrap();
+
+    //         let mut txmap = HashMap::new();
+    //         let mut si = scripts.iter();
+    //         for tx in block.txdata.iter().skip(1) {
+    //             for input in tx.input.iter() {
+    //                 txmap.insert(
+    //                     input.previous_output,
+    //                     ScriptBuf::from(hex!(si.next().unwrap().as_str().unwrap())),
+    //                 );
+    //             }
+    //         }
+
+    //         let filter = BlockFilter::new_script_filter(&block, |o| {
+    //             if let Some(s) = txmap.get(o) {
+    //                 Ok(s.clone())
+    //             } else {
+    //                 Err(Error::UtxoMissing(*o))
+    //             }
+    //         })
+    //         .unwrap();
+
+    //         let test_filter = BlockFilter::new(filter_content.as_slice());
+
+    //         assert_eq!(test_filter.content, filter.content);
+
+    //         let block_hash = &block.block_hash();
+    //         assert!(filter
+    //             .match_all(
+    //                 block_hash,
+    //                 &mut txmap.iter().filter_map(|(_, s)| if !s.is_empty() {
+    //                     Some(s.as_bytes())
+    //                 } else {
+    //                     None
+    //                 })
+    //             )
+    //             .unwrap());
+
+    //         for script in txmap.values() {
+    //             let query = [script];
+    //             if !script.is_empty() {
+    //                 assert!(filter
+    //                     .match_any(block_hash, &mut query.iter().map(|s| s.as_bytes()))
+    //                     .unwrap());
+    //             }
+    //         }
+
+    //         assert_eq!(filter_header, filter.filter_header(&previous_filter_header));
+    //     }
+    // }
+
+    #[test]
+    fn test_filter() {
+        let mut patterns = BTreeSet::new();
+
+        patterns.insert(hex!("000000"));
+        patterns.insert(hex!("111111"));
+        patterns.insert(hex!("222222"));
+        patterns.insert(hex!("333333"));
+        patterns.insert(hex!("444444"));
+        patterns.insert(hex!("555555"));
+        patterns.insert(hex!("666666"));
+        patterns.insert(hex!("777777"));
+        patterns.insert(hex!("888888"));
+        patterns.insert(hex!("999999"));
+        patterns.insert(hex!("aaaaaa"));
+        patterns.insert(hex!("bbbbbb"));
+        patterns.insert(hex!("cccccc"));
+        patterns.insert(hex!("dddddd"));
+        patterns.insert(hex!("eeeeee"));
+        patterns.insert(hex!("ffffff"));
+
+        let mut out = Vec::new();
+        {
+            let mut writer = GcsFilterWriter::new(&mut out, 0, 0, M, P);
+            for p in &patterns {
+                writer.add_element(p.as_slice());
+            }
+            writer.finish().unwrap();
+        }
+
+        let bytes = out;
+
+        {
+            let query = [hex!("abcdef"), hex!("eeeeee")];
+            let reader = GcsFilterReader::new(0, 0, M, P);
+            assert!(reader
+                .match_any(
+                    &mut bytes.as_slice(),
+                    &mut query.iter().map(|v| v.as_slice())
+                )
+                .unwrap());
+        }
+        {
+            let query = [hex!("abcdef"), hex!("123456")];
+            let reader = GcsFilterReader::new(0, 0, M, P);
+            assert!(!reader
+                .match_any(
+                    &mut bytes.as_slice(),
+                    &mut query.iter().map(|v| v.as_slice())
+                )
+                .unwrap());
+        }
+        {
+            let reader = GcsFilterReader::new(0, 0, M, P);
+            let mut query = Vec::new();
+            for p in &patterns {
+                query.push(p.clone());
+            }
+            assert!(reader
+                .match_all(
+                    &mut bytes.as_slice(),
+                    &mut query.iter().map(|v| v.as_slice())
+                )
+                .unwrap());
+        }
+        {
+            let reader = GcsFilterReader::new(0, 0, M, P);
+            let mut query = Vec::new();
+            for p in &patterns {
+                query.push(p.clone());
+            }
+            query.push(hex!("abcdef"));
+            assert!(!reader
+                .match_all(
+                    &mut bytes.as_slice(),
+                    &mut query.iter().map(|v| v.as_slice())
+                )
+                .unwrap());
+        }
+    }
+
+    #[test]
+    fn test_bit_stream() {
+        let mut out = Vec::new();
+        {
+            let mut writer = BitStreamWriter::new(&mut out);
+            writer.write(0, 1).unwrap(); // 0
+            writer.write(2, 2).unwrap(); // 10
+            writer.write(6, 3).unwrap(); // 110
+            writer.write(11, 4).unwrap(); // 1011
+            writer.write(1, 5).unwrap(); // 00001
+            writer.write(32, 6).unwrap(); // 100000
+            writer.write(7, 7).unwrap(); // 0000111
+            writer.flush().unwrap();
+        }
+        let bytes = out;
+        assert_eq!(
+            "01011010110000110000000001110000",
+            format!(
+                "{:08b}{:08b}{:08b}{:08b}",
+                bytes[0], bytes[1], bytes[2], bytes[3]
+            )
+        );
+        {
+            let mut input = bytes.as_slice();
+            let mut reader = BitStreamReader::new(&mut input);
+            assert_eq!(reader.read(1).unwrap(), 0);
+            assert_eq!(reader.read(2).unwrap(), 2);
+            assert_eq!(reader.read(3).unwrap(), 6);
+            assert_eq!(reader.read(4).unwrap(), 11);
+            assert_eq!(reader.read(5).unwrap(), 1);
+            assert_eq!(reader.read(6).unwrap(), 32);
+            assert_eq!(reader.read(7).unwrap(), 7);
+            // 4 bits remained
+            assert!(reader.read(5).is_err());
+        }
+    }
+}

--- a/libs/bitcoin/src/bip32.rs
+++ b/libs/bitcoin/src/bip32.rs
@@ -1,0 +1,1260 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! BIP32 implementation.
+//!
+//! Implementation of BIP32 hierarchical deterministic wallets, as defined
+//! at <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>.
+//!
+
+use core::ops::Index;
+use core::str::FromStr;
+use core::{fmt, slice};
+
+use hashes::{hash160, hash_newtype, sha512, Hash, HashEngine, Hmac, HmacEngine};
+use internals::{impl_array_newtype, write_err};
+use io::Write;
+use secp256k1::{Secp256k1, XOnlyPublicKey};
+
+use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
+use crate::internal_macros::impl_bytes_newtype;
+use crate::network::NetworkKind;
+use crate::prelude::*;
+
+/// Version bytes for extended public keys on the Bitcoin network.
+const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
+/// Version bytes for extended private keys on the Bitcoin network.
+const VERSION_BYTES_MAINNET_PRIVATE: [u8; 4] = [0x04, 0x88, 0xAD, 0xE4];
+/// Version bytes for extended public keys on any of the testnet networks.
+const VERSION_BYTES_TESTNETS_PUBLIC: [u8; 4] = [0x04, 0x35, 0x87, 0xCF];
+/// Version bytes for extended private keys on any of the testnet networks.
+const VERSION_BYTES_TESTNETS_PRIVATE: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
+
+/// The old name for xpub, extended public key.
+#[deprecated(since = "0.31.0", note = "use xpub instead")]
+pub type ExtendedPubKey = Xpub;
+
+/// The old name for xpub, extended public key (with a released typo in it).
+#[deprecated(since = "0.31.0", note = "use xpub instead")]
+pub type ExtendendPubKey = Xpub;
+
+/// The old name for xpriv, extended public key.
+#[deprecated(since = "0.31.0", note = "use xpriv instead")]
+pub type ExtendedPrivKey = Xpriv;
+
+/// The old name for xpriv, extended public key (with a released typo in it).
+#[deprecated(since = "0.31.0", note = "use xpriv instead")]
+pub type ExtendendPrivKey = Xpriv;
+
+/// A chain code
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ChainCode([u8; 32]);
+impl_array_newtype!(ChainCode, u8, 32);
+impl_bytes_newtype!(ChainCode, 32);
+
+impl ChainCode {
+    fn from_hmac(hmac: Hmac<sha512::Hash>) -> Self {
+        hmac[32..].try_into().expect("half of hmac is guaranteed to be 32 bytes")
+    }
+}
+
+/// A fingerprint
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Fingerprint([u8; 4]);
+impl_array_newtype!(Fingerprint, u8, 4);
+impl_bytes_newtype!(Fingerprint, 4);
+
+hash_newtype! {
+    /// Extended key identifier as defined in BIP-32.
+    pub struct XKeyIdentifier(hash160::Hash);
+}
+
+/// Extended private key
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct Xpriv {
+    /// The network this key is to be used on
+    pub network: NetworkKind,
+    /// How many derivations this key is from the master (which is 0)
+    pub depth: u8,
+    /// Fingerprint of the parent key (0 for master)
+    pub parent_fingerprint: Fingerprint,
+    /// Child number of the key used to derive from parent (0 for master)
+    pub child_number: ChildNumber,
+    /// Private key
+    pub private_key: secp256k1::SecretKey,
+    /// Chain code
+    pub chain_code: ChainCode,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(Xpriv, "a BIP-32 extended private key");
+
+#[cfg(not(feature = "std"))]
+impl fmt::Debug for Xpriv {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Xpriv")
+            .field("network", &self.network)
+            .field("depth", &self.depth)
+            .field("parent_fingerprint", &self.parent_fingerprint)
+            .field("child_number", &self.child_number)
+            .field("chain_code", &self.chain_code)
+            .field("private_key", &"[SecretKey]")
+            .finish()
+    }
+}
+
+/// Extended public key
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+pub struct Xpub {
+    /// The network kind this key is to be used on
+    pub network: NetworkKind,
+    /// How many derivations this key is from the master (which is 0)
+    pub depth: u8,
+    /// Fingerprint of the parent key
+    pub parent_fingerprint: Fingerprint,
+    /// Child number of the key used to derive from parent (0 for master)
+    pub child_number: ChildNumber,
+    /// Public key
+    pub public_key: secp256k1::PublicKey,
+    /// Chain code
+    pub chain_code: ChainCode,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(Xpub, "a BIP-32 extended public key");
+
+/// A child number for a derived key
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+pub enum ChildNumber {
+    /// Non-hardened key
+    Normal {
+        /// Key index, within [0, 2^31 - 1]
+        index: u32,
+    },
+    /// Hardened key
+    Hardened {
+        /// Key index, within [0, 2^31 - 1]
+        index: u32,
+    },
+}
+
+impl ChildNumber {
+    /// Create a [`Normal`] from an index, returns an error if the index is not within
+    /// [0, 2^31 - 1].
+    ///
+    /// [`Normal`]: #variant.Normal
+    pub fn from_normal_idx(index: u32) -> Result<Self, Error> {
+        if index & (1 << 31) == 0 {
+            Ok(ChildNumber::Normal { index })
+        } else {
+            Err(Error::InvalidChildNumber(index))
+        }
+    }
+
+    /// Create a [`Hardened`] from an index, returns an error if the index is not within
+    /// [0, 2^31 - 1].
+    ///
+    /// [`Hardened`]: #variant.Hardened
+    pub fn from_hardened_idx(index: u32) -> Result<Self, Error> {
+        if index & (1 << 31) == 0 {
+            Ok(ChildNumber::Hardened { index })
+        } else {
+            Err(Error::InvalidChildNumber(index))
+        }
+    }
+
+    /// Returns `true` if the child number is a [`Normal`] value.
+    ///
+    /// [`Normal`]: #variant.Normal
+    pub fn is_normal(&self) -> bool { !self.is_hardened() }
+
+    /// Returns `true` if the child number is a [`Hardened`] value.
+    ///
+    /// [`Hardened`]: #variant.Hardened
+    pub fn is_hardened(&self) -> bool {
+        match self {
+            ChildNumber::Hardened { .. } => true,
+            ChildNumber::Normal { .. } => false,
+        }
+    }
+
+    /// Returns the child number that is a single increment from this one.
+    pub fn increment(self) -> Result<ChildNumber, Error> {
+        match self {
+            ChildNumber::Normal { index: idx } => ChildNumber::from_normal_idx(idx + 1),
+            ChildNumber::Hardened { index: idx } => ChildNumber::from_hardened_idx(idx + 1),
+        }
+    }
+}
+
+impl From<u32> for ChildNumber {
+    fn from(number: u32) -> Self {
+        if number & (1 << 31) != 0 {
+            ChildNumber::Hardened { index: number ^ (1 << 31) }
+        } else {
+            ChildNumber::Normal { index: number }
+        }
+    }
+}
+
+impl From<ChildNumber> for u32 {
+    fn from(cnum: ChildNumber) -> Self {
+        match cnum {
+            ChildNumber::Normal { index } => index,
+            ChildNumber::Hardened { index } => index | (1 << 31),
+        }
+    }
+}
+
+impl fmt::Display for ChildNumber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ChildNumber::Hardened { index } => {
+                fmt::Display::fmt(&index, f)?;
+                let alt = f.alternate();
+                f.write_str(if alt { "h" } else { "'" })
+            }
+            ChildNumber::Normal { index } => fmt::Display::fmt(&index, f),
+        }
+    }
+}
+
+impl FromStr for ChildNumber {
+    type Err = Error;
+
+    fn from_str(inp: &str) -> Result<ChildNumber, Error> {
+        let is_hardened = inp.chars().last().map_or(false, |l| l == '\'' || l == 'h');
+        Ok(if is_hardened {
+            ChildNumber::from_hardened_idx(
+                inp[0..inp.len() - 1].parse().map_err(|_| Error::InvalidChildNumberFormat)?,
+            )?
+        } else {
+            ChildNumber::from_normal_idx(inp.parse().map_err(|_| Error::InvalidChildNumberFormat)?)?
+        })
+    }
+}
+
+impl AsRef<[ChildNumber]> for ChildNumber {
+    fn as_ref(&self) -> &[ChildNumber] { slice::from_ref(self) }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ChildNumber {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        u32::deserialize(deserializer).map(ChildNumber::from)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ChildNumber {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        u32::from(*self).serialize(serializer)
+    }
+}
+
+/// Trait that allows possibly failable conversion from a type into a
+/// derivation path
+pub trait IntoDerivationPath {
+    /// Converts a given type into a [`DerivationPath`] with possible error
+    fn into_derivation_path(self) -> Result<DerivationPath, Error>;
+}
+
+/// A BIP-32 derivation path.
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct DerivationPath(Vec<ChildNumber>);
+
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(DerivationPath, "a BIP-32 derivation path");
+
+impl<I> Index<I> for DerivationPath
+where
+    Vec<ChildNumber>: Index<I>,
+{
+    type Output = <Vec<ChildNumber> as Index<I>>::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output { &self.0[index] }
+}
+
+impl Default for DerivationPath {
+    fn default() -> DerivationPath { DerivationPath::master() }
+}
+
+impl<T> IntoDerivationPath for T
+where
+    T: Into<DerivationPath>,
+{
+    fn into_derivation_path(self) -> Result<DerivationPath, Error> { Ok(self.into()) }
+}
+
+impl IntoDerivationPath for String {
+    fn into_derivation_path(self) -> Result<DerivationPath, Error> { self.parse() }
+}
+
+impl<'a> IntoDerivationPath for &'a str {
+    fn into_derivation_path(self) -> Result<DerivationPath, Error> { self.parse() }
+}
+
+impl From<Vec<ChildNumber>> for DerivationPath {
+    fn from(numbers: Vec<ChildNumber>) -> Self { DerivationPath(numbers) }
+}
+
+impl From<DerivationPath> for Vec<ChildNumber> {
+    fn from(path: DerivationPath) -> Self { path.0 }
+}
+
+impl<'a> From<&'a [ChildNumber]> for DerivationPath {
+    fn from(numbers: &'a [ChildNumber]) -> Self { DerivationPath(numbers.to_vec()) }
+}
+
+impl core::iter::FromIterator<ChildNumber> for DerivationPath {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = ChildNumber>,
+    {
+        DerivationPath(Vec::from_iter(iter))
+    }
+}
+
+impl<'a> core::iter::IntoIterator for &'a DerivationPath {
+    type Item = &'a ChildNumber;
+    type IntoIter = slice::Iter<'a, ChildNumber>;
+    fn into_iter(self) -> Self::IntoIter { self.0.iter() }
+}
+
+impl AsRef<[ChildNumber]> for DerivationPath {
+    fn as_ref(&self) -> &[ChildNumber] { &self.0 }
+}
+
+impl FromStr for DerivationPath {
+    type Err = Error;
+
+    fn from_str(path: &str) -> Result<DerivationPath, Error> {
+        if path.is_empty() || path == "m" || path == "m/" {
+            return Ok(vec![].into());
+        }
+
+        let path = path.strip_prefix("m/").unwrap_or(path);
+
+        let parts = path.split('/');
+        let ret: Result<Vec<ChildNumber>, Error> = parts.map(str::parse).collect();
+        Ok(DerivationPath(ret?))
+    }
+}
+
+/// An iterator over children of a [DerivationPath].
+///
+/// It is returned by the methods [DerivationPath::children_from],
+/// [DerivationPath::normal_children] and [DerivationPath::hardened_children].
+pub struct DerivationPathIterator<'a> {
+    base: &'a DerivationPath,
+    next_child: Option<ChildNumber>,
+}
+
+impl<'a> DerivationPathIterator<'a> {
+    /// Start a new [DerivationPathIterator] at the given child.
+    pub fn start_from(path: &'a DerivationPath, start: ChildNumber) -> DerivationPathIterator<'a> {
+        DerivationPathIterator { base: path, next_child: Some(start) }
+    }
+}
+
+impl<'a> Iterator for DerivationPathIterator<'a> {
+    type Item = DerivationPath;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ret = self.next_child?;
+        self.next_child = ret.increment().ok();
+        Some(self.base.child(ret))
+    }
+}
+
+impl DerivationPath {
+    /// Returns length of the derivation path
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Returns `true` if the derivation path is empty
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Returns derivation path for a master key (i.e. empty derivation path)
+    pub fn master() -> DerivationPath { DerivationPath(vec![]) }
+
+    /// Returns whether derivation path represents master key (i.e. it's length
+    /// is empty). True for `m` path.
+    pub fn is_master(&self) -> bool { self.0.is_empty() }
+
+    /// Create a new [DerivationPath] that is a child of this one.
+    pub fn child(&self, cn: ChildNumber) -> DerivationPath {
+        let mut path = self.0.clone();
+        path.push(cn);
+        DerivationPath(path)
+    }
+
+    /// Convert into a [DerivationPath] that is a child of this one.
+    pub fn into_child(self, cn: ChildNumber) -> DerivationPath {
+        let mut path = self.0;
+        path.push(cn);
+        DerivationPath(path)
+    }
+
+    /// Get an [Iterator] over the children of this [DerivationPath]
+    /// starting with the given [ChildNumber].
+    pub fn children_from(&self, cn: ChildNumber) -> DerivationPathIterator {
+        DerivationPathIterator::start_from(self, cn)
+    }
+
+    /// Get an [Iterator] over the unhardened children of this [DerivationPath].
+    pub fn normal_children(&self) -> DerivationPathIterator {
+        DerivationPathIterator::start_from(self, ChildNumber::Normal { index: 0 })
+    }
+
+    /// Get an [Iterator] over the hardened children of this [DerivationPath].
+    pub fn hardened_children(&self) -> DerivationPathIterator {
+        DerivationPathIterator::start_from(self, ChildNumber::Hardened { index: 0 })
+    }
+
+    /// Concatenate `self` with `path` and return the resulting new path.
+    ///
+    /// ```
+    /// use bitcoin::bip32::{DerivationPath, ChildNumber};
+    /// use std::str::FromStr;
+    ///
+    /// let base = DerivationPath::from_str("m/42").unwrap();
+    ///
+    /// let deriv_1 = base.extend(DerivationPath::from_str("0/1").unwrap());
+    /// let deriv_2 = base.extend(&[
+    ///     ChildNumber::from_normal_idx(0).unwrap(),
+    ///     ChildNumber::from_normal_idx(1).unwrap()
+    /// ]);
+    ///
+    /// assert_eq!(deriv_1, deriv_2);
+    /// ```
+    pub fn extend<T: AsRef<[ChildNumber]>>(&self, path: T) -> DerivationPath {
+        let mut new_path = self.clone();
+        new_path.0.extend_from_slice(path.as_ref());
+        new_path
+    }
+
+    /// Returns the derivation path as a vector of u32 integers.
+    /// Unhardened elements are copied as is.
+    /// 0x80000000 is added to the hardened elements.
+    ///
+    /// ```
+    /// use bitcoin::bip32::DerivationPath;
+    /// use std::str::FromStr;
+    ///
+    /// let path = DerivationPath::from_str("m/84'/0'/0'/0/1").unwrap();
+    /// const HARDENED: u32 = 0x80000000;
+    /// assert_eq!(path.to_u32_vec(), vec![84 + HARDENED, HARDENED, HARDENED, 0, 1]);
+    /// ```
+    pub fn to_u32_vec(&self) -> Vec<u32> { self.into_iter().map(|&el| el.into()).collect() }
+}
+
+impl fmt::Display for DerivationPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(first_element) = iter.next() {
+            write!(f, "{}", first_element)?;
+        }
+        for cn in iter {
+            f.write_str("/")?;
+            write!(f, "{}", cn)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for DerivationPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self, f) }
+}
+
+/// Full information on the used extended public key: fingerprint of the
+/// master extended public key and a derivation path from it.
+pub type KeySource = (Fingerprint, DerivationPath);
+
+/// A BIP32 error
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// A pk->pk derivation was attempted on a hardened key
+    CannotDeriveFromHardenedKey,
+    /// A secp256k1 error occurred
+    Secp256k1(secp256k1::Error),
+    /// A child number was provided that was out of range
+    InvalidChildNumber(u32),
+    /// Invalid childnumber format.
+    InvalidChildNumberFormat,
+    /// Invalid derivation path format.
+    InvalidDerivationPathFormat,
+    /// Unknown version magic bytes
+    UnknownVersion([u8; 4]),
+    /// Encoded extended key data has wrong length
+    WrongExtendedKeyLength(usize),
+    /// Base58 encoding error
+    Base58(base58::Error),
+    /// Hexadecimal decoding error
+    Hex(hex::HexToArrayError),
+    /// `PublicKey` hex should be 66 or 130 digits long.
+    InvalidPublicKeyHexLength(usize),
+    /// Base58 decoded data was an invalid length.
+    InvalidBase58PayloadLength(InvalidBase58PayloadLengthError),
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            CannotDeriveFromHardenedKey =>
+                f.write_str("cannot derive hardened key from public key"),
+            Secp256k1(ref e) => write_err!(f, "secp256k1 error"; e),
+            InvalidChildNumber(ref n) =>
+                write!(f, "child number {} is invalid (not within [0, 2^31 - 1])", n),
+            InvalidChildNumberFormat => f.write_str("invalid child number format"),
+            InvalidDerivationPathFormat => f.write_str("invalid derivation path format"),
+            UnknownVersion(ref bytes) => write!(f, "unknown version magic bytes: {:?}", bytes),
+            WrongExtendedKeyLength(ref len) =>
+                write!(f, "encoded extended key data has wrong length {}", len),
+            Base58(ref e) => write_err!(f, "base58 encoding error"; e),
+            Hex(ref e) => write_err!(f, "Hexadecimal decoding error"; e),
+            InvalidPublicKeyHexLength(got) =>
+                write!(f, "PublicKey hex should be 66 or 130 digits long, got: {}", got),
+            InvalidBase58PayloadLength(ref e) => write_err!(f, "base58 payload"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            Secp256k1(ref e) => Some(e),
+            Base58(ref e) => Some(e),
+            Hex(ref e) => Some(e),
+            InvalidBase58PayloadLength(ref e) => Some(e),
+            CannotDeriveFromHardenedKey
+            | InvalidChildNumber(_)
+            | InvalidChildNumberFormat
+            | InvalidDerivationPathFormat
+            | UnknownVersion(_)
+            | WrongExtendedKeyLength(_)
+            | InvalidPublicKeyHexLength(_) => None,
+        }
+    }
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
+}
+
+impl From<base58::Error> for Error {
+    fn from(err: base58::Error) -> Self { Error::Base58(err) }
+}
+
+impl From<InvalidBase58PayloadLengthError> for Error {
+    fn from(e: InvalidBase58PayloadLengthError) -> Error { Self::InvalidBase58PayloadLength(e) }
+}
+
+impl Xpriv {
+    /// Construct a new master key from a seed value
+    pub fn new_master(network: impl Into<NetworkKind>, seed: &[u8]) -> Result<Xpriv, Error> {
+        let mut hmac_engine: HmacEngine<sha512::Hash> = HmacEngine::new(b"Bitcoin seed");
+        hmac_engine.input(seed);
+        let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
+
+        Ok(Xpriv {
+            network: network.into(),
+            depth: 0,
+            parent_fingerprint: Default::default(),
+            child_number: ChildNumber::from_normal_idx(0)?,
+            private_key: secp256k1::SecretKey::from_slice(&hmac_result[..32])?,
+            chain_code: ChainCode::from_hmac(hmac_result),
+        })
+    }
+
+    /// Constructs ECDSA compressed private key matching internal secret key representation.
+    pub fn to_priv(self) -> PrivateKey {
+        PrivateKey { compressed: true, network: self.network, inner: self.private_key }
+    }
+
+    /// Constructs BIP340 keypair for Schnorr signatures and Taproot use matching the internal
+    /// secret key representation.
+    pub fn to_keypair<C: secp256k1::Signing>(self, secp: &Secp256k1<C>) -> Keypair {
+        Keypair::from_seckey_slice(secp, &self.private_key[..])
+            .expect("BIP32 internal private key representation is broken")
+    }
+
+    /// Attempts to derive an extended private key from a path.
+    ///
+    /// The `path` argument can be both of type `DerivationPath` or `Vec<ChildNumber>`.
+    pub fn derive_priv<C: secp256k1::Signing, P: AsRef<[ChildNumber]>>(
+        &self,
+        secp: &Secp256k1<C>,
+        path: &P,
+    ) -> Result<Xpriv, Error> {
+        let mut sk: Xpriv = *self;
+        for cnum in path.as_ref() {
+            sk = sk.ckd_priv(secp, *cnum)?;
+        }
+        Ok(sk)
+    }
+
+    /// Private->Private child key derivation
+    fn ckd_priv<C: secp256k1::Signing>(
+        &self,
+        secp: &Secp256k1<C>,
+        i: ChildNumber,
+    ) -> Result<Xpriv, Error> {
+        let mut hmac_engine: HmacEngine<sha512::Hash> = HmacEngine::new(&self.chain_code[..]);
+        match i {
+            ChildNumber::Normal { .. } => {
+                // Non-hardened key: compute public data and use that
+                hmac_engine.input(
+                    &secp256k1::PublicKey::from_secret_key(secp, &self.private_key).serialize()[..],
+                );
+            }
+            ChildNumber::Hardened { .. } => {
+                // Hardened key: use only secret data to prevent public derivation
+                hmac_engine.input(&[0u8]);
+                hmac_engine.input(&self.private_key[..]);
+            }
+        }
+
+        hmac_engine.input(&u32::from(i).to_be_bytes());
+        let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
+        let sk = secp256k1::SecretKey::from_slice(&hmac_result[..32])
+            .expect("statistically impossible to hit");
+        let tweaked =
+            sk.add_tweak(&self.private_key.into()).expect("statistically impossible to hit");
+
+        Ok(Xpriv {
+            network: self.network,
+            depth: self.depth + 1,
+            parent_fingerprint: self.fingerprint(secp),
+            child_number: i,
+            private_key: tweaked,
+            chain_code: ChainCode::from_hmac(hmac_result),
+        })
+    }
+
+    /// Decoding extended private key from binary data according to BIP 32
+    pub fn decode(data: &[u8]) -> Result<Xpriv, Error> {
+        if data.len() != 78 {
+            return Err(Error::WrongExtendedKeyLength(data.len()));
+        }
+
+        let network = if data.starts_with(&VERSION_BYTES_MAINNET_PRIVATE) {
+            NetworkKind::Main
+        } else if data.starts_with(&VERSION_BYTES_TESTNETS_PRIVATE) {
+            NetworkKind::Test
+        } else {
+            let (b0, b1, b2, b3) = (data[0], data[1], data[2], data[3]);
+            return Err(Error::UnknownVersion([b0, b1, b2, b3]));
+        };
+
+        Ok(Xpriv {
+            network,
+            depth: data[4],
+            parent_fingerprint: data[5..9]
+                .try_into()
+                .expect("9 - 5 == 4, which is the Fingerprint length"),
+            child_number: u32::from_be_bytes(data[9..13].try_into().expect("4 byte slice")).into(),
+            chain_code: data[13..45]
+                .try_into()
+                .expect("45 - 13 == 32, which is the ChainCode length"),
+            private_key: secp256k1::SecretKey::from_slice(&data[46..78])?,
+        })
+    }
+
+    /// Extended private key binary encoding according to BIP 32
+    pub fn encode(&self) -> [u8; 78] {
+        let mut ret = [0; 78];
+        ret[0..4].copy_from_slice(&match self.network {
+            NetworkKind::Main => VERSION_BYTES_MAINNET_PRIVATE,
+            NetworkKind::Test => VERSION_BYTES_TESTNETS_PRIVATE,
+        });
+        ret[4] = self.depth;
+        ret[5..9].copy_from_slice(&self.parent_fingerprint[..]);
+        ret[9..13].copy_from_slice(&u32::from(self.child_number).to_be_bytes());
+        ret[13..45].copy_from_slice(&self.chain_code[..]);
+        ret[45] = 0;
+        ret[46..78].copy_from_slice(&self.private_key[..]);
+        ret
+    }
+
+    /// Returns the HASH160 of the public key belonging to the xpriv
+    pub fn identifier<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> XKeyIdentifier {
+        Xpub::from_priv(secp, self).identifier()
+    }
+
+    /// Returns the first four bytes of the identifier
+    pub fn fingerprint<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> Fingerprint {
+        self.identifier(secp)[0..4].try_into().expect("4 is the fingerprint length")
+    }
+}
+
+impl Xpub {
+    /// Derives a public key from a private key
+    pub fn from_priv<C: secp256k1::Signing>(secp: &Secp256k1<C>, sk: &Xpriv) -> Xpub {
+        Xpub {
+            network: sk.network,
+            depth: sk.depth,
+            parent_fingerprint: sk.parent_fingerprint,
+            child_number: sk.child_number,
+            public_key: secp256k1::PublicKey::from_secret_key(secp, &sk.private_key),
+            chain_code: sk.chain_code,
+        }
+    }
+
+    /// Constructs ECDSA compressed public key matching internal public key representation.
+    pub fn to_pub(self) -> CompressedPublicKey { CompressedPublicKey(self.public_key) }
+
+    /// Constructs BIP340 x-only public key for BIP-340 signatures and Taproot use matching
+    /// the internal public key representation.
+    pub fn to_x_only_pub(self) -> XOnlyPublicKey { XOnlyPublicKey::from(self.public_key) }
+
+    /// Attempts to derive an extended public key from a path.
+    ///
+    /// The `path` argument can be any type implementing `AsRef<ChildNumber>`, such as `DerivationPath`, for instance.
+    pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
+        &self,
+        secp: &Secp256k1<C>,
+        path: &P,
+    ) -> Result<Xpub, Error> {
+        let mut pk: Xpub = *self;
+        for cnum in path.as_ref() {
+            pk = pk.ckd_pub(secp, *cnum)?
+        }
+        Ok(pk)
+    }
+
+    /// Compute the scalar tweak added to this key to get a child key
+    pub fn ckd_pub_tweak(
+        &self,
+        i: ChildNumber,
+    ) -> Result<(secp256k1::SecretKey, ChainCode), Error> {
+        match i {
+            ChildNumber::Hardened { .. } => Err(Error::CannotDeriveFromHardenedKey),
+            ChildNumber::Normal { index: n } => {
+                let mut hmac_engine: HmacEngine<sha512::Hash> =
+                    HmacEngine::new(&self.chain_code[..]);
+                hmac_engine.input(&self.public_key.serialize()[..]);
+                hmac_engine.input(&n.to_be_bytes());
+
+                let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
+
+                let private_key = secp256k1::SecretKey::from_slice(&hmac_result[..32])?;
+                let chain_code = ChainCode::from_hmac(hmac_result);
+                Ok((private_key, chain_code))
+            }
+        }
+    }
+
+    /// Public->Public child key derivation
+    pub fn ckd_pub<C: secp256k1::Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        i: ChildNumber,
+    ) -> Result<Xpub, Error> {
+        let (sk, chain_code) = self.ckd_pub_tweak(i)?;
+        let tweaked = self.public_key.add_exp_tweak(secp, &sk.into())?;
+
+        Ok(Xpub {
+            network: self.network,
+            depth: self.depth + 1,
+            parent_fingerprint: self.fingerprint(),
+            child_number: i,
+            public_key: tweaked,
+            chain_code,
+        })
+    }
+
+    /// Decoding extended public key from binary data according to BIP 32
+    pub fn decode(data: &[u8]) -> Result<Xpub, Error> {
+        if data.len() != 78 {
+            return Err(Error::WrongExtendedKeyLength(data.len()));
+        }
+
+        let network = if data.starts_with(&VERSION_BYTES_MAINNET_PUBLIC) {
+            NetworkKind::Main
+        } else if data.starts_with(&VERSION_BYTES_TESTNETS_PUBLIC) {
+            NetworkKind::Test
+        } else {
+            let (b0, b1, b2, b3) = (data[0], data[1], data[2], data[3]);
+            return Err(Error::UnknownVersion([b0, b1, b2, b3]));
+        };
+
+        Ok(Xpub {
+            network,
+            depth: data[4],
+            parent_fingerprint: data[5..9]
+                .try_into()
+                .expect("9 - 5 == 4, which is the Fingerprint length"),
+            child_number: u32::from_be_bytes(data[9..13].try_into().expect("4 byte slice")).into(),
+            chain_code: data[13..45]
+                .try_into()
+                .expect("45 - 13 == 32, which is the ChainCode length"),
+            public_key: secp256k1::PublicKey::from_slice(&data[45..78])?,
+        })
+    }
+
+    /// Extended public key binary encoding according to BIP 32
+    pub fn encode(&self) -> [u8; 78] {
+        let mut ret = [0; 78];
+        ret[0..4].copy_from_slice(&match self.network {
+            NetworkKind::Main => VERSION_BYTES_MAINNET_PUBLIC,
+            NetworkKind::Test => VERSION_BYTES_TESTNETS_PUBLIC,
+        });
+        ret[4] = self.depth;
+        ret[5..9].copy_from_slice(&self.parent_fingerprint[..]);
+        ret[9..13].copy_from_slice(&u32::from(self.child_number).to_be_bytes());
+        ret[13..45].copy_from_slice(&self.chain_code[..]);
+        ret[45..78].copy_from_slice(&self.public_key.serialize()[..]);
+        ret
+    }
+
+    /// Returns the HASH160 of the chaincode
+    pub fn identifier(&self) -> XKeyIdentifier {
+        let mut engine = XKeyIdentifier::engine();
+        engine.write_all(&self.public_key.serialize()).expect("engines don't error");
+        XKeyIdentifier::from_engine(engine)
+    }
+
+    /// Returns the first four bytes of the identifier
+    pub fn fingerprint(&self) -> Fingerprint {
+        self.identifier()[0..4].try_into().expect("4 is the fingerprint length")
+    }
+}
+
+impl fmt::Display for Xpriv {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        base58::encode_check_to_fmt(fmt, &self.encode()[..])
+    }
+}
+
+impl FromStr for Xpriv {
+    type Err = Error;
+
+    fn from_str(inp: &str) -> Result<Xpriv, Error> {
+        let data = base58::decode_check(inp)?;
+
+        if data.len() != 78 {
+            return Err(InvalidBase58PayloadLengthError { length: data.len() }.into());
+        }
+
+        Xpriv::decode(&data)
+    }
+}
+
+impl fmt::Display for Xpub {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        base58::encode_check_to_fmt(fmt, &self.encode()[..])
+    }
+}
+
+impl FromStr for Xpub {
+    type Err = Error;
+
+    fn from_str(inp: &str) -> Result<Xpub, Error> {
+        let data = base58::decode_check(inp)?;
+
+        if data.len() != 78 {
+            return Err(InvalidBase58PayloadLengthError { length: data.len() }.into());
+        }
+
+        Xpub::decode(&data)
+    }
+}
+
+impl From<Xpub> for XKeyIdentifier {
+    fn from(key: Xpub) -> XKeyIdentifier { key.identifier() }
+}
+
+impl From<&Xpub> for XKeyIdentifier {
+    fn from(key: &Xpub) -> XKeyIdentifier { key.identifier() }
+}
+
+/// Decoded base58 data was an invalid length.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidBase58PayloadLengthError {
+    /// The base58 payload length we got after decoding xpriv/xpub string.
+    pub(crate) length: usize,
+}
+
+impl InvalidBase58PayloadLengthError {
+    /// Returns the invalid payload length.
+    pub fn invalid_base58_payload_length(&self) -> usize { self.length }
+}
+
+impl fmt::Display for InvalidBase58PayloadLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "decoded base58 xpriv/xpub data was an invalid length: {} (expected 78)",
+            self.length
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidBase58PayloadLengthError {}
+
+#[cfg(test)]
+mod tests {
+    use hex::test_hex_unwrap as hex;
+
+    use super::ChildNumber::{Hardened, Normal};
+    use super::*;
+
+    #[test]
+    fn test_parse_derivation_path() {
+        assert_eq!(DerivationPath::from_str("n/0'/0"), Err(Error::InvalidChildNumberFormat));
+        assert_eq!(DerivationPath::from_str("4/m/5"), Err(Error::InvalidChildNumberFormat));
+        assert_eq!(DerivationPath::from_str("//3/0'"), Err(Error::InvalidChildNumberFormat));
+        assert_eq!(DerivationPath::from_str("0h/0x"), Err(Error::InvalidChildNumberFormat));
+        assert_eq!(
+            DerivationPath::from_str("2147483648"),
+            Err(Error::InvalidChildNumber(2147483648))
+        );
+
+        assert_eq!(DerivationPath::master(), DerivationPath::from_str("").unwrap());
+        assert_eq!(DerivationPath::master(), DerivationPath::default());
+
+        // Acceptable forms for a master path.
+        assert_eq!(DerivationPath::from_str("m").unwrap(), DerivationPath(vec![]));
+        assert_eq!(DerivationPath::from_str("m/").unwrap(), DerivationPath(vec![]));
+        assert_eq!(DerivationPath::from_str("").unwrap(), DerivationPath(vec![]));
+
+        assert_eq!(
+            DerivationPath::from_str("0'"),
+            Ok(vec![ChildNumber::from_hardened_idx(0).unwrap()].into())
+        );
+        assert_eq!(
+            DerivationPath::from_str("0'/1"),
+            Ok(vec![
+                ChildNumber::from_hardened_idx(0).unwrap(),
+                ChildNumber::from_normal_idx(1).unwrap()
+            ]
+            .into())
+        );
+        assert_eq!(
+            DerivationPath::from_str("0h/1/2'"),
+            Ok(vec![
+                ChildNumber::from_hardened_idx(0).unwrap(),
+                ChildNumber::from_normal_idx(1).unwrap(),
+                ChildNumber::from_hardened_idx(2).unwrap(),
+            ]
+            .into())
+        );
+        assert_eq!(
+            DerivationPath::from_str("0'/1/2h/2"),
+            Ok(vec![
+                ChildNumber::from_hardened_idx(0).unwrap(),
+                ChildNumber::from_normal_idx(1).unwrap(),
+                ChildNumber::from_hardened_idx(2).unwrap(),
+                ChildNumber::from_normal_idx(2).unwrap(),
+            ]
+            .into())
+        );
+        let want = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(2).unwrap(),
+            ChildNumber::from_normal_idx(2).unwrap(),
+            ChildNumber::from_normal_idx(1000000000).unwrap(),
+        ]);
+        assert_eq!(DerivationPath::from_str("0'/1/2'/2/1000000000").unwrap(), want);
+        assert_eq!(DerivationPath::from_str("m/0'/1/2'/2/1000000000").unwrap(), want);
+
+        let s = "0'/50/3'/5/545456";
+        assert_eq!(DerivationPath::from_str(s), s.into_derivation_path());
+        assert_eq!(DerivationPath::from_str(s), s.to_string().into_derivation_path());
+
+        let s = "m/0'/50/3'/5/545456";
+        assert_eq!(DerivationPath::from_str(s), s.into_derivation_path());
+        assert_eq!(DerivationPath::from_str(s), s.to_string().into_derivation_path());
+    }
+
+    #[test]
+    fn test_derivation_path_conversion_index() {
+        let path = DerivationPath::from_str("0h/1/2'").unwrap();
+        let numbers: Vec<ChildNumber> = path.clone().into();
+        let path2: DerivationPath = numbers.into();
+        assert_eq!(path, path2);
+        assert_eq!(
+            &path[..2],
+            &[ChildNumber::from_hardened_idx(0).unwrap(), ChildNumber::from_normal_idx(1).unwrap()]
+        );
+        let indexed: DerivationPath = path[..2].into();
+        assert_eq!(indexed, DerivationPath::from_str("0h/1").unwrap());
+        assert_eq!(indexed.child(ChildNumber::from_hardened_idx(2).unwrap()), path);
+    }
+
+    fn test_path<C: secp256k1::Signing + secp256k1::Verification>(
+        secp: &Secp256k1<C>,
+        network: NetworkKind,
+        seed: &[u8],
+        path: DerivationPath,
+        expected_sk: &str,
+        expected_pk: &str,
+    ) {
+        let mut sk = Xpriv::new_master(network, seed).unwrap();
+        let mut pk = Xpub::from_priv(secp, &sk);
+
+        // Check derivation convenience method for Xpriv
+        assert_eq!(&sk.derive_priv(secp, &path).unwrap().to_string()[..], expected_sk);
+
+        // Check derivation convenience method for Xpub, should error
+        // appropriately if any ChildNumber is hardened
+        if path.0.iter().any(|cnum| cnum.is_hardened()) {
+            assert_eq!(pk.derive_pub(secp, &path), Err(Error::CannotDeriveFromHardenedKey));
+        } else {
+            assert_eq!(&pk.derive_pub(secp, &path).unwrap().to_string()[..], expected_pk);
+        }
+
+        // Derive keys, checking hardened and non-hardened derivation one-by-one
+        for &num in path.0.iter() {
+            sk = sk.ckd_priv(secp, num).unwrap();
+            match num {
+                Normal { .. } => {
+                    let pk2 = pk.ckd_pub(secp, num).unwrap();
+                    pk = Xpub::from_priv(secp, &sk);
+                    assert_eq!(pk, pk2);
+                }
+                Hardened { .. } => {
+                    assert_eq!(pk.ckd_pub(secp, num), Err(Error::CannotDeriveFromHardenedKey));
+                    pk = Xpub::from_priv(secp, &sk);
+                }
+            }
+        }
+
+        // Check result against expected base58
+        assert_eq!(&sk.to_string()[..], expected_sk);
+        assert_eq!(&pk.to_string()[..], expected_pk);
+        // Check decoded base58 against result
+        let decoded_sk = Xpriv::from_str(expected_sk);
+        let decoded_pk = Xpub::from_str(expected_pk);
+        assert_eq!(Ok(sk), decoded_sk);
+        assert_eq!(Ok(pk), decoded_pk);
+    }
+
+    #[test]
+    fn test_increment() {
+        let idx = 9345497; // randomly generated, I promise
+        let cn = ChildNumber::from_normal_idx(idx).unwrap();
+        assert_eq!(cn.increment().ok(), Some(ChildNumber::from_normal_idx(idx + 1).unwrap()));
+        let cn = ChildNumber::from_hardened_idx(idx).unwrap();
+        assert_eq!(cn.increment().ok(), Some(ChildNumber::from_hardened_idx(idx + 1).unwrap()));
+
+        let max = (1 << 31) - 1;
+        let cn = ChildNumber::from_normal_idx(max).unwrap();
+        assert_eq!(cn.increment().err(), Some(Error::InvalidChildNumber(1 << 31)));
+        let cn = ChildNumber::from_hardened_idx(max).unwrap();
+        assert_eq!(cn.increment().err(), Some(Error::InvalidChildNumber(1 << 31)));
+
+        let cn = ChildNumber::from_normal_idx(350).unwrap();
+        let path = DerivationPath::from_str("42'").unwrap();
+        let mut iter = path.children_from(cn);
+        assert_eq!(iter.next(), Some("42'/350".parse().unwrap()));
+        assert_eq!(iter.next(), Some("42'/351".parse().unwrap()));
+
+        let path = DerivationPath::from_str("42'/350'").unwrap();
+        let mut iter = path.normal_children();
+        assert_eq!(iter.next(), Some("42'/350'/0".parse().unwrap()));
+        assert_eq!(iter.next(), Some("42'/350'/1".parse().unwrap()));
+
+        let path = DerivationPath::from_str("42'/350'").unwrap();
+        let mut iter = path.hardened_children();
+        assert_eq!(iter.next(), Some("42'/350'/0'".parse().unwrap()));
+        assert_eq!(iter.next(), Some("42'/350'/1'".parse().unwrap()));
+
+        let cn = ChildNumber::from_hardened_idx(42350).unwrap();
+        let path = DerivationPath::from_str("42'").unwrap();
+        let mut iter = path.children_from(cn);
+        assert_eq!(iter.next(), Some("42'/42350'".parse().unwrap()));
+        assert_eq!(iter.next(), Some("42'/42351'".parse().unwrap()));
+
+        let cn = ChildNumber::from_hardened_idx(max).unwrap();
+        let path = DerivationPath::from_str("42'").unwrap();
+        let mut iter = path.children_from(cn);
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_vector_1() {
+        let secp = Secp256k1::new();
+        let seed = hex!("000102030405060708090a0b0c0d0e0f");
+
+        // m
+        test_path(&secp, NetworkKind::Main, &seed, "m".parse().unwrap(),
+                  "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+                  "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
+
+        // m/0h
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h".parse().unwrap(),
+                  "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+                  "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
+
+        // m/0h/1
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1".parse().unwrap(),
+                   "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+                   "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ");
+
+        // m/0h/1/2h
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1/2h".parse().unwrap(),
+                  "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+                  "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5");
+
+        // m/0h/1/2h/2
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1/2h/2".parse().unwrap(),
+                  "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+                  "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV");
+
+        // m/0h/1/2h/2/1000000000
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1/2h/2/1000000000".parse().unwrap(),
+                  "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
+                  "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy");
+    }
+
+    #[test]
+    fn test_vector_2() {
+        let secp = Secp256k1::new();
+        let seed = hex!("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542");
+
+        // m
+        test_path(&secp, NetworkKind::Main, &seed, "m".parse().unwrap(),
+                  "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
+                  "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
+
+        // m/0
+        test_path(&secp, NetworkKind::Main, &seed, "m/0".parse().unwrap(),
+                  "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
+                  "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");
+
+        // m/0/2147483647h
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h".parse().unwrap(),
+                  "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+                  "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a");
+
+        // m/0/2147483647h/1
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h/1".parse().unwrap(),
+                  "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
+                  "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon");
+
+        // m/0/2147483647h/1/2147483646h
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h/1/2147483646h".parse().unwrap(),
+                  "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+                  "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL");
+
+        // m/0/2147483647h/1/2147483646h/2
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h/1/2147483646h/2".parse().unwrap(),
+                  "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
+                  "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt");
+    }
+
+    #[test]
+    fn test_vector_3() {
+        let secp = Secp256k1::new();
+        let seed = hex!("4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be");
+
+        // m
+        test_path(&secp, NetworkKind::Main, &seed, "m".parse().unwrap(),
+                  "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6",
+                  "xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13");
+
+        // m/0h
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h".parse().unwrap(),
+                  "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
+                  "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y");
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    pub fn encode_decode_childnumber() {
+        serde_round_trip!(ChildNumber::from_normal_idx(0).unwrap());
+        serde_round_trip!(ChildNumber::from_normal_idx(1).unwrap());
+        serde_round_trip!(ChildNumber::from_normal_idx((1 << 31) - 1).unwrap());
+        serde_round_trip!(ChildNumber::from_hardened_idx(0).unwrap());
+        serde_round_trip!(ChildNumber::from_hardened_idx(1).unwrap());
+        serde_round_trip!(ChildNumber::from_hardened_idx((1 << 31) - 1).unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    pub fn encode_fingerprint_chaincode() {
+        use serde_json;
+        let fp = Fingerprint::from([1u8, 2, 3, 42]);
+        #[rustfmt::skip]
+        let cc = ChainCode::from(
+            [1u8,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]
+        );
+
+        serde_round_trip!(fp);
+        serde_round_trip!(cc);
+
+        assert_eq!("\"0102032a\"", serde_json::to_string(&fp).unwrap());
+        assert_eq!(
+            "\"0102030405060708090001020304050607080900010203040506070809000102\"",
+            serde_json::to_string(&cc).unwrap()
+        );
+        assert_eq!("0102032a", fp.to_string());
+        assert_eq!(
+            "0102030405060708090001020304050607080900010203040506070809000102",
+            cc.to_string()
+        );
+    }
+
+    #[test]
+    fn fmt_child_number() {
+        assert_eq!("000005h", &format!("{:#06}", ChildNumber::from_hardened_idx(5).unwrap()));
+        assert_eq!("5h", &format!("{:#}", ChildNumber::from_hardened_idx(5).unwrap()));
+        assert_eq!("000005'", &format!("{:06}", ChildNumber::from_hardened_idx(5).unwrap()));
+        assert_eq!("5'", &format!("{}", ChildNumber::from_hardened_idx(5).unwrap()));
+        assert_eq!("42", &format!("{}", ChildNumber::from_normal_idx(42).unwrap()));
+        assert_eq!("000042", &format!("{:06}", ChildNumber::from_normal_idx(42).unwrap()));
+    }
+
+    #[test]
+    #[should_panic(expected = "Secp256k1(InvalidSecretKey)")]
+    fn schnorr_broken_privkey_zeros() {
+        /* this is how we generate key:
+        let mut sk = secp256k1::key::ONE_KEY;
+
+        let zeros = [0u8; 32];
+        unsafe {
+            sk.as_mut_ptr().copy_from(zeros.as_ptr(), 32);
+        }
+
+        let xpriv = Xpriv {
+            network: NetworkKind::Main,
+            depth: 0,
+            parent_fingerprint: Default::default(),
+            child_number: ChildNumber::Normal { index: 0 },
+            private_key: sk,
+            chain_code: ChainCode::from([0u8; 32])
+        };
+
+        println!("{}", xpriv);
+         */
+
+        // Xpriv having secret key set to all zeros
+        let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx";
+        Xpriv::from_str(xpriv_str).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Secp256k1(InvalidSecretKey)")]
+    fn schnorr_broken_privkey_ffs() {
+        // Xpriv having secret key set to all 0xFF's
+        let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fENZ3QzxW";
+        Xpriv::from_str(xpriv_str).unwrap();
+    }
+}

--- a/libs/bitcoin/src/blockdata/block.rs
+++ b/libs/bitcoin/src/blockdata/block.rs
@@ -1,0 +1,788 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin blocks.
+//!
+//! A block is a bundle of transactions with a proof-of-work attached,
+//! which commits to an earlier block to form the blockchain. This
+//! module describes structures and functions needed to describe
+//! these blocks and the blockchain.
+//!
+
+use core::fmt;
+
+use hashes::{sha256d, Hash, HashEngine};
+use io::{Read, Write};
+
+use super::Weight;
+use crate::blockdata::script;
+use crate::blockdata::transaction::{Transaction, Txid, Wtxid};
+use crate::consensus::{encode, Decodable, Encodable, Params};
+use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
+use crate::pow::{CompactTarget, Target, Work};
+use crate::prelude::*;
+use crate::{merkle_tree, VarInt};
+
+hashes::hash_newtype! {
+    /// A bitcoin block hash.
+    pub struct BlockHash(sha256d::Hash);
+    /// A hash of the Merkle tree branch or root for transactions.
+    pub struct TxMerkleNode(sha256d::Hash);
+    /// A hash corresponding to the Merkle tree root for witness data.
+    pub struct WitnessMerkleNode(sha256d::Hash);
+    /// A hash corresponding to the witness structure commitment in the coinbase transaction.
+    pub struct WitnessCommitment(sha256d::Hash);
+}
+impl_hashencode!(BlockHash);
+impl_hashencode!(TxMerkleNode);
+impl_hashencode!(WitnessMerkleNode);
+
+impl From<Txid> for TxMerkleNode {
+    fn from(txid: Txid) -> Self {
+        Self::from_byte_array(txid.to_byte_array())
+    }
+}
+
+impl From<Wtxid> for WitnessMerkleNode {
+    fn from(wtxid: Wtxid) -> Self {
+        Self::from_byte_array(wtxid.to_byte_array())
+    }
+}
+
+/// Bitcoin block header.
+///
+/// Contains all the block's information except the actual transactions, but
+/// including a root of a [merkle tree] committing to all transactions in the block.
+///
+/// [merkle tree]: https://en.wikipedia.org/wiki/Merkle_tree
+///
+/// ### Bitcoin Core References
+///
+/// * [CBlockHeader definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/block.h#L20)
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Header {
+    /// Block version, now repurposed for soft fork signalling.
+    pub version: Version,
+    /// Reference to the previous block in the chain.
+    pub prev_blockhash: BlockHash,
+    /// The root hash of the merkle tree of transactions in the block.
+    pub merkle_root: TxMerkleNode,
+    /// The timestamp of the block, as claimed by the miner.
+    pub time: u32,
+    /// The target value below which the blockhash must lie.
+    pub bits: CompactTarget,
+    /// The nonce, selected to obtain a low enough blockhash.
+    pub nonce: u32,
+}
+
+impl_consensus_encoding!(
+    Header,
+    version,
+    prev_blockhash,
+    merkle_root,
+    time,
+    bits,
+    nonce
+);
+
+impl Header {
+    /// The number of bytes that the block header contributes to the size of a block.
+    // Serialized length of fields (version, prev_blockhash, merkle_root, time, bits, nonce)
+    pub const SIZE: usize = 4 + 32 + 32 + 4 + 4 + 4; // 80
+
+    /// Returns the block hash.
+    pub fn block_hash(&self) -> BlockHash {
+        let mut engine = BlockHash::engine();
+        self.consensus_encode(&mut engine)
+            .expect("engines don't error");
+        BlockHash::from_engine(engine)
+    }
+
+    /// Computes the target (range [0, T] inclusive) that a blockhash must land in to be valid.
+    pub fn target(&self) -> Target {
+        self.bits.into()
+    }
+
+    /// Computes the popular "difficulty" measure for mining.
+    ///
+    /// Difficulty represents how difficult the current target makes it to find a block, relative to
+    /// how difficult it would be at the highest possible target (highest target == lowest difficulty).
+    pub fn difficulty(&self, params: impl AsRef<Params>) -> u128 {
+        self.target().difficulty(params)
+    }
+
+    /// Computes the popular "difficulty" measure for mining and returns a float value of f64.
+    pub fn difficulty_float(&self) -> f64 {
+        self.target().difficulty_float()
+    }
+
+    /// Checks that the proof-of-work for the block is valid, returning the block hash.
+    pub fn validate_pow(&self, required_target: Target) -> Result<BlockHash, ValidationError> {
+        let target = self.target();
+        if target != required_target {
+            return Err(ValidationError::BadTarget);
+        }
+        let block_hash = self.block_hash();
+        if target.is_met_by(block_hash) {
+            Ok(block_hash)
+        } else {
+            Err(ValidationError::BadProofOfWork)
+        }
+    }
+
+    /// Returns the total work of the block.
+    pub fn work(&self) -> Work {
+        self.target().to_work()
+    }
+}
+
+impl fmt::Debug for Header {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Header")
+            .field("block_hash", &self.block_hash())
+            .field("version", &self.version)
+            .field("prev_blockhash", &self.prev_blockhash)
+            .field("merkle_root", &self.merkle_root)
+            .field("time", &self.time)
+            .field("bits", &self.bits)
+            .field("nonce", &self.nonce)
+            .finish()
+    }
+}
+
+/// Bitcoin block version number.
+///
+/// Originally used as a protocol version, but repurposed for soft-fork signaling.
+///
+/// The inner value is a signed integer in Bitcoin Core for historical reasons, if version bits is
+/// being used the top three bits must be 001, this gives us a useful range of [0x20000000...0x3FFFFFFF].
+///
+/// > When a block nVersion does not have top bits 001, it is treated as if all bits are 0 for the purposes of deployments.
+///
+/// ### Relevant BIPs
+///
+/// * [BIP9 - Version bits with timeout and delay](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) (current usage)
+/// * [BIP34 - Block v2, Height in Coinbase](https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki)
+#[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Version(i32);
+
+impl Version {
+    /// The original Bitcoin Block v1.
+    pub const ONE: Self = Self(1);
+
+    /// BIP-34 Block v2.
+    pub const TWO: Self = Self(2);
+
+    /// BIP-9 compatible version number that does not signal for any softforks.
+    pub const NO_SOFT_FORK_SIGNALLING: Self = Self(Self::USE_VERSION_BITS as i32);
+
+    /// BIP-9 soft fork signal bits mask.
+    const VERSION_BITS_MASK: u32 = 0x1FFF_FFFF;
+
+    /// 32bit value starting with `001` to use version bits.
+    ///
+    /// The value has the top three bits `001` which enables the use of version bits to signal for soft forks.
+    const USE_VERSION_BITS: u32 = 0x2000_0000;
+
+    /// Creates a [`Version`] from a signed 32 bit integer value.
+    ///
+    /// This is the data type used in consensus code in Bitcoin Core.
+    #[inline]
+    pub const fn from_consensus(v: i32) -> Self {
+        Version(v)
+    }
+
+    /// Returns the inner `i32` value.
+    ///
+    /// This is the data type used in consensus code in Bitcoin Core.
+    pub fn to_consensus(self) -> i32 {
+        self.0
+    }
+
+    /// Checks whether the version number is signalling a soft fork at the given bit.
+    ///
+    /// A block is signalling for a soft fork under BIP-9 if the first 3 bits are `001` and
+    /// the version bit for the specific soft fork is toggled on.
+    pub fn is_signalling_soft_fork(&self, bit: u8) -> bool {
+        // Only bits [0, 28] inclusive are used for signalling.
+        if bit > 28 {
+            return false;
+        }
+
+        // To signal using version bits, the first three bits must be `001`.
+        if (self.0 as u32) & !Self::VERSION_BITS_MASK != Self::USE_VERSION_BITS {
+            return false;
+        }
+
+        // The bit is set if signalling a soft fork.
+        (self.0 as u32 & Self::VERSION_BITS_MASK) & (1 << bit) > 0
+    }
+}
+
+impl Default for Version {
+    fn default() -> Version {
+        Self::NO_SOFT_FORK_SIGNALLING
+    }
+}
+
+impl Encodable for Version {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for Version {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Decodable::consensus_decode(r).map(Version)
+    }
+}
+
+/// Bitcoin block.
+///
+/// A collection of transactions with an attached proof of work.
+///
+/// See [Bitcoin Wiki: Block][wiki-block] for more information.
+///
+/// [wiki-block]: https://en.bitcoin.it/wiki/Block
+///
+/// ### Bitcoin Core References
+///
+/// * [CBlock definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/block.h#L62)
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Block {
+    /// The block header
+    pub header: Header,
+    /// List of transactions contained in the block
+    pub txdata: Vec<Transaction>,
+}
+
+impl_consensus_encoding!(Block, header, txdata);
+
+impl Block {
+    /// Returns the block hash.
+    pub fn block_hash(&self) -> BlockHash {
+        self.header.block_hash()
+    }
+
+    /// Checks if merkle root of header matches merkle root of the transaction list.
+    pub fn check_merkle_root(&self) -> bool {
+        match self.compute_merkle_root() {
+            Some(merkle_root) => self.header.merkle_root == merkle_root,
+            None => false,
+        }
+    }
+
+    /// Checks if witness commitment in coinbase matches the transaction list.
+    pub fn check_witness_commitment(&self) -> bool {
+        const MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+        // Witness commitment is optional if there are no transactions using SegWit in the block.
+        if self
+            .txdata
+            .iter()
+            .all(|t| t.input.iter().all(|i| i.witness.is_empty()))
+        {
+            return true;
+        }
+
+        if self.txdata.is_empty() {
+            return false;
+        }
+
+        let coinbase = &self.txdata[0];
+        if !coinbase.is_coinbase() {
+            return false;
+        }
+
+        // Commitment is in the last output that starts with magic bytes.
+        if let Some(pos) = coinbase
+            .output
+            .iter()
+            .rposition(|o| o.script_pubkey.len() >= 38 && o.script_pubkey.as_bytes()[0..6] == MAGIC)
+        {
+            let commitment = WitnessCommitment::from_slice(
+                &coinbase.output[pos].script_pubkey.as_bytes()[6..38],
+            )
+            .unwrap();
+            // Witness reserved value is in coinbase input witness.
+            let witness_vec: Vec<_> = coinbase.input[0].witness.iter().collect();
+            if witness_vec.len() == 1 && witness_vec[0].len() == 32 {
+                if let Some(witness_root) = self.witness_root() {
+                    return commitment
+                        == Self::compute_witness_commitment(&witness_root, witness_vec[0]);
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Computes the transaction merkle root.
+    pub fn compute_merkle_root(&self) -> Option<TxMerkleNode> {
+        let hashes = self
+            .txdata
+            .iter()
+            .map(|obj| obj.compute_txid().to_raw_hash());
+        merkle_tree::calculate_root(hashes).map(|h| h.into())
+    }
+
+    /// Computes the witness commitment for the block's transaction list.
+    pub fn compute_witness_commitment(
+        witness_root: &WitnessMerkleNode,
+        witness_reserved_value: &[u8],
+    ) -> WitnessCommitment {
+        let mut encoder = WitnessCommitment::engine();
+        witness_root
+            .consensus_encode(&mut encoder)
+            .expect("engines don't error");
+        encoder.input(witness_reserved_value);
+        WitnessCommitment::from_engine(encoder)
+    }
+
+    /// Computes the merkle root of transactions hashed for witness.
+    pub fn witness_root(&self) -> Option<WitnessMerkleNode> {
+        let hashes = self.txdata.iter().enumerate().map(|(i, t)| {
+            if i == 0 {
+                // Replace the first hash with zeroes.
+                Wtxid::all_zeros().to_raw_hash()
+            } else {
+                t.compute_wtxid().to_raw_hash()
+            }
+        });
+        merkle_tree::calculate_root(hashes).map(|h| h.into())
+    }
+
+    /// Returns the weight of the block.
+    ///
+    /// > Block weight is defined as Base size * 3 + Total size.
+    pub fn weight(&self) -> Weight {
+        // This is the exact definition of a weight unit, as defined by BIP-141 (quote above).
+        let wu = self.base_size() * 3 + self.total_size();
+        Weight::from_wu_usize(wu)
+    }
+
+    /// Returns the base block size.
+    ///
+    /// > Base size is the block size in bytes with the original transaction serialization without
+    /// > any witness-related data, as seen by a non-upgraded node.
+    fn base_size(&self) -> usize {
+        let mut size = Header::SIZE;
+
+        size += VarInt::from(self.txdata.len()).size();
+        size += self.txdata.iter().map(|tx| tx.base_size()).sum::<usize>();
+
+        size
+    }
+
+    /// Returns the total block size.
+    ///
+    /// > Total size is the block size in bytes with transactions serialized as described in BIP144,
+    /// > including base data and witness data.
+    pub fn total_size(&self) -> usize {
+        let mut size = Header::SIZE;
+
+        size += VarInt::from(self.txdata.len()).size();
+        size += self.txdata.iter().map(|tx| tx.total_size()).sum::<usize>();
+
+        size
+    }
+
+    /// Returns the coinbase transaction, if one is present.
+    pub fn coinbase(&self) -> Option<&Transaction> {
+        self.txdata.first()
+    }
+
+    /// Returns the block height, as encoded in the coinbase transaction according to BIP34.
+    pub fn bip34_block_height(&self) -> Result<u64, Bip34Error> {
+        // Citing the spec:
+        // Add height as the first item in the coinbase transaction's scriptSig,
+        // and increase block version to 2. The format of the height is
+        // "minimally encoded serialized CScript"" -- first byte is number of bytes in the number
+        // (will be 0x03 on main net for the next 150 or so years with 2^23-1
+        // blocks), following bytes are little-endian representation of the
+        // number (including a sign bit). Height is the height of the mined
+        // block in the block chain, where the genesis block is height zero (0).
+
+        if self.header.version < Version::TWO {
+            return Err(Bip34Error::Unsupported);
+        }
+
+        let cb = self.coinbase().ok_or(Bip34Error::NotPresent)?;
+        let input = cb.input.first().ok_or(Bip34Error::NotPresent)?;
+        let push = input
+            .script_sig
+            .instructions_minimal()
+            .next()
+            .ok_or(Bip34Error::NotPresent)?;
+        match push.map_err(|_| Bip34Error::NotPresent)? {
+            script::Instruction::PushBytes(b) => {
+                // Check that the number is encoded in the minimal way.
+                let h = script::read_scriptint(b.as_bytes())
+                    .map_err(|_e| Bip34Error::UnexpectedPush(b.as_bytes().to_vec()))?;
+                if h < 0 {
+                    Err(Bip34Error::NegativeHeight)
+                } else {
+                    Ok(h as u64)
+                }
+            }
+            _ => Err(Bip34Error::NotPresent),
+        }
+    }
+}
+
+impl From<Header> for BlockHash {
+    fn from(header: Header) -> BlockHash {
+        header.block_hash()
+    }
+}
+
+impl From<&Header> for BlockHash {
+    fn from(header: &Header) -> BlockHash {
+        header.block_hash()
+    }
+}
+
+impl From<Block> for BlockHash {
+    fn from(block: Block) -> BlockHash {
+        block.block_hash()
+    }
+}
+
+impl From<&Block> for BlockHash {
+    fn from(block: &Block) -> BlockHash {
+        block.block_hash()
+    }
+}
+
+/// An error when looking up a BIP34 block height.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Bip34Error {
+    /// The block does not support BIP34 yet.
+    Unsupported,
+    /// No push was present where the BIP34 push was expected.
+    NotPresent,
+    /// The BIP34 push was larger than 8 bytes.
+    UnexpectedPush(Vec<u8>),
+    /// The BIP34 push was negative.
+    NegativeHeight,
+}
+
+internals::impl_from_infallible!(Bip34Error);
+
+impl fmt::Display for Bip34Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Bip34Error::*;
+
+        match *self {
+            Unsupported => write!(f, "block doesn't support BIP34"),
+            NotPresent => write!(f, "BIP34 push not present in block's coinbase"),
+            UnexpectedPush(ref p) => {
+                write!(f, "unexpected byte push of > 8 bytes: {:?}", p)
+            }
+            NegativeHeight => write!(f, "negative BIP34 height"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Bip34Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Bip34Error::*;
+
+        match *self {
+            Unsupported | NotPresent | UnexpectedPush(_) | NegativeHeight => None,
+        }
+    }
+}
+
+/// A block validation error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ValidationError {
+    /// The header hash is not below the target.
+    BadProofOfWork,
+    /// The `target` field of a block header did not match the expected difficulty.
+    BadTarget,
+}
+
+internals::impl_from_infallible!(ValidationError);
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ValidationError::*;
+
+        match *self {
+            BadProofOfWork => f.write_str("block target correct but not attained"),
+            BadTarget => f.write_str("block target incorrect"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ValidationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::ValidationError::*;
+
+        match *self {
+            BadProofOfWork | BadTarget => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex::{test_hex_unwrap as hex, FromHex};
+
+    use super::*;
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::Network;
+
+    #[test]
+    fn test_coinbase_and_bip34() {
+        // testnet block 100,000
+        const BLOCK_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
+        let block: Block = deserialize(&hex!(BLOCK_HEX)).unwrap();
+
+        let cb_txid = "d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38";
+        assert_eq!(
+            block.coinbase().unwrap().compute_txid().to_string(),
+            cb_txid
+        );
+
+        assert_eq!(block.bip34_block_height(), Ok(100_000));
+
+        // block with 9-byte bip34 push
+        const BAD_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3d09a08601112233445566000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
+        let bad: Block = deserialize(&hex!(BAD_HEX)).unwrap();
+
+        let push = Vec::<u8>::from_hex("a08601112233445566").unwrap();
+        assert_eq!(
+            bad.bip34_block_height(),
+            Err(super::Bip34Error::UnexpectedPush(push))
+        );
+    }
+
+    #[test]
+    fn block_test() {
+        let params = Params::new(Network::Bitcoin);
+        // Mainnet block 00000000b0c5a240b2a61d2e75692224efd4cbecdf6eaf4cc2cf477ca7c270e7
+        let some_block = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000");
+        let cutoff_block = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac");
+
+        let prevhash = hex!("4ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000");
+        let merkle = hex!("bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914c");
+        let work = Work::from(0x100010001_u128);
+
+        let decode: Result<Block, _> = deserialize(&some_block);
+        let bad_decode: Result<Block, _> = deserialize(&cutoff_block);
+
+        assert!(decode.is_ok());
+        assert!(bad_decode.is_err());
+        let real_decode = decode.unwrap();
+        assert_eq!(real_decode.header.version, Version(1));
+        assert_eq!(serialize(&real_decode.header.prev_blockhash), prevhash);
+        assert_eq!(
+            real_decode.header.merkle_root,
+            real_decode.compute_merkle_root().unwrap()
+        );
+        assert_eq!(serialize(&real_decode.header.merkle_root), merkle);
+        assert_eq!(real_decode.header.time, 1231965655);
+        assert_eq!(
+            real_decode.header.bits,
+            CompactTarget::from_consensus(486604799)
+        );
+        assert_eq!(real_decode.header.nonce, 2067413810);
+        assert_eq!(real_decode.header.work(), work);
+        assert_eq!(
+            real_decode
+                .header
+                .validate_pow(real_decode.header.target())
+                .unwrap(),
+            real_decode.block_hash()
+        );
+        assert_eq!(real_decode.header.difficulty(&params), 1);
+        assert_eq!(real_decode.header.difficulty_float(), 1.0);
+
+        assert_eq!(real_decode.total_size(), some_block.len());
+        assert_eq!(real_decode.base_size(), some_block.len());
+        assert_eq!(
+            real_decode.weight(),
+            Weight::from_non_witness_data_size(some_block.len() as u64)
+        );
+
+        // should be also ok for a non-witness block as commitment is optional in that case
+        assert!(real_decode.check_witness_commitment());
+
+        assert_eq!(serialize(&real_decode), some_block);
+    }
+
+    // // Check testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
+    // #[test]
+    // fn segwit_block_test() {
+    //     let params = Params::new(Network::Testnet);
+    //     let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
+
+    //     let decode: Result<Block, _> = deserialize(&segwit_block);
+
+    //     let prevhash = hex!("2aa2f2ca794ccbd40c16e2f3333f6b8b683f9e7179b2c4d74906000000000000");
+    //     let merkle = hex!("10bc26e70a2f672ad420a6153dd0c28b40a6002c55531bfc99bf8994a8e8f67e");
+    //     let work = Work::from(0x257c3becdacc64_u64);
+
+    //     assert!(decode.is_ok());
+    //     let real_decode = decode.unwrap();
+    //     assert_eq!(real_decode.header.version, Version(Version::USE_VERSION_BITS as i32)); // VERSIONBITS but no bits set
+    //     assert_eq!(serialize(&real_decode.header.prev_blockhash), prevhash);
+    //     assert_eq!(serialize(&real_decode.header.merkle_root), merkle);
+    //     assert_eq!(real_decode.header.merkle_root, real_decode.compute_merkle_root().unwrap());
+    //     assert_eq!(real_decode.header.time, 1472004949);
+    //     assert_eq!(real_decode.header.bits, CompactTarget::from_consensus(0x1a06d450));
+    //     assert_eq!(real_decode.header.nonce, 1879759182);
+    //     assert_eq!(real_decode.header.work(), work);
+    //     assert_eq!(
+    //         real_decode.header.validate_pow(real_decode.header.target()).unwrap(),
+    //         real_decode.block_hash()
+    //     );
+    //     assert_eq!(real_decode.header.difficulty(&params), 2456598);
+    //     assert_eq!(real_decode.header.difficulty_float(), 2456598.4399242126);
+
+    //     assert_eq!(real_decode.total_size(), segwit_block.len());
+    //     assert_eq!(real_decode.base_size(), 4283);
+    //     assert_eq!(real_decode.weight(), Weight::from_wu(17168));
+
+    //     assert!(real_decode.check_witness_commitment());
+
+    //     assert_eq!(serialize(&real_decode), segwit_block);
+    // }
+
+    #[test]
+    fn block_version_test() {
+        let block = hex!("ffffff7f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let decode: Result<Block, _> = deserialize(&block);
+        assert!(decode.is_ok());
+        let real_decode = decode.unwrap();
+        assert_eq!(real_decode.header.version, Version(2147483647));
+
+        let block2 = hex!("000000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let decode2: Result<Block, _> = deserialize(&block2);
+        assert!(decode2.is_ok());
+        let real_decode2 = decode2.unwrap();
+        assert_eq!(real_decode2.header.version, Version(-2147483648));
+    }
+
+    #[test]
+    fn validate_pow_test() {
+        let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
+        let some_header: Header =
+            deserialize(&some_header).expect("Can't deserialize correct block header");
+        assert_eq!(
+            some_header.validate_pow(some_header.target()).unwrap(),
+            some_header.block_hash()
+        );
+
+        // test with zero target
+        match some_header.validate_pow(Target::ZERO) {
+            Err(ValidationError::BadTarget) => (),
+            _ => panic!("unexpected result from validate_pow"),
+        }
+
+        // test with modified header
+        let mut invalid_header: Header = some_header;
+        invalid_header.version.0 += 1;
+        match invalid_header.validate_pow(invalid_header.target()) {
+            Err(ValidationError::BadProofOfWork) => (),
+            _ => panic!("unexpected result from validate_pow"),
+        }
+    }
+
+    #[test]
+    fn compact_roundrtip_test() {
+        let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
+
+        let header: Header =
+            deserialize(&some_header).expect("Can't deserialize correct block header");
+
+        assert_eq!(header.bits, header.target().to_compact_lossy());
+    }
+
+    #[test]
+    fn soft_fork_signalling() {
+        for i in 0..31 {
+            let version_int = (0x20000000u32 ^ 1 << i) as i32;
+            let version = Version(version_int);
+            if i < 29 {
+                assert!(version.is_signalling_soft_fork(i));
+            } else {
+                assert!(!version.is_signalling_soft_fork(i));
+            }
+        }
+
+        let segwit_signal = Version(0x20000000 ^ 1 << 1);
+        assert!(!segwit_signal.is_signalling_soft_fork(0));
+        assert!(segwit_signal.is_signalling_soft_fork(1));
+        assert!(!segwit_signal.is_signalling_soft_fork(2));
+    }
+}
+
+#[cfg(bench)]
+mod benches {
+    use io::sink;
+    use test::{black_box, Bencher};
+
+    use super::Block;
+    use crate::consensus::{deserialize, Decodable, Encodable};
+
+    #[bench]
+    pub fn bench_stream_reader(bh: &mut Bencher) {
+        let big_block = include_bytes!("../../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
+        assert_eq!(big_block.len(), 1_381_836);
+        let big_block = black_box(big_block);
+
+        bh.iter(|| {
+            let mut reader = &big_block[..];
+            let block = Block::consensus_decode(&mut reader).unwrap();
+            black_box(&block);
+        });
+    }
+
+    #[bench]
+    pub fn bench_block_serialize(bh: &mut Bencher) {
+        let raw_block = include_bytes!("../../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
+
+        let block: Block = deserialize(&raw_block[..]).unwrap();
+
+        let mut data = Vec::with_capacity(raw_block.len());
+
+        bh.iter(|| {
+            let result = block.consensus_encode(&mut data);
+            black_box(&result);
+            data.clear();
+        });
+    }
+
+    #[bench]
+    pub fn bench_block_serialize_logic(bh: &mut Bencher) {
+        let raw_block = include_bytes!("../../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
+
+        let block: Block = deserialize(&raw_block[..]).unwrap();
+
+        bh.iter(|| {
+            let size = block.consensus_encode(&mut sink());
+            black_box(&size);
+        });
+    }
+
+    #[bench]
+    pub fn bench_block_deserialize(bh: &mut Bencher) {
+        let raw_block = include_bytes!("../../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
+
+        bh.iter(|| {
+            let block: Block = deserialize(&raw_block[..]).unwrap();
+            black_box(&block);
+        });
+    }
+}

--- a/libs/bitcoin/src/blockdata/constants.rs
+++ b/libs/bitcoin/src/blockdata/constants.rs
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Blockdata constants.
+//!
+//! This module provides various constants relating to the blockchain and
+//! consensus code. In particular, it defines the genesis block and its
+//! single transaction.
+//!
+
+use hashes::{sha256d, Hash};
+use internals::impl_array_newtype;
+
+use crate::blockdata::block::{self, Block};
+use crate::blockdata::locktime::absolute;
+use crate::blockdata::opcodes::all::*;
+use crate::blockdata::script;
+use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
+use crate::blockdata::witness::Witness;
+use crate::consensus::Params;
+use crate::internal_macros::impl_bytes_newtype;
+use crate::network::Network;
+use crate::pow::CompactTarget;
+use crate::Amount;
+
+/// How many seconds between blocks we expect on average.
+pub const TARGET_BLOCK_SPACING: u32 = 600;
+/// How many blocks between diffchanges.
+pub const DIFFCHANGE_INTERVAL: u32 = 2016;
+/// How much time on average should occur between diffchanges.
+pub const DIFFCHANGE_TIMESPAN: u32 = 14 * 24 * 3600;
+
+/// The factor that non-witness serialization data is multiplied by during weight calculation.
+pub const WITNESS_SCALE_FACTOR: usize = units::weight::WITNESS_SCALE_FACTOR;
+/// The maximum allowed number of signature check operations in a block.
+pub const MAX_BLOCK_SIGOPS_COST: i64 = 80_000;
+/// Mainnet (bitcoin) pubkey address prefix.
+pub const PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0; // 0x00
+/// Mainnet (bitcoin) script address prefix.
+pub const SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5; // 0x05
+/// Test (tesnet, signet, regtest) pubkey address prefix.
+pub const PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111; // 0x6f
+/// Test (tesnet, signet, regtest) script address prefix.
+pub const SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196; // 0xc4
+/// The maximum allowed script size.
+pub const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
+/// How may blocks between halvings.
+pub const SUBSIDY_HALVING_INTERVAL: u32 = 210_000;
+/// Maximum allowed value for an integer in Script.
+pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
+/// Number of blocks needed for an output from a coinbase transaction to be spendable.
+pub const COINBASE_MATURITY: u32 = 100;
+
+// This is the 65 byte (uncompressed) pubkey used as the one-and-only output of the genesis transaction.
+//
+// ref: https://blockstream.info/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b?expand
+// Note output script includes a leading 0x41 and trailing 0xac (added below using the `script::Builder`).
+#[rustfmt::skip]
+const GENESIS_OUTPUT_PK: [u8; 65] = [
+    0x04,
+    0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, 0x48, 0x27,
+    0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, 0xb7, 0x10,
+    0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, 0x09, 0xa6,
+    0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, 0xde, 0xb6,
+    0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, 0x38, 0xc4,
+    0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, 0x12, 0xde,
+    0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, 0x8d, 0x57,
+    0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, 0x1d, 0x5f
+];
+
+#[rustfmt::skip]
+const TESTNET4_GENESIS_OUTPUT_PK: [u8; 33] = [0x00; 33];
+
+/// Constructs and returns the coinbase (and only) transaction of the Bitcoin genesis block.
+fn bitcoin_genesis_tx(params: &Params) -> Transaction {
+    // Base
+    let mut ret = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![],
+    };
+
+    let (in_script, out_script) = {
+        match params.network {
+            Network::Testnet4 => (
+                script::Builder::new()
+                .push_int(486604799)
+                .push_int_non_minimal(4)
+                .push_slice(b"03/May/2024 000000000000000000001ebd58c244970b3aa9d783bb001011fbe8ea8e98e00e")
+                .into_script(),
+                script::Builder::new().push_slice(TESTNET4_GENESIS_OUTPUT_PK).push_opcode(OP_CHECKSIG).into_script(),
+
+            ),
+            _ => (
+                script::Builder::new()
+                .push_int(486604799)
+                .push_int_non_minimal(4)
+                .push_slice(b"The Times 03/Jan/2009 Chancellor on brink of second bailout for banks")
+                .into_script(),
+                script::Builder::new().push_slice(GENESIS_OUTPUT_PK).push_opcode(OP_CHECKSIG).into_script(),
+            ),
+        }
+    };
+
+    ret.input.push(TxIn {
+        previous_output: OutPoint::null(),
+        script_sig: in_script,
+        sequence: Sequence::MAX,
+        witness: Witness::default(),
+    });
+    ret.output.push(TxOut { value: Amount::from_sat(50 * 100_000_000), script_pubkey: out_script });
+
+    // end
+    ret
+}
+
+/// Constructs and returns the genesis block.
+pub fn genesis_block(params: impl AsRef<Params>) -> Block {
+    let params = params.as_ref();
+    let txdata = vec![bitcoin_genesis_tx(params)];
+    let hash: sha256d::Hash = txdata[0].compute_txid().into();
+    let merkle_root: crate::TxMerkleNode = hash.into();
+
+    match params.network {
+        Network::Bitcoin => Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: Hash::all_zeros(),
+                merkle_root,
+                time: 1231006505,
+                bits: CompactTarget::from_consensus(0x1d00ffff),
+                nonce: 2083236893,
+            },
+            txdata,
+        },
+        Network::Testnet => Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: Hash::all_zeros(),
+                merkle_root,
+                time: 1296688602,
+                bits: CompactTarget::from_consensus(0x1d00ffff),
+                nonce: 414098458,
+            },
+            txdata,
+        },
+        Network::Testnet4 => Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: Hash::all_zeros(),
+                merkle_root,
+                time: 1714777860,
+                bits: CompactTarget::from_consensus(0x1d00ffff),
+                nonce: 393743547,
+            },
+            txdata,
+        },
+        Network::Signet => Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: Hash::all_zeros(),
+                merkle_root,
+                time: 1598918400,
+                bits: CompactTarget::from_consensus(0x1e0377ae),
+                nonce: 52613770,
+            },
+            txdata,
+        },
+        Network::Regtest => Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: Hash::all_zeros(),
+                merkle_root,
+                time: 1296688602,
+                bits: CompactTarget::from_consensus(0x207fffff),
+                nonce: 2,
+            },
+            txdata,
+        },
+    }
+}
+
+/// The uniquely identifying hash of the target blockchain.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ChainHash([u8; 32]);
+impl_array_newtype!(ChainHash, u8, 32);
+impl_bytes_newtype!(ChainHash, 32);
+
+impl ChainHash {
+    // Mainnet value can be verified at https://github.com/lightning/bolts/blob/master/00-introduction.md
+    /// `ChainHash` for mainnet bitcoin.
+    pub const BITCOIN: Self = Self([
+        111, 226, 140, 10, 182, 241, 179, 114, 193, 166, 162, 70, 174, 99, 247, 79, 147, 30, 131,
+        101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0,
+    ]);
+    /// `ChainHash` for testnet3 bitcoin.
+    #[deprecated(since = "0.32.4", note = "Use TESTNET3 instead")]
+    pub const TESTNET: Self = Self([
+        67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
+        32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,
+    ]);
+    /// `ChainHash` for testnet3 bitcoin.
+    pub const TESTNET3: Self = Self([
+        67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
+        32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,
+    ]);
+    /// `ChainHash` for testnet4 bitcoin.
+    pub const TESTNET4: Self = Self([
+        67, 240, 139, 218, 176, 80, 227, 91, 86, 124, 134, 75, 145, 244, 127, 80, 174, 114, 90,
+        226, 222, 83, 188, 251, 186, 242, 132, 218, 0, 0, 0, 0,
+    ]);
+    /// `ChainHash` for signet bitcoin.
+    pub const SIGNET: Self = Self([
+        246, 30, 238, 59, 99, 163, 128, 164, 119, 160, 99, 175, 50, 178, 187, 201, 124, 159, 249,
+        240, 31, 44, 66, 37, 233, 115, 152, 129, 8, 0, 0, 0,
+    ]);
+    /// `ChainHash` for regtest bitcoin.
+    pub const REGTEST: Self = Self([
+        6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94,
+        51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15,
+    ]);
+
+    /// Returns the hash of the `network` genesis block for use as a chain hash.
+    ///
+    /// See [BOLT 0](https://github.com/lightning/bolts/blob/ffeece3dab1c52efdb9b53ae476539320fa44938/00-introduction.md#chain_hash)
+    /// for specification.
+    pub fn using_genesis_block(params: impl AsRef<Params>) -> Self {
+        match params.as_ref().network {
+            Network::Bitcoin => Self::BITCOIN,
+            Network::Testnet => Self::TESTNET3,
+            Network::Testnet4 => Self::TESTNET4,
+            Network::Signet => Self::SIGNET,
+            Network::Regtest => Self::REGTEST,
+        }
+    }
+
+    /// Returns the hash of the `network` genesis block for use as a chain hash.
+    ///
+    /// See [BOLT 0](https://github.com/lightning/bolts/blob/ffeece3dab1c52efdb9b53ae476539320fa44938/00-introduction.md#chain_hash)
+    /// for specification.
+    pub const fn using_genesis_block_const(network: Network) -> Self {
+        match network {
+            Network::Bitcoin => Self::BITCOIN,
+            Network::Testnet => Self::TESTNET3,
+            Network::Testnet4 => Self::TESTNET4,
+            Network::Signet => Self::SIGNET,
+            Network::Regtest => Self::REGTEST,
+        }
+    }
+
+    /// Converts genesis block hash into `ChainHash`.
+    pub fn from_genesis_block_hash(block_hash: crate::BlockHash) -> Self {
+        ChainHash(block_hash.to_byte_array())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::str::FromStr;
+
+    use hex::test_hex_unwrap as hex;
+
+    use super::*;
+    use crate::consensus::params;
+    use crate::consensus::encode::serialize;
+
+    #[test]
+    fn bitcoin_genesis_first_transaction() {
+        let gen = bitcoin_genesis_tx(&Params::MAINNET);
+
+        assert_eq!(gen.version, transaction::Version::ONE);
+        assert_eq!(gen.input.len(), 1);
+        assert_eq!(gen.input[0].previous_output.txid, Hash::all_zeros());
+        assert_eq!(gen.input[0].previous_output.vout, 0xFFFFFFFF);
+        assert_eq!(serialize(&gen.input[0].script_sig),
+                   hex!("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
+
+        assert_eq!(gen.input[0].sequence, Sequence::MAX);
+        assert_eq!(gen.output.len(), 1);
+        assert_eq!(serialize(&gen.output[0].script_pubkey),
+                   hex!("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"));
+        assert_eq!(gen.output[0].value, Amount::from_str("50 BTC").unwrap());
+        assert_eq!(gen.lock_time, absolute::LockTime::ZERO);
+
+        assert_eq!(
+            gen.compute_wtxid().to_string(),
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+        );
+    }
+
+    #[test]
+    fn bitcoin_genesis_block_calling_convention() {
+        // This is the best.
+        let _ = genesis_block(&params::MAINNET);
+        // this works and is ok too.
+        let _ = genesis_block(&Network::Bitcoin);
+        let _ = genesis_block(Network::Bitcoin);
+        // This works too, but is suboptimal because it inlines the const.
+        let _ = genesis_block(Params::MAINNET);
+        let _ = genesis_block(&Params::MAINNET);
+    }
+
+    #[test]
+    fn bitcoin_genesis_full_block() {
+        let gen = genesis_block(&params::MAINNET);
+
+        assert_eq!(gen.header.version, block::Version::ONE);
+        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(
+            gen.header.merkle_root.to_string(),
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+        );
+
+        assert_eq!(gen.header.time, 1231006505);
+        assert_eq!(gen.header.bits, CompactTarget::from_consensus(0x1d00ffff));
+        assert_eq!(gen.header.nonce, 2083236893);
+        assert_eq!(
+            gen.header.block_hash().to_string(),
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        );
+    }
+
+    #[test]
+    fn testnet_genesis_full_block() {
+        let gen = genesis_block(&params::TESTNET3);
+        assert_eq!(gen.header.version, block::Version::ONE);
+        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(
+            gen.header.merkle_root.to_string(),
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+        );
+        assert_eq!(gen.header.time, 1296688602);
+        assert_eq!(gen.header.bits, CompactTarget::from_consensus(0x1d00ffff));
+        assert_eq!(gen.header.nonce, 414098458);
+        assert_eq!(
+            gen.header.block_hash().to_string(),
+            "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
+        );
+    }
+
+    #[test]
+    fn signet_genesis_full_block() {
+        let gen = genesis_block(&params::SIGNET);
+        assert_eq!(gen.header.version, block::Version::ONE);
+        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(
+            gen.header.merkle_root.to_string(),
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+        );
+        assert_eq!(gen.header.time, 1598918400);
+        assert_eq!(gen.header.bits, CompactTarget::from_consensus(0x1e0377ae));
+        assert_eq!(gen.header.nonce, 52613770);
+        assert_eq!(
+            gen.header.block_hash().to_string(),
+            "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"
+        );
+    }
+
+    // The *_chain_hash tests are sanity/regression tests, they verify that the const byte array
+    // representing the genesis block is the same as that created by hashing the genesis block.
+    fn chain_hash_and_genesis_block(network: Network) {
+        use hashes::sha256;
+
+        // The genesis block hash is a double-sha256 and it is displayed backwards.
+        let genesis_hash = genesis_block(network).block_hash();
+        // We abuse the sha256 hash here so we get a LowerHex impl that does not print the hex backwards.
+        let hash = sha256::Hash::from_slice(genesis_hash.as_byte_array()).unwrap();
+        let want = format!("{:02x}", hash);
+
+        let chain_hash = ChainHash::using_genesis_block_const(network);
+        let got = format!("{:02x}", chain_hash);
+
+        // Compare strings because the spec specifically states how the chain hash must encode to hex.
+        assert_eq!(got, want);
+
+        #[allow(unreachable_patterns)] // This is specifically trying to catch later added variants.
+        match network {
+            Network::Bitcoin => {},
+            Network::Testnet => {},
+            Network::Testnet4 => {},
+            Network::Signet => {},
+            Network::Regtest => {},
+            _ => panic!("Update ChainHash::using_genesis_block and chain_hash_genesis_block with new variants"),
+        }
+    }
+
+    macro_rules! chain_hash_genesis_block {
+        ($($test_name:ident, $network:expr);* $(;)*) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    chain_hash_and_genesis_block($network);
+                }
+            )*
+        }
+    }
+
+    chain_hash_genesis_block! {
+        mainnet_chain_hash_genesis_block, Network::Bitcoin;
+        testnet_chain_hash_genesis_block, Network::Testnet;
+        testnet4_chain_hash_genesis_block, Network::Testnet4;
+        signet_chain_hash_genesis_block, Network::Signet;
+        regtest_chain_hash_genesis_block, Network::Regtest;
+    }
+
+    // Test vector taken from: https://github.com/lightning/bolts/blob/master/00-introduction.md
+    #[test]
+    fn mainnet_chain_hash_test_vector() {
+        let got = ChainHash::using_genesis_block_const(Network::Bitcoin).to_string();
+        let want = "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000";
+        assert_eq!(got, want);
+    }
+}

--- a/libs/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/libs/bitcoin/src/blockdata/locktime/absolute.rs
@@ -1,0 +1,571 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Provides type [`LockTime`] that implements the logic around nLockTime/OP_CHECKLOCKTIMEVERIFY.
+//!
+//! There are two types of lock time: lock-by-blockheight and lock-by-blocktime, distinguished by
+//! whether `LockTime < LOCKTIME_THRESHOLD`.
+//!
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::str::FromStr;
+
+use io::{Read, Write};
+#[cfg(all(test, mutate))]
+use mutagen::mutate;
+use units::parse::{self, ParseIntError};
+
+#[cfg(doc)]
+use crate::absolute;
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::error::{ContainsPrefixError, MissingPrefixError, PrefixedHexError, UnprefixedHexError};
+use crate::prelude::{Box, String};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use units::locktime::absolute::{
+    Height, Time, LOCK_TIME_THRESHOLD, ConversionError, ParseHeightError, ParseTimeError,
+};
+
+/// An absolute lock time value, representing either a block height or a UNIX timestamp (seconds
+/// since epoch).
+///
+/// Used for transaction lock time (`nLockTime` in Bitcoin Core and [`crate::Transaction::lock_time`]
+/// in this library) and also for the argument to opcode 'OP_CHECKLOCKTIMEVERIFY`.
+///
+/// ### Note on ordering
+///
+/// Locktimes may be height- or time-based, and these metrics are incommensurate; there is no total
+/// ordering on locktimes. We therefore have implemented [`PartialOrd`] but not [`Ord`].
+/// For [`crate::Transaction`], which has a locktime field, we implement a total ordering to make
+/// it easy to store transactions in sorted data structures, and use the locktime's 32-bit integer
+/// consensus encoding to order it. We also implement [`ordered::ArbitraryOrd`] if the "ordered"
+/// feature is enabled.
+///
+/// ### Relevant BIPs
+///
+/// * [BIP-65 OP_CHECKLOCKTIMEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+/// * [BIP-113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
+///
+/// # Examples
+/// ```
+/// # use bitcoin::absolute::{LockTime, LockTime::*};
+/// # let n = LockTime::from_consensus(741521);          // n OP_CHECKLOCKTIMEVERIFY
+/// # let lock_time = LockTime::from_consensus(741521);  // nLockTime
+/// // To compare absolute lock times there are various `is_satisfied_*` methods, you may also use:
+/// let is_satisfied = match (n, lock_time) {
+///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,
+///     (Seconds(n), Seconds(lock_time)) => n <= lock_time,
+///     _ => panic!("handle invalid comparison error"),
+/// };
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LockTime {
+    /// A block height lock time value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::absolute::LockTime;
+    ///
+    /// let block: u32 = 741521;
+    /// let n = LockTime::from_height(block).expect("valid height");
+    /// assert!(n.is_block_height());
+    /// assert_eq!(n.to_consensus_u32(), block);
+    /// ```
+    Blocks(Height),
+    /// A UNIX timestamp lock time value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::absolute::LockTime;
+    ///
+    /// let seconds: u32 = 1653195600; // May 22nd, 5am UTC.
+    /// let n = LockTime::from_time(seconds).expect("valid time");
+    /// assert!(n.is_block_time());
+    /// assert_eq!(n.to_consensus_u32(), seconds);
+    /// ```
+    Seconds(Time),
+}
+
+impl LockTime {
+    /// If [`crate::Transaction::lock_time`] is set to zero it is ignored, in other words a
+    /// transaction with nLocktime==0 is able to be included immediately in any block.
+    pub const ZERO: LockTime = LockTime::Blocks(Height::ZERO);
+
+    /// The number of bytes that the locktime contributes to the size of a transaction.
+    pub const SIZE: usize = 4; // Serialized length of a u32.
+
+    /// Creates a `LockTime` from an prefixed hex string.
+    pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
+        let stripped = if let Some(stripped) = s.strip_prefix("0x") {
+            stripped
+        } else if let Some(stripped) = s.strip_prefix("0X") {
+            stripped
+        } else {
+            return Err(MissingPrefixError::new(s).into());
+        };
+
+        let lock_time = parse::hex_u32(stripped)?;
+        Ok(Self::from_consensus(lock_time))
+    }
+
+    /// Creates a `LockTime` from an unprefixed hex string.
+    pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
+        if s.starts_with("0x") || s.starts_with("0X") {
+            return Err(ContainsPrefixError::new(s).into());
+        }
+        let lock_time = parse::hex_u32(s)?;
+        Ok(Self::from_consensus(lock_time))
+    }
+
+    /// Constructs a `LockTime` from an nLockTime value or the argument to OP_CHEKCLOCKTIMEVERIFY.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::absolute::LockTime;
+    /// # let n = LockTime::from_consensus(741521); // n OP_CHECKLOCKTIMEVERIFY
+    ///
+    /// // `from_consensus` roundtrips as expected with `to_consensus_u32`.
+    /// let n_lock_time: u32 = 741521;
+    /// let lock_time = LockTime::from_consensus(n_lock_time);
+    /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    #[inline]
+    pub fn from_consensus(n: u32) -> Self {
+        if units::locktime::absolute::is_block_height(n) {
+            Self::Blocks(Height::from_consensus(n).expect("n is valid"))
+        } else {
+            Self::Seconds(Time::from_consensus(n).expect("n is valid"))
+        }
+    }
+
+    /// Constructs a `LockTime` from `n`, expecting `n` to be a valid block height.
+    ///
+    /// See [`LOCK_TIME_THRESHOLD`] for definition of a valid height value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use bitcoin::absolute::LockTime;
+    /// assert!(LockTime::from_height(741521).is_ok());
+    /// assert!(LockTime::from_height(1653195600).is_err());
+    /// ```
+    #[inline]
+    pub fn from_height(n: u32) -> Result<Self, ConversionError> {
+        let height = Height::from_consensus(n)?;
+        Ok(LockTime::Blocks(height))
+    }
+
+    /// Constructs a `LockTime` from `n`, expecting `n` to be a valid block time.
+    ///
+    /// See [`LOCK_TIME_THRESHOLD`] for definition of a valid time value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use bitcoin::absolute::LockTime;
+    /// assert!(LockTime::from_time(1653195600).is_ok());
+    /// assert!(LockTime::from_time(741521).is_err());
+    /// ```
+    #[inline]
+    pub fn from_time(n: u32) -> Result<Self, ConversionError> {
+        let time = Time::from_consensus(n)?;
+        Ok(LockTime::Seconds(time))
+    }
+
+    /// Returns true if both lock times use the same unit i.e., both height based or both time based.
+    #[inline]
+    pub const fn is_same_unit(&self, other: LockTime) -> bool {
+        matches!(
+            (self, other),
+            (LockTime::Blocks(_), LockTime::Blocks(_))
+                | (LockTime::Seconds(_), LockTime::Seconds(_))
+        )
+    }
+
+    /// Returns true if this lock time value is a block height.
+    #[inline]
+    pub const fn is_block_height(&self) -> bool { matches!(*self, LockTime::Blocks(_)) }
+
+    /// Returns true if this lock time value is a block time (UNIX timestamp).
+    #[inline]
+    pub const fn is_block_time(&self) -> bool { !self.is_block_height() }
+
+    /// Returns true if this timelock constraint is satisfied by the respective `height`/`time`.
+    ///
+    /// If `self` is a blockheight based lock then it is checked against `height` and if `self` is a
+    /// blocktime based lock it is checked against `time`.
+    ///
+    /// A 'timelock constraint' refers to the `n` from `n OP_CHEKCLOCKTIMEVERIFY`, this constraint
+    /// is satisfied if a transaction with nLockTime ([`crate::Transaction::lock_time`]) set to
+    /// `height`/`time` is valid.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use bitcoin::absolute::{LockTime, Height, Time};
+    /// // Can be implemented if block chain data is available.
+    /// fn get_height() -> Height { todo!("return the current block height") }
+    /// fn get_time() -> Time { todo!("return the current block time") }
+    ///
+    /// let n = LockTime::from_consensus(741521); // `n OP_CHEKCLOCKTIMEVERIFY`.
+    /// if n.is_satisfied_by(get_height(), get_time()) {
+    ///     // Can create and mine a transaction that satisfies the OP_CLTV timelock constraint.
+    /// }
+    /// ````
+    #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_satisfied_by(&self, height: Height, time: Time) -> bool {
+        use LockTime::*;
+
+        match *self {
+            Blocks(n) => n <= height,
+            Seconds(n) => n <= time,
+        }
+    }
+
+    /// Returns true if satisfaction of `other` lock time implies satisfaction of this
+    /// [`absolute::LockTime`].
+    ///
+    /// A lock time can only be satisfied by n blocks being mined or n seconds passing. If you have
+    /// two lock times (same unit) then the larger lock time being satisfied implies (in a
+    /// mathematical sense) the smaller one being satisfied.
+    ///
+    /// This function is useful if you wish to check a lock time against various other locks e.g.,
+    /// filtering out locks which cannot be satisfied. Can also be used to remove the smaller value
+    /// of two `OP_CHECKLOCKTIMEVERIFY` operations within one branch of the script.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::absolute::{LockTime, LockTime::*};
+    /// let lock_time = LockTime::from_consensus(741521);
+    /// let check = LockTime::from_consensus(741521 + 1);
+    /// assert!(lock_time.is_implied_by(check));
+    /// ```
+    #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_implied_by(&self, other: LockTime) -> bool {
+        use LockTime::*;
+
+        match (*self, other) {
+            (Blocks(this), Blocks(other)) => this <= other,
+            (Seconds(this), Seconds(other)) => this <= other,
+            _ => false, // Not the same units.
+        }
+    }
+
+    /// Returns the inner `u32` value. This is the value used when creating this `LockTime`
+    /// i.e., `n OP_CHECKLOCKTIMEVERIFY` or nLockTime.
+    ///
+    /// # Warning
+    ///
+    /// Do not compare values return by this method. The whole point of the `LockTime` type is to
+    /// assist in doing correct comparisons. Either use `is_satisfied_by`, `is_satisfied_by_lock`,
+    /// or use the pattern below:
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::absolute::{LockTime, LockTime::*};
+    /// # let n = LockTime::from_consensus(741521);              // n OP_CHECKLOCKTIMEVERIFY
+    /// # let lock_time = LockTime::from_consensus(741521 + 1);  // nLockTime
+    ///
+    /// let is_satisfied = match (n, lock_time) {
+    ///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,
+    ///     (Seconds(n), Seconds(lock_time)) => n <= lock_time,
+    ///     _ => panic!("invalid comparison"),
+    /// };
+    ///
+    /// // Or, if you have Rust 1.53 or greater
+    /// // let is_satisfied = n.partial_cmp(&lock_time).expect("invalid comparison").is_le();
+    /// ```
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 {
+        match self {
+            LockTime::Blocks(ref h) => h.to_consensus_u32(),
+            LockTime::Seconds(ref t) => t.to_consensus_u32(),
+        }
+    }
+}
+
+impl FromStr for LockTime {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse::int::<u32, &str>(s).map(LockTime::from_consensus)
+    }
+}
+
+impl TryFrom<&str> for LockTime {
+    type Error = ParseIntError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        LockTime::from_str(s)
+    }
+}
+
+impl TryFrom<String> for LockTime {
+    type Error = ParseIntError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        LockTime::from_str(&s)
+    }
+}
+
+impl TryFrom<Box<str>> for LockTime {
+    type Error = ParseIntError;
+
+    fn try_from(s: Box<str>) -> Result<Self, Self::Error> {
+        LockTime::from_str(&s)
+    }
+}
+
+impl From<Height> for LockTime {
+    #[inline]
+    fn from(h: Height) -> Self { LockTime::Blocks(h) }
+}
+
+impl From<Time> for LockTime {
+    #[inline]
+    fn from(t: Time) -> Self { LockTime::Seconds(t) }
+}
+
+impl PartialOrd for LockTime {
+    #[inline]
+    fn partial_cmp(&self, other: &LockTime) -> Option<Ordering> {
+        use LockTime::*;
+
+        match (*self, *other) {
+            (Blocks(ref a), Blocks(ref b)) => a.partial_cmp(b),
+            (Seconds(ref a), Seconds(ref b)) => a.partial_cmp(b),
+            (_, _) => None,
+        }
+    }
+}
+
+impl fmt::Debug for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LockTime::*;
+
+        match *self {
+            Blocks(ref h) => write!(f, "{} blocks", h),
+            Seconds(ref t) => write!(f, "{} seconds", t),
+        }
+    }
+}
+
+impl fmt::Display for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LockTime::*;
+
+        if f.alternate() {
+            match *self {
+                Blocks(ref h) => write!(f, "block-height {}", h),
+                Seconds(ref t) => write!(f, "block-time {} (seconds since epoch)", t),
+            }
+        } else {
+            match *self {
+                Blocks(ref h) => fmt::Display::fmt(h, f),
+                Seconds(ref t) => fmt::Display::fmt(t, f),
+            }
+        }
+    }
+}
+
+impl Encodable for LockTime {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let v = self.to_consensus_u32();
+        v.consensus_encode(w)
+    }
+}
+
+impl Decodable for LockTime {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        u32::consensus_decode(r).map(LockTime::from_consensus)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for LockTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u32(self.to_consensus_u32())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LockTime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = u32;
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result { f.write_str("a u32") }
+            // We cannot just implement visit_u32 because JSON (among other things) always
+            // calls visit_u64, even when called from Deserializer::deserialize_u32. The
+            // other visit_u*s have default implementations that forward to visit_u64.
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<u32, E> {
+                v.try_into().map_err(|_| {
+                    E::invalid_value(serde::de::Unexpected::Unsigned(v), &"a 32-bit number")
+                })
+            }
+            // Also do the signed version, just for good measure.
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<u32, E> {
+                v.try_into().map_err(|_| {
+                    E::invalid_value(serde::de::Unexpected::Signed(v), &"a 32-bit number")
+                })
+            }
+        }
+        deserializer.deserialize_u32(Visitor).map(LockTime::from_consensus)
+    }
+}
+
+#[cfg(feature = "ordered")]
+impl ordered::ArbitraryOrd for LockTime {
+    fn arbitrary_cmp(&self, other: &Self) -> Ordering {
+        use LockTime::*;
+
+        match (self, other) {
+            (Blocks(_), Seconds(_)) => Ordering::Less,
+            (Seconds(_), Blocks(_)) => Ordering::Greater,
+            (Blocks(this), Blocks(that)) => this.cmp(that),
+            (Seconds(this), Seconds(that)) => this.cmp(that),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_and_alternate() {
+        let n = LockTime::from_consensus(741521);
+        let s = format!("{}", n);
+        assert_eq!(&s, "741521");
+
+        let got = format!("{:#}", n);
+        assert_eq!(got, "block-height 741521");
+    }
+
+    #[test]
+    fn lock_time_from_hex_lower() {
+        let lock = LockTime::from_hex("0x6289c350").unwrap();
+        assert_eq!(lock, LockTime::from_consensus(0x6289C350));
+    }
+
+    #[test]
+    fn lock_time_from_hex_upper() {
+        let lock = LockTime::from_hex("0X6289C350").unwrap();
+        assert_eq!(lock, LockTime::from_consensus(0x6289C350));
+    }
+
+    #[test]
+    fn lock_time_from_unprefixed_hex_lower() {
+        let lock = LockTime::from_unprefixed_hex("6289c350").unwrap();
+        assert_eq!(lock, LockTime::from_consensus(0x6289C350));
+    }
+
+    #[test]
+    fn lock_time_from_unprefixed_hex_upper() {
+        let lock = LockTime::from_unprefixed_hex("6289C350").unwrap();
+        assert_eq!(lock, LockTime::from_consensus(0x6289C350));
+    }
+
+    #[test]
+    fn lock_time_from_invalid_hex_should_err() {
+        let hex = "0xzb93";
+        let result = LockTime::from_hex(hex);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parses_correctly_to_height_or_time() {
+        let lock = LockTime::from_consensus(750_000);
+
+        assert!(lock.is_block_height());
+        assert!(!lock.is_block_time());
+
+        let t: u32 = 1653195600; // May 22nd, 5am UTC.
+        let lock = LockTime::from_consensus(t);
+
+        assert!(!lock.is_block_height());
+        assert!(lock.is_block_time());
+    }
+
+    #[test]
+    fn satisfied_by_height() {
+        let lock = LockTime::from_consensus(750_000);
+
+        let height = Height::from_consensus(800_000).expect("failed to parse height");
+
+        let t: u32 = 1653195600; // May 22nd, 5am UTC.
+        let time = Time::from_consensus(t).expect("invalid time value");
+
+        assert!(lock.is_satisfied_by(height, time))
+    }
+
+    #[test]
+    fn satisfied_by_time() {
+        let lock = LockTime::from_consensus(1053195600);
+
+        let t: u32 = 1653195600; // May 22nd, 5am UTC.
+        let time = Time::from_consensus(t).expect("invalid time value");
+
+        let height = Height::from_consensus(800_000).expect("failed to parse height");
+
+        assert!(lock.is_satisfied_by(height, time))
+    }
+
+    #[test]
+    fn satisfied_by_same_height() {
+        let h = 750_000;
+        let lock = LockTime::from_consensus(h);
+        let height = Height::from_consensus(h).expect("failed to parse height");
+
+        let t: u32 = 1653195600; // May 22nd, 5am UTC.
+        let time = Time::from_consensus(t).expect("invalid time value");
+
+        assert!(lock.is_satisfied_by(height, time))
+    }
+
+    #[test]
+    fn satisfied_by_same_time() {
+        let t: u32 = 1653195600; // May 22nd, 5am UTC.
+        let lock = LockTime::from_consensus(t);
+        let time = Time::from_consensus(t).expect("invalid time value");
+
+        let height = Height::from_consensus(800_000).expect("failed to parse height");
+
+        assert!(lock.is_satisfied_by(height, time))
+    }
+
+    #[test]
+    fn height_correctly_implies() {
+        let lock = LockTime::from_consensus(750_005);
+
+        assert!(!lock.is_implied_by(LockTime::from_consensus(750_004)));
+        assert!(lock.is_implied_by(LockTime::from_consensus(750_005)));
+        assert!(lock.is_implied_by(LockTime::from_consensus(750_006)));
+    }
+
+    #[test]
+    fn time_correctly_implies() {
+        let t: u32 = 1700000005;
+        let lock = LockTime::from_consensus(t);
+
+        assert!(!lock.is_implied_by(LockTime::from_consensus(1700000004)));
+        assert!(lock.is_implied_by(LockTime::from_consensus(1700000005)));
+        assert!(lock.is_implied_by(LockTime::from_consensus(1700000006)));
+    }
+
+    #[test]
+    fn incorrect_units_do_not_imply() {
+        let lock = LockTime::from_consensus(750_005);
+        assert!(!lock.is_implied_by(LockTime::from_consensus(1700000004)));
+    }
+}

--- a/libs/bitcoin/src/blockdata/locktime/mod.rs
+++ b/libs/bitcoin/src/blockdata/locktime/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Provides absolute and relative locktimes.
+//!
+
+pub mod absolute;
+pub mod relative;

--- a/libs/bitcoin/src/blockdata/locktime/relative.rs
+++ b/libs/bitcoin/src/blockdata/locktime/relative.rs
@@ -1,0 +1,513 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Provides type [`LockTime`] that implements the logic around nSequence/OP_CHECKSEQUENCEVERIFY.
+//!
+//! There are two types of lock time: lock-by-blockheight and lock-by-blocktime, distinguished by
+//! whether bit 22 of the `u32` consensus value is set.
+//!
+
+#[cfg(feature = "ordered")]
+use core::cmp::Ordering;
+use core::{cmp, convert, fmt};
+
+#[cfg(all(test, mutate))]
+use mutagen::mutate;
+
+#[cfg(doc)]
+use crate::relative;
+use crate::Sequence;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use units::locktime::relative::{Height, Time, TimeOverflowError};
+
+/// A relative lock time value, representing either a block height or time (512 second intervals).
+///
+/// Used for sequence numbers (`nSequence` in Bitcoin Core and [`crate::TxIn::sequence`]
+/// in this library) and also for the argument to opcode 'OP_CHECKSEQUENCEVERIFY`.
+///
+/// ### Note on ordering
+///
+/// Locktimes may be height- or time-based, and these metrics are incommensurate; there is no total
+/// ordering on locktimes. We therefore have implemented [`PartialOrd`] but not [`Ord`]. We also
+/// implement [`ordered::ArbitraryOrd`] if the "ordered" feature is enabled.
+///
+/// ### Relevant BIPs
+///
+/// * [BIP 68 Relative lock-time using consensus-enforced sequence numbers](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+/// * [BIP 112 CHECKSEQUENCEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub enum LockTime {
+    /// A block height lock time value.
+    Blocks(Height),
+    /// A 512 second time interval value.
+    Time(Time),
+}
+
+impl LockTime {
+    /// A relative locktime of 0 is always valid, and is assumed valid for inputs that
+    /// are not yet confirmed.
+    pub const ZERO: LockTime = LockTime::Blocks(Height::ZERO);
+
+    /// The number of bytes that the locktime contributes to the size of a transaction.
+    pub const SIZE: usize = 4; // Serialized length of a u32.
+
+    /// Constructs a `LockTime` from an nSequence value or the argument to OP_CHECKSEQUENCEVERIFY.
+    ///
+    /// This method will **not** round-trip with [`Self::to_consensus_u32`], because relative
+    /// locktimes only use some bits of the underlying `u32` value and discard the rest. If
+    /// you want to preserve the full value, you should use the [`Sequence`] type instead.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::relative::LockTime;
+    ///
+    /// // `from_consensus` roundtrips with `to_consensus_u32` for small values.
+    /// let n_lock_time: u32 = 7000;
+    /// let lock_time = LockTime::from_consensus(n_lock_time).unwrap();
+    /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    /// ```
+    pub fn from_consensus(n: u32) -> Result<Self, DisabledLockTimeError> {
+        let sequence = crate::Sequence::from_consensus(n);
+        sequence.to_relative_lock_time().ok_or(DisabledLockTimeError(n))
+    }
+
+    /// Returns the `u32` value used to encode this locktime in an nSequence field or
+    /// argument to `OP_CHECKSEQUENCEVERIFY`.
+    ///
+    /// # Warning
+    ///
+    /// Locktimes are not ordered by the natural ordering on `u32`. If you want to
+    /// compare locktimes, use [`Self::is_implied_by`] or similar methods.
+    #[inline]
+    pub fn to_consensus_u32(&self) -> u32 {
+        match self {
+            LockTime::Blocks(ref h) => h.to_consensus_u32(),
+            LockTime::Time(ref t) => t.to_consensus_u32(),
+        }
+    }
+
+    /// Constructs a `LockTime` from the sequence number of a Bitcoin input.
+    ///
+    /// This method will **not** round-trip with [`Self::to_sequence`]. See the
+    /// docs for [`Self::from_consensus`] for more information.
+    #[inline]
+    pub fn from_sequence(n: Sequence) -> Result<Self, DisabledLockTimeError> {
+        Self::from_consensus(n.to_consensus_u32())
+    }
+
+    /// Encodes the locktime as a sequence number.
+    #[inline]
+    pub fn to_sequence(&self) -> Sequence { Sequence::from_consensus(self.to_consensus_u32()) }
+
+    /// Constructs a `LockTime` from `n`, expecting `n` to be a 16-bit count of blocks.
+    #[inline]
+    pub const fn from_height(n: u16) -> Self { LockTime::Blocks(Height::from_height(n)) }
+
+    /// Constructs a `LockTime` from `n`, expecting `n` to be a count of 512-second intervals.
+    ///
+    /// This function is a little awkward to use, and users may wish to instead use
+    /// [`Self::from_seconds_floor`] or [`Self::from_seconds_ceil`].
+    #[inline]
+    pub const fn from_512_second_intervals(intervals: u16) -> Self {
+        LockTime::Time(Time::from_512_second_intervals(intervals))
+    }
+
+    /// Create a [`LockTime`] from seconds, converting the seconds into 512 second interval
+    /// with truncating division.
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if the input cannot be encoded in 16 bits.
+    #[inline]
+    pub const fn from_seconds_floor(seconds: u32) -> Result<Self, TimeOverflowError> {
+        match Time::from_seconds_floor(seconds) {
+            Ok(time) => Ok(LockTime::Time(time)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Create a [`LockTime`] from seconds, converting the seconds into 512 second interval
+    /// with ceiling division.
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if the input cannot be encoded in 16 bits.
+    #[inline]
+    pub const fn from_seconds_ceil(seconds: u32) -> Result<Self, TimeOverflowError> {
+        match Time::from_seconds_ceil(seconds) {
+            Ok(time) => Ok(LockTime::Time(time)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns true if both lock times use the same unit i.e., both height based or both time based.
+    #[inline]
+    pub const fn is_same_unit(&self, other: LockTime) -> bool {
+        matches!(
+            (self, other),
+            (LockTime::Blocks(_), LockTime::Blocks(_)) | (LockTime::Time(_), LockTime::Time(_))
+        )
+    }
+
+    /// Returns true if this lock time value is in units of block height.
+    #[inline]
+    pub const fn is_block_height(&self) -> bool { matches!(*self, LockTime::Blocks(_)) }
+
+    /// Returns true if this lock time value is in units of time.
+    #[inline]
+    pub const fn is_block_time(&self) -> bool { !self.is_block_height() }
+
+    /// Returns true if this [`relative::LockTime`] is satisfied by either height or time.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::Sequence;
+    /// # use bitcoin::locktime::relative::{LockTime, Height, Time};
+    ///
+    /// # let height = 100;       // 100 blocks.
+    /// # let intervals = 70;     // Approx 10 hours.
+    /// # let current_height = || Height::from(height + 10);
+    /// # let current_time = || Time::from_512_second_intervals(intervals + 10);
+    /// # let lock = Sequence::from_height(height).to_relative_lock_time().expect("valid height");
+    ///
+    /// // Users that have chain data can get the current height and time to check against a lock.
+    /// let height_and_time = (current_time(), current_height());  // tuple order does not matter.
+    /// assert!(lock.is_satisfied_by(current_height(), current_time()));
+    /// ```
+    #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_satisfied_by(&self, h: Height, t: Time) -> bool {
+        if let Ok(true) = self.is_satisfied_by_height(h) {
+            true
+        } else {
+            matches!(self.is_satisfied_by_time(t), Ok(true))
+        }
+    }
+
+    /// Returns true if satisfaction of `other` lock time implies satisfaction of this
+    /// [`relative::LockTime`].
+    ///
+    /// A lock time can only be satisfied by n blocks being mined or n seconds passing. If you have
+    /// two lock times (same unit) then the larger lock time being satisfied implies (in a
+    /// mathematical sense) the smaller one being satisfied.
+    ///
+    /// This function is useful when checking sequence values against a lock, first one checks the
+    /// sequence represents a relative lock time by converting to `LockTime` then use this function
+    /// to see if satisfaction of the newly created lock time would imply satisfaction of `self`.
+    ///
+    /// Can also be used to remove the smaller value of two `OP_CHECKSEQUENCEVERIFY` operations
+    /// within one branch of the script.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::Sequence;
+    /// # use bitcoin::locktime::relative::{LockTime, Height, Time};
+    ///
+    /// # let height = 100;       // 100 blocks.
+    /// # let lock = Sequence::from_height(height).to_relative_lock_time().expect("valid height");
+    /// # let test_sequence = Sequence::from_height(height + 10);
+    ///
+    /// let satisfied = match test_sequence.to_relative_lock_time() {
+    ///     None => false, // Handle non-lock-time case.
+    ///     Some(test_lock) => lock.is_implied_by(test_lock),
+    /// };
+    /// assert!(satisfied);
+    /// ```
+    #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_implied_by(&self, other: LockTime) -> bool {
+        use LockTime::*;
+
+        match (*self, other) {
+            (Blocks(this), Blocks(other)) => this.value() <= other.value(),
+            (Time(this), Time(other)) => this.value() <= other.value(),
+            _ => false, // Not the same units.
+        }
+    }
+
+    /// Returns true if satisfaction of the sequence number implies satisfaction of this lock time.
+    ///
+    /// When deciding whether an instance of `<n> CHECKSEQUENCEVERIFY` will pass, this
+    /// method can be used by parsing `n` as a [`LockTime`] and calling this method
+    /// with the sequence number of the input which spends the script.
+    #[inline]
+    pub fn is_implied_by_sequence(&self, other: Sequence) -> bool {
+        if let Ok(other) = LockTime::from_sequence(other) {
+            self.is_implied_by(other)
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if this [`relative::LockTime`] is satisfied by [`Height`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this lock is not lock-by-height.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::Sequence;
+    /// # use bitcoin::locktime::relative::{LockTime, Height, Time};
+    ///
+    /// let height: u16 = 100;
+    /// let lock = Sequence::from_height(height).to_relative_lock_time().expect("valid height");
+    /// assert!(lock.is_satisfied_by_height(Height::from(height+1)).expect("a height"));
+    /// ```
+    #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_satisfied_by_height(&self, height: Height) -> Result<bool, IncompatibleHeightError> {
+        use LockTime::*;
+
+        match *self {
+            Blocks(ref h) => Ok(h.value() <= height.value()),
+            Time(time) => Err(IncompatibleHeightError { height, time }),
+        }
+    }
+
+    /// Returns true if this [`relative::LockTime`] is satisfied by [`Time`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this lock is not lock-by-time.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::Sequence;
+    /// # use bitcoin::locktime::relative::{LockTime, Height, Time};
+    ///
+    /// let intervals: u16 = 70; // approx 10 hours;
+    /// let lock = Sequence::from_512_second_intervals(intervals).to_relative_lock_time().expect("valid time");
+    /// assert!(lock.is_satisfied_by_time(Time::from_512_second_intervals(intervals + 10)).expect("a time"));
+    /// ```
+    #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_satisfied_by_time(&self, time: Time) -> Result<bool, IncompatibleTimeError> {
+        use LockTime::*;
+
+        match *self {
+            Time(ref t) => Ok(t.value() <= time.value()),
+            Blocks(height) => Err(IncompatibleTimeError { time, height }),
+        }
+    }
+}
+
+impl From<Height> for LockTime {
+    #[inline]
+    fn from(h: Height) -> Self { LockTime::Blocks(h) }
+}
+
+impl From<Time> for LockTime {
+    #[inline]
+    fn from(t: Time) -> Self { LockTime::Time(t) }
+}
+
+impl PartialOrd for LockTime {
+    #[inline]
+    fn partial_cmp(&self, other: &LockTime) -> Option<cmp::Ordering> {
+        use LockTime::*;
+
+        match (*self, *other) {
+            (Blocks(ref a), Blocks(ref b)) => a.partial_cmp(b),
+            (Time(ref a), Time(ref b)) => a.partial_cmp(b),
+            (_, _) => None,
+        }
+    }
+}
+
+impl fmt::Display for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LockTime::*;
+
+        if f.alternate() {
+            match *self {
+                Blocks(ref h) => write!(f, "block-height {}", h),
+                Time(ref t) => write!(f, "block-time {} (512 second intervals)", t),
+            }
+        } else {
+            match *self {
+                Blocks(ref h) => fmt::Display::fmt(h, f),
+                Time(ref t) => fmt::Display::fmt(t, f),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "ordered")]
+impl ordered::ArbitraryOrd for LockTime {
+    fn arbitrary_cmp(&self, other: &Self) -> Ordering {
+        use LockTime::*;
+
+        match (self, other) {
+            (Blocks(_), Time(_)) => Ordering::Less,
+            (Time(_), Blocks(_)) => Ordering::Greater,
+            (Blocks(this), Blocks(that)) => this.cmp(that),
+            (Time(this), Time(that)) => this.cmp(that),
+        }
+    }
+}
+
+impl convert::TryFrom<Sequence> for LockTime {
+    type Error = DisabledLockTimeError;
+    fn try_from(seq: Sequence) -> Result<LockTime, DisabledLockTimeError> {
+        LockTime::from_sequence(seq)
+    }
+}
+
+impl From<LockTime> for Sequence {
+    fn from(lt: LockTime) -> Sequence { lt.to_sequence() }
+}
+
+/// Error returned when a sequence number is parsed as a lock time, but its
+/// "disable" flag is set.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DisabledLockTimeError(u32);
+
+impl DisabledLockTimeError {
+    /// Accessor for the `u32` whose "disable" flag was set, preventing
+    /// it from being parsed as a relative locktime.
+    pub fn disabled_locktime_value(&self) -> u32 { self.0 }
+}
+
+impl fmt::Display for DisabledLockTimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "lock time 0x{:08x} has disable flag set", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DisabledLockTimeError {}
+
+/// Tried to satisfy a lock-by-blocktime lock using a height value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct IncompatibleHeightError {
+    /// Attempted to satisfy a lock-by-blocktime lock with this height.
+    pub height: Height,
+    /// The inner time value of the lock-by-blocktime lock.
+    pub time: Time,
+}
+
+impl fmt::Display for IncompatibleHeightError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "tried to satisfy a lock-by-blocktime lock {} with height: {}",
+            self.time, self.height
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IncompatibleHeightError {}
+
+/// Tried to satisfy a lock-by-blockheight lock using a time value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct IncompatibleTimeError {
+    /// Attempted to satisfy a lock-by-blockheight lock with this time.
+    pub time: Time,
+    /// The inner height value of the lock-by-blockheight lock.
+    pub height: Height,
+}
+
+impl fmt::Display for IncompatibleTimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "tried to satisfy a lock-by-blockheight lock {} with time: {}",
+            self.height, self.time
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IncompatibleTimeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn satisfied_by_height() {
+        let height = Height::from(10);
+        let time = Time::from_512_second_intervals(70);
+
+        let lock = LockTime::from(height);
+
+        assert!(!lock.is_satisfied_by(Height::from(9), time));
+        assert!(lock.is_satisfied_by(Height::from(10), time));
+        assert!(lock.is_satisfied_by(Height::from(11), time));
+    }
+
+    #[test]
+    fn satisfied_by_time() {
+        let height = Height::from(10);
+        let time = Time::from_512_second_intervals(70);
+
+        let lock = LockTime::from(time);
+
+        assert!(!lock.is_satisfied_by(height, Time::from_512_second_intervals(69)));
+        assert!(lock.is_satisfied_by(height, Time::from_512_second_intervals(70)));
+        assert!(lock.is_satisfied_by(height, Time::from_512_second_intervals(71)));
+    }
+
+    #[test]
+    fn height_correctly_implies() {
+        let height = Height::from(10);
+        let lock = LockTime::from(height);
+
+        assert!(!lock.is_implied_by(LockTime::from(Height::from(9))));
+        assert!(lock.is_implied_by(LockTime::from(Height::from(10))));
+        assert!(lock.is_implied_by(LockTime::from(Height::from(11))));
+    }
+
+    #[test]
+    fn time_correctly_implies() {
+        let time = Time::from_512_second_intervals(70);
+        let lock = LockTime::from(time);
+
+        assert!(!lock.is_implied_by(LockTime::from(Time::from_512_second_intervals(69))));
+        assert!(lock.is_implied_by(LockTime::from(Time::from_512_second_intervals(70))));
+        assert!(lock.is_implied_by(LockTime::from(Time::from_512_second_intervals(71))));
+    }
+
+    #[test]
+    fn incorrect_units_do_not_imply() {
+        let time = Time::from_512_second_intervals(70);
+        let height = Height::from(10);
+
+        let lock = LockTime::from(time);
+        assert!(!lock.is_implied_by(LockTime::from(height)));
+    }
+
+    #[test]
+    fn consensus_round_trip() {
+        assert!(LockTime::from_consensus(1 << 31).is_err());
+        assert!(LockTime::from_consensus(1 << 30).is_ok());
+        // Relative locktimes do not care about bits 17 through 21.
+        assert_eq!(LockTime::from_consensus(65536), LockTime::from_consensus(0));
+
+        for val in [0u32, 1, 1000, 65535] {
+            let seq = Sequence::from_consensus(val);
+            let lt = LockTime::from_consensus(val).unwrap();
+            assert_eq!(lt.to_consensus_u32(), val);
+            assert_eq!(lt.to_sequence(), seq);
+            assert_eq!(LockTime::from_sequence(seq).unwrap().to_sequence(), seq);
+
+            let seq = Sequence::from_consensus(val + (1 << 22));
+            let lt = LockTime::from_consensus(val + (1 << 22)).unwrap();
+            assert_eq!(lt.to_consensus_u32(), val + (1 << 22));
+            assert_eq!(lt.to_sequence(), seq);
+            assert_eq!(LockTime::from_sequence(seq).unwrap().to_sequence(), seq);
+        }
+    }
+}

--- a/libs/bitcoin/src/blockdata/mod.rs
+++ b/libs/bitcoin/src/blockdata/mod.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin block data.
+//!
+//! This module defines structures and functions for storing the blocks and
+//! transactions which make up the Bitcoin system.
+//!
+
+pub mod block;
+pub mod constants;
+pub mod locktime;
+pub mod opcodes;
+pub mod script;
+pub mod transaction;
+pub mod witness;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    fee_rate::FeeRate,
+    weight::Weight
+};
+
+/// Implements `FeeRate` and assoctiated features.
+pub mod fee_rate {
+    /// Re-export everything from the [`units::fee_rate`] module.
+    pub use units::fee_rate::*;
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn fee_convenience_functions_agree() {
+            use hex::test_hex_unwrap as hex;
+
+            use crate::blockdata::transaction::Transaction;
+            use crate::consensus::Decodable;
+
+            const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
+
+            let raw_tx = hex!(SOME_TX);
+            let tx: Transaction = Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
+
+            let rate = FeeRate::from_sat_per_vb(1).expect("1 sat/byte is valid");
+
+            assert_eq!(rate.fee_vb(tx.vsize() as u64), rate.fee_wu(tx.weight()));
+        }
+    }
+}
+
+/// Implements `Weight` and associated features.
+pub mod weight {
+    /// Re-export everything from the [`units::weight`] module.
+    pub use units::weight::*;
+}

--- a/libs/bitcoin/src/blockdata/opcodes.rs
+++ b/libs/bitcoin/src/blockdata/opcodes.rs
@@ -1,0 +1,894 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin script opcodes.
+//!
+//! Bitcoin's script uses a stack-based assembly language. This module defines
+//! all of the opcodes for that language.
+//!
+
+#![allow(non_camel_case_types)]
+
+use core::fmt;
+
+use internals::debug_from_display;
+
+#[cfg(feature = "serde")]
+use crate::prelude::*;
+
+/// A script Opcode.
+///
+/// We do not implement Ord on this type because there is no natural ordering on opcodes, but there
+/// may appear to be one (e.g. because all the push opcodes appear in a consecutive block) and we
+/// don't want to encourage subtly buggy code. Please use [`Opcode::classify`] to distinguish different
+/// types of opcodes.
+///
+/// <details>
+///   <summary>Example of Core bug caused by assuming ordering</summary>
+///
+///   Bitcoin Core's `IsPushOnly` considers `OP_RESERVED` to be a "push code", allowing this opcode
+///   in contexts where only pushes are supposed to be allowed.
+/// </details>
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Opcode {
+    code: u8,
+}
+
+use self::all::*;
+
+macro_rules! all_opcodes {
+    ($($op:ident => $val:expr, $doc:expr);*) => {
+        /// Enables wildcard imports to bring into scope all opcodes and nothing else.
+        ///
+        /// The `all` module is provided so one can use a wildcard import `use bitcoin::opcodes::all::*` to
+        /// get all the `OP_FOO` opcodes without getting other types defined in `opcodes` (e.g. `Opcode`, `Class`).
+        ///
+        /// This module is guaranteed to never contain anything except opcode constants and all opcode
+        /// constants are guaranteed to begin with OP_.
+        pub mod all {
+            use super::Opcode;
+            $(
+                #[doc = $doc]
+                pub const $op: Opcode = Opcode { code: $val};
+            )*
+        }
+
+        /// Push an empty array onto the stack.
+        pub static OP_0: Opcode = OP_PUSHBYTES_0;
+        /// Empty stack is also FALSE.
+        pub static OP_FALSE: Opcode = OP_PUSHBYTES_0;
+        /// Number 1 is also TRUE.
+        pub static OP_TRUE: Opcode = OP_PUSHNUM_1;
+        /// Previously called OP_NOP2.
+        pub static OP_NOP2: Opcode = OP_CLTV;
+        /// Previously called OP_NOP3.
+        pub static OP_NOP3: Opcode = OP_CSV;
+
+        impl fmt::Display for Opcode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                 match *self {
+                   $(
+                        $op => core::fmt::Display::fmt(stringify!($op), f),
+                    )+
+                }
+            }
+        }
+    }
+}
+
+all_opcodes! {
+    OP_PUSHBYTES_0 => 0x00, "Push an empty array onto the stack.";
+    OP_PUSHBYTES_1 => 0x01, "Push the next byte as an array onto the stack.";
+    OP_PUSHBYTES_2 => 0x02, "Push the next 2 bytes as an array onto the stack.";
+    OP_PUSHBYTES_3 => 0x03, "Push the next 3 bytes as an array onto the stack.";
+    OP_PUSHBYTES_4 => 0x04, "Push the next 4 bytes as an array onto the stack.";
+    OP_PUSHBYTES_5 => 0x05, "Push the next 5 bytes as an array onto the stack.";
+    OP_PUSHBYTES_6 => 0x06, "Push the next 6 bytes as an array onto the stack.";
+    OP_PUSHBYTES_7 => 0x07, "Push the next 7 bytes as an array onto the stack.";
+    OP_PUSHBYTES_8 => 0x08, "Push the next 8 bytes as an array onto the stack.";
+    OP_PUSHBYTES_9 => 0x09, "Push the next 9 bytes as an array onto the stack.";
+    OP_PUSHBYTES_10 => 0x0a, "Push the next 10 bytes as an array onto the stack.";
+    OP_PUSHBYTES_11 => 0x0b, "Push the next 11 bytes as an array onto the stack.";
+    OP_PUSHBYTES_12 => 0x0c, "Push the next 12 bytes as an array onto the stack.";
+    OP_PUSHBYTES_13 => 0x0d, "Push the next 13 bytes as an array onto the stack.";
+    OP_PUSHBYTES_14 => 0x0e, "Push the next 14 bytes as an array onto the stack.";
+    OP_PUSHBYTES_15 => 0x0f, "Push the next 15 bytes as an array onto the stack.";
+    OP_PUSHBYTES_16 => 0x10, "Push the next 16 bytes as an array onto the stack.";
+    OP_PUSHBYTES_17 => 0x11, "Push the next 17 bytes as an array onto the stack.";
+    OP_PUSHBYTES_18 => 0x12, "Push the next 18 bytes as an array onto the stack.";
+    OP_PUSHBYTES_19 => 0x13, "Push the next 19 bytes as an array onto the stack.";
+    OP_PUSHBYTES_20 => 0x14, "Push the next 20 bytes as an array onto the stack.";
+    OP_PUSHBYTES_21 => 0x15, "Push the next 21 bytes as an array onto the stack.";
+    OP_PUSHBYTES_22 => 0x16, "Push the next 22 bytes as an array onto the stack.";
+    OP_PUSHBYTES_23 => 0x17, "Push the next 23 bytes as an array onto the stack.";
+    OP_PUSHBYTES_24 => 0x18, "Push the next 24 bytes as an array onto the stack.";
+    OP_PUSHBYTES_25 => 0x19, "Push the next 25 bytes as an array onto the stack.";
+    OP_PUSHBYTES_26 => 0x1a, "Push the next 26 bytes as an array onto the stack.";
+    OP_PUSHBYTES_27 => 0x1b, "Push the next 27 bytes as an array onto the stack.";
+    OP_PUSHBYTES_28 => 0x1c, "Push the next 28 bytes as an array onto the stack.";
+    OP_PUSHBYTES_29 => 0x1d, "Push the next 29 bytes as an array onto the stack.";
+    OP_PUSHBYTES_30 => 0x1e, "Push the next 30 bytes as an array onto the stack.";
+    OP_PUSHBYTES_31 => 0x1f, "Push the next 31 bytes as an array onto the stack.";
+    OP_PUSHBYTES_32 => 0x20, "Push the next 32 bytes as an array onto the stack.";
+    OP_PUSHBYTES_33 => 0x21, "Push the next 33 bytes as an array onto the stack.";
+    OP_PUSHBYTES_34 => 0x22, "Push the next 34 bytes as an array onto the stack.";
+    OP_PUSHBYTES_35 => 0x23, "Push the next 35 bytes as an array onto the stack.";
+    OP_PUSHBYTES_36 => 0x24, "Push the next 36 bytes as an array onto the stack.";
+    OP_PUSHBYTES_37 => 0x25, "Push the next 37 bytes as an array onto the stack.";
+    OP_PUSHBYTES_38 => 0x26, "Push the next 38 bytes as an array onto the stack.";
+    OP_PUSHBYTES_39 => 0x27, "Push the next 39 bytes as an array onto the stack.";
+    OP_PUSHBYTES_40 => 0x28, "Push the next 40 bytes as an array onto the stack.";
+    OP_PUSHBYTES_41 => 0x29, "Push the next 41 bytes as an array onto the stack.";
+    OP_PUSHBYTES_42 => 0x2a, "Push the next 42 bytes as an array onto the stack.";
+    OP_PUSHBYTES_43 => 0x2b, "Push the next 43 bytes as an array onto the stack.";
+    OP_PUSHBYTES_44 => 0x2c, "Push the next 44 bytes as an array onto the stack.";
+    OP_PUSHBYTES_45 => 0x2d, "Push the next 45 bytes as an array onto the stack.";
+    OP_PUSHBYTES_46 => 0x2e, "Push the next 46 bytes as an array onto the stack.";
+    OP_PUSHBYTES_47 => 0x2f, "Push the next 47 bytes as an array onto the stack.";
+    OP_PUSHBYTES_48 => 0x30, "Push the next 48 bytes as an array onto the stack.";
+    OP_PUSHBYTES_49 => 0x31, "Push the next 49 bytes as an array onto the stack.";
+    OP_PUSHBYTES_50 => 0x32, "Push the next 50 bytes as an array onto the stack.";
+    OP_PUSHBYTES_51 => 0x33, "Push the next 51 bytes as an array onto the stack.";
+    OP_PUSHBYTES_52 => 0x34, "Push the next 52 bytes as an array onto the stack.";
+    OP_PUSHBYTES_53 => 0x35, "Push the next 53 bytes as an array onto the stack.";
+    OP_PUSHBYTES_54 => 0x36, "Push the next 54 bytes as an array onto the stack.";
+    OP_PUSHBYTES_55 => 0x37, "Push the next 55 bytes as an array onto the stack.";
+    OP_PUSHBYTES_56 => 0x38, "Push the next 56 bytes as an array onto the stack.";
+    OP_PUSHBYTES_57 => 0x39, "Push the next 57 bytes as an array onto the stack.";
+    OP_PUSHBYTES_58 => 0x3a, "Push the next 58 bytes as an array onto the stack.";
+    OP_PUSHBYTES_59 => 0x3b, "Push the next 59 bytes as an array onto the stack.";
+    OP_PUSHBYTES_60 => 0x3c, "Push the next 60 bytes as an array onto the stack.";
+    OP_PUSHBYTES_61 => 0x3d, "Push the next 61 bytes as an array onto the stack.";
+    OP_PUSHBYTES_62 => 0x3e, "Push the next 62 bytes as an array onto the stack.";
+    OP_PUSHBYTES_63 => 0x3f, "Push the next 63 bytes as an array onto the stack.";
+    OP_PUSHBYTES_64 => 0x40, "Push the next 64 bytes as an array onto the stack.";
+    OP_PUSHBYTES_65 => 0x41, "Push the next 65 bytes as an array onto the stack.";
+    OP_PUSHBYTES_66 => 0x42, "Push the next 66 bytes as an array onto the stack.";
+    OP_PUSHBYTES_67 => 0x43, "Push the next 67 bytes as an array onto the stack.";
+    OP_PUSHBYTES_68 => 0x44, "Push the next 68 bytes as an array onto the stack.";
+    OP_PUSHBYTES_69 => 0x45, "Push the next 69 bytes as an array onto the stack.";
+    OP_PUSHBYTES_70 => 0x46, "Push the next 70 bytes as an array onto the stack.";
+    OP_PUSHBYTES_71 => 0x47, "Push the next 71 bytes as an array onto the stack.";
+    OP_PUSHBYTES_72 => 0x48, "Push the next 72 bytes as an array onto the stack.";
+    OP_PUSHBYTES_73 => 0x49, "Push the next 73 bytes as an array onto the stack.";
+    OP_PUSHBYTES_74 => 0x4a, "Push the next 74 bytes as an array onto the stack.";
+    OP_PUSHBYTES_75 => 0x4b, "Push the next 75 bytes as an array onto the stack.";
+    OP_PUSHDATA1 => 0x4c, "Read the next byte as N; push the next N bytes as an array onto the stack.";
+    OP_PUSHDATA2 => 0x4d, "Read the next 2 bytes as N; push the next N bytes as an array onto the stack.";
+    OP_PUSHDATA4 => 0x4e, "Read the next 4 bytes as N; push the next N bytes as an array onto the stack.";
+    OP_PUSHNUM_NEG1 => 0x4f, "Push the array `0x81` onto the stack.";
+    OP_RESERVED => 0x50, "Synonym for OP_RETURN.";
+    OP_PUSHNUM_1 => 0x51, "Push the array `0x01` onto the stack.";
+    OP_PUSHNUM_2 => 0x52, "Push the array `0x02` onto the stack.";
+    OP_PUSHNUM_3 => 0x53, "Push the array `0x03` onto the stack.";
+    OP_PUSHNUM_4 => 0x54, "Push the array `0x04` onto the stack.";
+    OP_PUSHNUM_5 => 0x55, "Push the array `0x05` onto the stack.";
+    OP_PUSHNUM_6 => 0x56, "Push the array `0x06` onto the stack.";
+    OP_PUSHNUM_7 => 0x57, "Push the array `0x07` onto the stack.";
+    OP_PUSHNUM_8 => 0x58, "Push the array `0x08` onto the stack.";
+    OP_PUSHNUM_9 => 0x59, "Push the array `0x09` onto the stack.";
+    OP_PUSHNUM_10 => 0x5a, "Push the array `0x0a` onto the stack.";
+    OP_PUSHNUM_11 => 0x5b, "Push the array `0x0b` onto the stack.";
+    OP_PUSHNUM_12 => 0x5c, "Push the array `0x0c` onto the stack.";
+    OP_PUSHNUM_13 => 0x5d, "Push the array `0x0d` onto the stack.";
+    OP_PUSHNUM_14 => 0x5e, "Push the array `0x0e` onto the stack.";
+    OP_PUSHNUM_15 => 0x5f, "Push the array `0x0f` onto the stack.";
+    OP_PUSHNUM_16 => 0x60, "Push the array `0x10` onto the stack.";
+    OP_NOP => 0x61, "Does nothing.";
+    OP_VER => 0x62, "Synonym for OP_RETURN.";
+    OP_IF => 0x63, "Pop and execute the next statements if a nonzero element was popped.";
+    OP_NOTIF => 0x64, "Pop and execute the next statements if a zero element was popped.";
+    OP_VERIF => 0x65, "Fail the script unconditionally, does not even need to be executed.";
+    OP_VERNOTIF => 0x66, "Fail the script unconditionally, does not even need to be executed.";
+    OP_ELSE => 0x67, "Execute statements if those after the previous OP_IF were not, and vice-versa. \
+             If there is no previous OP_IF, this acts as a RETURN.";
+    OP_ENDIF => 0x68, "Pop and execute the next statements if a zero element was popped.";
+    OP_VERIFY => 0x69, "If the top value is zero or the stack is empty, fail; otherwise, pop the stack.";
+    OP_RETURN => 0x6a, "Fail the script immediately. (Must be executed.).";
+    OP_TOALTSTACK => 0x6b, "Pop one element from the main stack onto the alt stack.";
+    OP_FROMALTSTACK => 0x6c, "Pop one element from the alt stack onto the main stack.";
+    OP_2DROP => 0x6d, "Drops the top two stack items.";
+    OP_2DUP => 0x6e, "Duplicates the top two stack items as AB -> ABAB.";
+    OP_3DUP => 0x6f, "Duplicates the two three stack items as ABC -> ABCABC.";
+    OP_2OVER => 0x70, "Copies the two stack items of items two spaces back to the front, as xxAB -> ABxxAB.";
+    OP_2ROT => 0x71, "Moves the two stack items four spaces back to the front, as xxxxAB -> ABxxxx.";
+    OP_2SWAP => 0x72, "Swaps the top two pairs, as ABCD -> CDAB.";
+    OP_IFDUP => 0x73, "Duplicate the top stack element unless it is zero.";
+    OP_DEPTH => 0x74, "Push the current number of stack items onto the stack.";
+    OP_DROP => 0x75, "Drops the top stack item.";
+    OP_DUP => 0x76, "Duplicates the top stack item.";
+    OP_NIP => 0x77, "Drops the second-to-top stack item.";
+    OP_OVER => 0x78, "Copies the second-to-top stack item, as xA -> AxA.";
+    OP_PICK => 0x79, "Pop the top stack element as N. Copy the Nth stack element to the top.";
+    OP_ROLL => 0x7a, "Pop the top stack element as N. Move the Nth stack element to the top.";
+    OP_ROT => 0x7b, "Rotate the top three stack items, as [top next1 next2] -> [next2 top next1].";
+    OP_SWAP => 0x7c, "Swap the top two stack items.";
+    OP_TUCK => 0x7d, "Copy the top stack item to before the second item, as [top next] -> [top next top].";
+    OP_CAT => 0x7e, "Fail the script unconditionally, does not even need to be executed.";
+    OP_SUBSTR => 0x7f, "Fail the script unconditionally, does not even need to be executed.";
+    OP_LEFT => 0x80, "Fail the script unconditionally, does not even need to be executed.";
+    OP_RIGHT => 0x81, "Fail the script unconditionally, does not even need to be executed.";
+    OP_SIZE => 0x82, "Pushes the length of the top stack item onto the stack.";
+    OP_INVERT => 0x83, "Fail the script unconditionally, does not even need to be executed.";
+    OP_AND => 0x84, "Fail the script unconditionally, does not even need to be executed.";
+    OP_OR => 0x85, "Fail the script unconditionally, does not even need to be executed.";
+    OP_XOR => 0x86, "Fail the script unconditionally, does not even need to be executed.";
+    OP_EQUAL => 0x87, "Pushes 1 if the inputs are exactly equal, 0 otherwise.";
+    OP_EQUALVERIFY => 0x88, "Returns success if the inputs are exactly equal, failure otherwise.";
+    OP_RESERVED1 => 0x89, "Synonym for OP_RETURN.";
+    OP_RESERVED2 => 0x8a, "Synonym for OP_RETURN.";
+    OP_1ADD => 0x8b, "Increment the top stack element in place.";
+    OP_1SUB => 0x8c, "Decrement the top stack element in place.";
+    OP_2MUL => 0x8d, "Fail the script unconditionally, does not even need to be executed.";
+    OP_2DIV => 0x8e, "Fail the script unconditionally, does not even need to be executed.";
+    OP_NEGATE => 0x8f, "Multiply the top stack item by -1 in place.";
+    OP_ABS => 0x90, "Absolute value the top stack item in place.";
+    OP_NOT => 0x91, "Map 0 to 1 and everything else to 0, in place.";
+    OP_0NOTEQUAL => 0x92, "Map 0 to 0 and everything else to 1, in place.";
+    OP_ADD => 0x93, "Pop two stack items and push their sum.";
+    OP_SUB => 0x94, "Pop two stack items and push the second minus the top.";
+    OP_MUL => 0x95, "Fail the script unconditionally, does not even need to be executed.";
+    OP_DIV => 0x96, "Fail the script unconditionally, does not even need to be executed.";
+    OP_MOD => 0x97, "Fail the script unconditionally, does not even need to be executed.";
+    OP_LSHIFT => 0x98, "Fail the script unconditionally, does not even need to be executed.";
+    OP_RSHIFT => 0x99, "Fail the script unconditionally, does not even need to be executed.";
+    OP_BOOLAND => 0x9a, "Pop the top two stack items and push 1 if both are nonzero, else push 0.";
+    OP_BOOLOR => 0x9b, "Pop the top two stack items and push 1 if either is nonzero, else push 0.";
+    OP_NUMEQUAL => 0x9c, "Pop the top two stack items and push 1 if both are numerically equal, else push 0.";
+    OP_NUMEQUALVERIFY => 0x9d, "Pop the top two stack items and return success if both are numerically equal, else return failure.";
+    OP_NUMNOTEQUAL => 0x9e, "Pop the top two stack items and push 0 if both are numerically equal, else push 1.";
+    OP_LESSTHAN  => 0x9f, "Pop the top two items; push 1 if the second is less than the top, 0 otherwise.";
+    OP_GREATERTHAN  => 0xa0, "Pop the top two items; push 1 if the second is greater than the top, 0 otherwise.";
+    OP_LESSTHANOREQUAL  => 0xa1, "Pop the top two items; push 1 if the second is <= the top, 0 otherwise.";
+    OP_GREATERTHANOREQUAL  => 0xa2, "Pop the top two items; push 1 if the second is >= the top, 0 otherwise.";
+    OP_MIN => 0xa3, "Pop the top two items; push the smaller.";
+    OP_MAX => 0xa4, "Pop the top two items; push the larger.";
+    OP_WITHIN => 0xa5, "Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push 0.";
+    OP_RIPEMD160 => 0xa6, "Pop the top stack item and push its RIPEMD160 hash.";
+    OP_SHA1 => 0xa7, "Pop the top stack item and push its SHA1 hash.";
+    OP_SHA256 => 0xa8, "Pop the top stack item and push its SHA256 hash.";
+    OP_HASH160 => 0xa9, "Pop the top stack item and push its RIPEMD(SHA256) hash.";
+    OP_HASH256 => 0xaa, "Pop the top stack item and push its SHA256(SHA256) hash.";
+    OP_CODESEPARATOR => 0xab, "Ignore this and everything preceding when deciding what to sign when signature-checking.";
+    OP_CHECKSIG => 0xac, "<https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure.";
+    OP_CHECKSIGVERIFY => 0xad, "<https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure.";
+    OP_CHECKMULTISIG => 0xae, "Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), \
+                      and verify that all M signatures are valid. Push 1 for 'all valid', 0 otherwise.";
+    OP_CHECKMULTISIGVERIFY => 0xaf, "Like the above but return success/failure.";
+    OP_NOP1 => 0xb0, "Does nothing.";
+    OP_CLTV => 0xb1, "<https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>";
+    OP_CSV => 0xb2, "<https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>";
+    OP_NOP4 => 0xb3, "Does nothing.";
+    OP_NOP5 => 0xb4, "Does nothing.";
+    OP_NOP6 => 0xb5, "Does nothing.";
+    OP_NOP7 => 0xb6, "Does nothing.";
+    OP_NOP8 => 0xb7, "Does nothing.";
+    OP_NOP9 => 0xb8, "Does nothing.";
+    OP_NOP10 => 0xb9, "Does nothing.";
+    // Every other opcode acts as OP_RETURN
+    OP_CHECKSIGADD => 0xba, "OP_CHECKSIGADD post tapscript.";
+    OP_RETURN_187 => 0xbb, "Synonym for OP_RETURN.";
+    OP_RETURN_188 => 0xbc, "Synonym for OP_RETURN.";
+    OP_RETURN_189 => 0xbd, "Synonym for OP_RETURN.";
+    OP_RETURN_190 => 0xbe, "Synonym for OP_RETURN.";
+    OP_RETURN_191 => 0xbf, "Synonym for OP_RETURN.";
+    OP_RETURN_192 => 0xc0, "Synonym for OP_RETURN.";
+    OP_RETURN_193 => 0xc1, "Synonym for OP_RETURN.";
+    OP_RETURN_194 => 0xc2, "Synonym for OP_RETURN.";
+    OP_RETURN_195 => 0xc3, "Synonym for OP_RETURN.";
+    OP_RETURN_196 => 0xc4, "Synonym for OP_RETURN.";
+    OP_RETURN_197 => 0xc5, "Synonym for OP_RETURN.";
+    OP_RETURN_198 => 0xc6, "Synonym for OP_RETURN.";
+    OP_RETURN_199 => 0xc7, "Synonym for OP_RETURN.";
+    OP_RETURN_200 => 0xc8, "Synonym for OP_RETURN.";
+    OP_RETURN_201 => 0xc9, "Synonym for OP_RETURN.";
+    OP_RETURN_202 => 0xca, "Synonym for OP_RETURN.";
+    OP_RETURN_203 => 0xcb, "Synonym for OP_RETURN.";
+    OP_RETURN_204 => 0xcc, "Synonym for OP_RETURN.";
+    OP_RETURN_205 => 0xcd, "Synonym for OP_RETURN.";
+    OP_RETURN_206 => 0xce, "Synonym for OP_RETURN.";
+    OP_RETURN_207 => 0xcf, "Synonym for OP_RETURN.";
+    OP_RETURN_208 => 0xd0, "Synonym for OP_RETURN.";
+    OP_RETURN_209 => 0xd1, "Synonym for OP_RETURN.";
+    OP_RETURN_210 => 0xd2, "Synonym for OP_RETURN.";
+    OP_RETURN_211 => 0xd3, "Synonym for OP_RETURN.";
+    OP_RETURN_212 => 0xd4, "Synonym for OP_RETURN.";
+    OP_RETURN_213 => 0xd5, "Synonym for OP_RETURN.";
+    OP_RETURN_214 => 0xd6, "Synonym for OP_RETURN.";
+    OP_RETURN_215 => 0xd7, "Synonym for OP_RETURN.";
+    OP_RETURN_216 => 0xd8, "Synonym for OP_RETURN.";
+    OP_RETURN_217 => 0xd9, "Synonym for OP_RETURN.";
+    OP_RETURN_218 => 0xda, "Synonym for OP_RETURN.";
+    OP_RETURN_219 => 0xdb, "Synonym for OP_RETURN.";
+    OP_RETURN_220 => 0xdc, "Synonym for OP_RETURN.";
+    OP_RETURN_221 => 0xdd, "Synonym for OP_RETURN.";
+    OP_RETURN_222 => 0xde, "Synonym for OP_RETURN.";
+    OP_RETURN_223 => 0xdf, "Synonym for OP_RETURN.";
+    OP_RETURN_224 => 0xe0, "Synonym for OP_RETURN.";
+    OP_RETURN_225 => 0xe1, "Synonym for OP_RETURN.";
+    OP_RETURN_226 => 0xe2, "Synonym for OP_RETURN.";
+    OP_RETURN_227 => 0xe3, "Synonym for OP_RETURN.";
+    OP_RETURN_228 => 0xe4, "Synonym for OP_RETURN.";
+    OP_RETURN_229 => 0xe5, "Synonym for OP_RETURN.";
+    OP_RETURN_230 => 0xe6, "Synonym for OP_RETURN.";
+    OP_RETURN_231 => 0xe7, "Synonym for OP_RETURN.";
+    OP_RETURN_232 => 0xe8, "Synonym for OP_RETURN.";
+    OP_RETURN_233 => 0xe9, "Synonym for OP_RETURN.";
+    OP_RETURN_234 => 0xea, "Synonym for OP_RETURN.";
+    OP_RETURN_235 => 0xeb, "Synonym for OP_RETURN.";
+    OP_RETURN_236 => 0xec, "Synonym for OP_RETURN.";
+    OP_RETURN_237 => 0xed, "Synonym for OP_RETURN.";
+    OP_RETURN_238 => 0xee, "Synonym for OP_RETURN.";
+    OP_RETURN_239 => 0xef, "Synonym for OP_RETURN.";
+    OP_RETURN_240 => 0xf0, "Synonym for OP_RETURN.";
+    OP_RETURN_241 => 0xf1, "Synonym for OP_RETURN.";
+    OP_RETURN_242 => 0xf2, "Synonym for OP_RETURN.";
+    OP_RETURN_243 => 0xf3, "Synonym for OP_RETURN.";
+    OP_RETURN_244 => 0xf4, "Synonym for OP_RETURN.";
+    OP_RETURN_245 => 0xf5, "Synonym for OP_RETURN.";
+    OP_RETURN_246 => 0xf6, "Synonym for OP_RETURN.";
+    OP_RETURN_247 => 0xf7, "Synonym for OP_RETURN.";
+    OP_RETURN_248 => 0xf8, "Synonym for OP_RETURN.";
+    OP_RETURN_249 => 0xf9, "Synonym for OP_RETURN.";
+    OP_RETURN_250 => 0xfa, "Synonym for OP_RETURN.";
+    OP_RETURN_251 => 0xfb, "Synonym for OP_RETURN.";
+    OP_RETURN_252 => 0xfc, "Synonym for OP_RETURN.";
+    OP_RETURN_253 => 0xfd, "Synonym for OP_RETURN.";
+    OP_RETURN_254 => 0xfe, "Synonym for OP_RETURN.";
+    OP_INVALIDOPCODE => 0xff, "Synonym for OP_RETURN."
+}
+
+/// Classification context for the opcode.
+///
+/// Some opcodes like [`OP_RESERVED`] abort the script in `ClassifyContext::Legacy` context,
+/// but will act as `OP_SUCCESSx` in `ClassifyContext::TapScript` (see BIP342 for full list).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ClassifyContext {
+    /// Opcode used in tapscript context.
+    TapScript,
+    /// Opcode used in legacy context.
+    Legacy,
+}
+
+impl Opcode {
+    /// Classifies an Opcode into a broad class.
+    #[inline]
+    pub fn classify(self, ctx: ClassifyContext) -> Class {
+        match (self, ctx) {
+            // 3 opcodes illegal in all contexts
+            (OP_VERIF, _) | (OP_VERNOTIF, _) | (OP_INVALIDOPCODE, _) => Class::IllegalOp,
+
+            // 15 opcodes illegal in Legacy context
+            #[rustfmt::skip]
+            (OP_CAT, ctx) | (OP_SUBSTR, ctx)
+            | (OP_LEFT, ctx) | (OP_RIGHT, ctx)
+            | (OP_INVERT, ctx)
+            | (OP_AND, ctx) | (OP_OR, ctx) | (OP_XOR, ctx)
+            | (OP_2MUL, ctx) | (OP_2DIV, ctx)
+            | (OP_MUL, ctx) | (OP_DIV, ctx) | (OP_MOD, ctx)
+            | (OP_LSHIFT, ctx) | (OP_RSHIFT, ctx) if ctx == ClassifyContext::Legacy => Class::IllegalOp,
+
+            // 87 opcodes of SuccessOp class only in TapScript context
+            (op, ClassifyContext::TapScript)
+                if op.code == 80
+                    || op.code == 98
+                    || (op.code >= 126 && op.code <= 129)
+                    || (op.code >= 131 && op.code <= 134)
+                    || (op.code >= 137 && op.code <= 138)
+                    || (op.code >= 141 && op.code <= 142)
+                    || (op.code >= 149 && op.code <= 153)
+                    || (op.code >= 187 && op.code <= 254) =>
+                Class::SuccessOp,
+
+            // 11 opcodes of NoOp class
+            (OP_NOP, _) => Class::NoOp,
+            (op, _) if op.code >= OP_NOP1.code && op.code <= OP_NOP10.code => Class::NoOp,
+
+            // 1 opcode for `OP_RETURN`
+            (OP_RETURN, _) => Class::ReturnOp,
+
+            // 4 opcodes operating equally to `OP_RETURN` only in Legacy context
+            (OP_RESERVED, ctx) | (OP_RESERVED1, ctx) | (OP_RESERVED2, ctx) | (OP_VER, ctx)
+                if ctx == ClassifyContext::Legacy =>
+                Class::ReturnOp,
+
+            // 71 opcodes operating equally to `OP_RETURN` only in Legacy context
+            (op, ClassifyContext::Legacy) if op.code >= OP_CHECKSIGADD.code => Class::ReturnOp,
+
+            // 2 opcodes operating equally to `OP_RETURN` only in TapScript context
+            (OP_CHECKMULTISIG, ClassifyContext::TapScript)
+            | (OP_CHECKMULTISIGVERIFY, ClassifyContext::TapScript) => Class::ReturnOp,
+
+            // 1 opcode of PushNum class
+            (OP_PUSHNUM_NEG1, _) => Class::PushNum(-1),
+
+            // 16 opcodes of PushNum class
+            (op, _) if op.code >= OP_PUSHNUM_1.code && op.code <= OP_PUSHNUM_16.code =>
+                Class::PushNum(1 + self.code as i32 - OP_PUSHNUM_1.code as i32),
+
+            // 76 opcodes of PushBytes class
+            (op, _) if op.code <= OP_PUSHBYTES_75.code => Class::PushBytes(self.code as u32),
+
+            // opcodes of Ordinary class: 61 for Legacy and 60 for TapScript context
+            (_, _) => Class::Ordinary(Ordinary::with(self)),
+        }
+    }
+
+    /// Encodes [`Opcode`] as a byte.
+    #[inline]
+    pub const fn to_u8(self) -> u8 { self.code }
+
+    /// Encodes PUSHNUM [`Opcode`] as a `u8` representing its number (1-16).
+    ///
+    /// Does not convert `OP_FALSE` to 0. Only `1` to `OP_PUSHNUM_16` are covered.
+    ///
+    /// # Returns
+    ///
+    /// Returns `None` if `self` is not a PUSHNUM.
+    #[inline]
+    pub(crate) const fn decode_pushnum(self) -> Option<u8> {
+        const START: u8 = OP_PUSHNUM_1.code;
+        const END: u8 = OP_PUSHNUM_16.code;
+        match self.code {
+            START..=END => Some(self.code - START + 1),
+            _ => None,
+        }
+    }
+}
+
+impl From<u8> for Opcode {
+    #[inline]
+    fn from(b: u8) -> Opcode { Opcode { code: b } }
+}
+
+debug_from_display!(Opcode);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Opcode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+/// Broad categories of opcodes with similar behavior.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Class {
+    /// Pushes the given number onto the stack.
+    PushNum(i32),
+    /// Pushes the given number of bytes onto the stack.
+    PushBytes(u32),
+    /// Fails the script if executed.
+    ReturnOp,
+    /// Succeeds the script even if not executed.
+    SuccessOp,
+    /// Fails the script even if not executed.
+    IllegalOp,
+    /// Does nothing.
+    NoOp,
+    /// Any opcode not covered above.
+    Ordinary(Ordinary),
+}
+
+macro_rules! ordinary_opcode {
+    ($($op:ident),*) => (
+        #[repr(u8)]
+        #[doc(hidden)]
+        #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+        pub enum Ordinary {
+            $( $op = $op.code ),*
+        }
+
+        impl fmt::Display for Ordinary {
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+                match *self {
+                   $(Ordinary::$op => { f.pad(stringify!($op)) }),*
+                }
+            }
+        }
+
+        impl Ordinary {
+            fn with(b: Opcode) -> Self {
+                match b {
+                    $( $op => { Ordinary::$op } ),*
+                    _ => unreachable!("construction of `Ordinary` type from non-ordinary opcode {}", b),
+                }
+            }
+
+            /// Try to create a [`Ordinary`] from an [`Opcode`].
+            pub fn from_opcode(b: Opcode) -> Option<Self> {
+                match b {
+                    $( $op => { Some(Ordinary::$op) } ),*
+                    _ => None,
+                }
+            }
+        }
+    );
+}
+
+// "Ordinary" opcodes -- should be 61 of these
+ordinary_opcode! {
+    // pushdata
+    OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4,
+    // control flow
+    OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF, OP_VERIFY,
+    // stack
+    OP_TOALTSTACK, OP_FROMALTSTACK,
+    OP_2DROP, OP_2DUP, OP_3DUP, OP_2OVER, OP_2ROT, OP_2SWAP,
+    OP_DROP, OP_DUP, OP_NIP, OP_OVER, OP_PICK, OP_ROLL, OP_ROT, OP_SWAP, OP_TUCK,
+    OP_IFDUP, OP_DEPTH, OP_SIZE,
+    // equality
+    OP_EQUAL, OP_EQUALVERIFY,
+    // arithmetic
+    OP_1ADD, OP_1SUB, OP_NEGATE, OP_ABS, OP_NOT, OP_0NOTEQUAL,
+    OP_ADD, OP_SUB, OP_BOOLAND, OP_BOOLOR,
+    OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
+    OP_GREATERTHAN, OP_LESSTHANOREQUAL, OP_GREATERTHANOREQUAL,
+    OP_MIN, OP_MAX, OP_WITHIN,
+    // crypto
+    OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256,
+    OP_CODESEPARATOR, OP_CHECKSIG, OP_CHECKSIGVERIFY,
+    OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY,
+    OP_CHECKSIGADD
+}
+
+impl Ordinary {
+    /// Encodes [`Opcode`] as a byte.
+    #[inline]
+    pub fn to_u8(self) -> u8 { self as u8 }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    macro_rules! roundtrip {
+        ($unique:expr, $op:ident) => {
+            assert_eq!($op, Opcode::from($op.to_u8()));
+
+            let s1 = format!("{}", $op);
+            let s2 = format!("{:?}", $op);
+            assert_eq!(s1, s2);
+            assert_eq!(s1, stringify!($op));
+            assert!($unique.insert(s1));
+        };
+    }
+
+    #[test]
+    fn formatting_works() {
+        let op = all::OP_NOP;
+        let s = format!("{:>10}", op);
+        assert_eq!(s, "    OP_NOP");
+    }
+
+    #[test]
+    fn decode_pushnum() {
+        // Test all possible opcodes
+        // - Sanity check
+        assert_eq!(OP_PUSHNUM_1.code, 0x51_u8);
+        assert_eq!(OP_PUSHNUM_16.code, 0x60_u8);
+        for i in 0x00..=0xff_u8 {
+            let expected = match i {
+                // OP_PUSHNUM_1 ..= OP_PUSHNUM_16
+                0x51..=0x60 => Some(i - 0x50),
+                _ => None,
+            };
+            assert_eq!(Opcode::from(i).decode_pushnum(), expected);
+        }
+
+        // Test the named opcode constants
+        // - This is the OP right before PUSHNUMs start
+        assert!(OP_RESERVED.decode_pushnum().is_none());
+        assert_eq!(OP_PUSHNUM_1.decode_pushnum().expect("pushnum"), 1);
+        assert_eq!(OP_PUSHNUM_2.decode_pushnum().expect("pushnum"), 2);
+        assert_eq!(OP_PUSHNUM_3.decode_pushnum().expect("pushnum"), 3);
+        assert_eq!(OP_PUSHNUM_4.decode_pushnum().expect("pushnum"), 4);
+        assert_eq!(OP_PUSHNUM_5.decode_pushnum().expect("pushnum"), 5);
+        assert_eq!(OP_PUSHNUM_6.decode_pushnum().expect("pushnum"), 6);
+        assert_eq!(OP_PUSHNUM_7.decode_pushnum().expect("pushnum"), 7);
+        assert_eq!(OP_PUSHNUM_8.decode_pushnum().expect("pushnum"), 8);
+        assert_eq!(OP_PUSHNUM_9.decode_pushnum().expect("pushnum"), 9);
+        assert_eq!(OP_PUSHNUM_10.decode_pushnum().expect("pushnum"), 10);
+        assert_eq!(OP_PUSHNUM_11.decode_pushnum().expect("pushnum"), 11);
+        assert_eq!(OP_PUSHNUM_12.decode_pushnum().expect("pushnum"), 12);
+        assert_eq!(OP_PUSHNUM_13.decode_pushnum().expect("pushnum"), 13);
+        assert_eq!(OP_PUSHNUM_14.decode_pushnum().expect("pushnum"), 14);
+        assert_eq!(OP_PUSHNUM_15.decode_pushnum().expect("pushnum"), 15);
+        assert_eq!(OP_PUSHNUM_16.decode_pushnum().expect("pushnum"), 16);
+        // - This is the OP right after PUSHNUMs end
+        assert!(OP_NOP.decode_pushnum().is_none());
+    }
+
+    #[test]
+    fn classify_test() {
+        let op174 = OP_CHECKMULTISIG;
+        assert_eq!(
+            op174.classify(ClassifyContext::Legacy),
+            Class::Ordinary(Ordinary::OP_CHECKMULTISIG)
+        );
+        assert_eq!(op174.classify(ClassifyContext::TapScript), Class::ReturnOp);
+
+        let op175 = OP_CHECKMULTISIGVERIFY;
+        assert_eq!(
+            op175.classify(ClassifyContext::Legacy),
+            Class::Ordinary(Ordinary::OP_CHECKMULTISIGVERIFY)
+        );
+        assert_eq!(op175.classify(ClassifyContext::TapScript), Class::ReturnOp);
+
+        let op186 = OP_CHECKSIGADD;
+        assert_eq!(op186.classify(ClassifyContext::Legacy), Class::ReturnOp);
+        assert_eq!(
+            op186.classify(ClassifyContext::TapScript),
+            Class::Ordinary(Ordinary::OP_CHECKSIGADD)
+        );
+
+        let op187 = OP_RETURN_187;
+        assert_eq!(op187.classify(ClassifyContext::Legacy), Class::ReturnOp);
+        assert_eq!(op187.classify(ClassifyContext::TapScript), Class::SuccessOp);
+    }
+
+    #[test]
+    fn str_roundtrip() {
+        let mut unique = HashSet::new();
+        roundtrip!(unique, OP_PUSHBYTES_0);
+        roundtrip!(unique, OP_PUSHBYTES_1);
+        roundtrip!(unique, OP_PUSHBYTES_2);
+        roundtrip!(unique, OP_PUSHBYTES_3);
+        roundtrip!(unique, OP_PUSHBYTES_4);
+        roundtrip!(unique, OP_PUSHBYTES_5);
+        roundtrip!(unique, OP_PUSHBYTES_6);
+        roundtrip!(unique, OP_PUSHBYTES_7);
+        roundtrip!(unique, OP_PUSHBYTES_8);
+        roundtrip!(unique, OP_PUSHBYTES_9);
+        roundtrip!(unique, OP_PUSHBYTES_10);
+        roundtrip!(unique, OP_PUSHBYTES_11);
+        roundtrip!(unique, OP_PUSHBYTES_12);
+        roundtrip!(unique, OP_PUSHBYTES_13);
+        roundtrip!(unique, OP_PUSHBYTES_14);
+        roundtrip!(unique, OP_PUSHBYTES_15);
+        roundtrip!(unique, OP_PUSHBYTES_16);
+        roundtrip!(unique, OP_PUSHBYTES_17);
+        roundtrip!(unique, OP_PUSHBYTES_18);
+        roundtrip!(unique, OP_PUSHBYTES_19);
+        roundtrip!(unique, OP_PUSHBYTES_20);
+        roundtrip!(unique, OP_PUSHBYTES_21);
+        roundtrip!(unique, OP_PUSHBYTES_22);
+        roundtrip!(unique, OP_PUSHBYTES_23);
+        roundtrip!(unique, OP_PUSHBYTES_24);
+        roundtrip!(unique, OP_PUSHBYTES_25);
+        roundtrip!(unique, OP_PUSHBYTES_26);
+        roundtrip!(unique, OP_PUSHBYTES_27);
+        roundtrip!(unique, OP_PUSHBYTES_28);
+        roundtrip!(unique, OP_PUSHBYTES_29);
+        roundtrip!(unique, OP_PUSHBYTES_30);
+        roundtrip!(unique, OP_PUSHBYTES_31);
+        roundtrip!(unique, OP_PUSHBYTES_32);
+        roundtrip!(unique, OP_PUSHBYTES_33);
+        roundtrip!(unique, OP_PUSHBYTES_34);
+        roundtrip!(unique, OP_PUSHBYTES_35);
+        roundtrip!(unique, OP_PUSHBYTES_36);
+        roundtrip!(unique, OP_PUSHBYTES_37);
+        roundtrip!(unique, OP_PUSHBYTES_38);
+        roundtrip!(unique, OP_PUSHBYTES_39);
+        roundtrip!(unique, OP_PUSHBYTES_40);
+        roundtrip!(unique, OP_PUSHBYTES_41);
+        roundtrip!(unique, OP_PUSHBYTES_42);
+        roundtrip!(unique, OP_PUSHBYTES_43);
+        roundtrip!(unique, OP_PUSHBYTES_44);
+        roundtrip!(unique, OP_PUSHBYTES_45);
+        roundtrip!(unique, OP_PUSHBYTES_46);
+        roundtrip!(unique, OP_PUSHBYTES_47);
+        roundtrip!(unique, OP_PUSHBYTES_48);
+        roundtrip!(unique, OP_PUSHBYTES_49);
+        roundtrip!(unique, OP_PUSHBYTES_50);
+        roundtrip!(unique, OP_PUSHBYTES_51);
+        roundtrip!(unique, OP_PUSHBYTES_52);
+        roundtrip!(unique, OP_PUSHBYTES_53);
+        roundtrip!(unique, OP_PUSHBYTES_54);
+        roundtrip!(unique, OP_PUSHBYTES_55);
+        roundtrip!(unique, OP_PUSHBYTES_56);
+        roundtrip!(unique, OP_PUSHBYTES_57);
+        roundtrip!(unique, OP_PUSHBYTES_58);
+        roundtrip!(unique, OP_PUSHBYTES_59);
+        roundtrip!(unique, OP_PUSHBYTES_60);
+        roundtrip!(unique, OP_PUSHBYTES_61);
+        roundtrip!(unique, OP_PUSHBYTES_62);
+        roundtrip!(unique, OP_PUSHBYTES_63);
+        roundtrip!(unique, OP_PUSHBYTES_64);
+        roundtrip!(unique, OP_PUSHBYTES_65);
+        roundtrip!(unique, OP_PUSHBYTES_66);
+        roundtrip!(unique, OP_PUSHBYTES_67);
+        roundtrip!(unique, OP_PUSHBYTES_68);
+        roundtrip!(unique, OP_PUSHBYTES_69);
+        roundtrip!(unique, OP_PUSHBYTES_70);
+        roundtrip!(unique, OP_PUSHBYTES_71);
+        roundtrip!(unique, OP_PUSHBYTES_72);
+        roundtrip!(unique, OP_PUSHBYTES_73);
+        roundtrip!(unique, OP_PUSHBYTES_74);
+        roundtrip!(unique, OP_PUSHBYTES_75);
+        roundtrip!(unique, OP_PUSHDATA1);
+        roundtrip!(unique, OP_PUSHDATA2);
+        roundtrip!(unique, OP_PUSHDATA4);
+        roundtrip!(unique, OP_PUSHNUM_NEG1);
+        roundtrip!(unique, OP_RESERVED);
+        roundtrip!(unique, OP_PUSHNUM_1);
+        roundtrip!(unique, OP_PUSHNUM_2);
+        roundtrip!(unique, OP_PUSHNUM_3);
+        roundtrip!(unique, OP_PUSHNUM_4);
+        roundtrip!(unique, OP_PUSHNUM_5);
+        roundtrip!(unique, OP_PUSHNUM_6);
+        roundtrip!(unique, OP_PUSHNUM_7);
+        roundtrip!(unique, OP_PUSHNUM_8);
+        roundtrip!(unique, OP_PUSHNUM_9);
+        roundtrip!(unique, OP_PUSHNUM_10);
+        roundtrip!(unique, OP_PUSHNUM_11);
+        roundtrip!(unique, OP_PUSHNUM_12);
+        roundtrip!(unique, OP_PUSHNUM_13);
+        roundtrip!(unique, OP_PUSHNUM_14);
+        roundtrip!(unique, OP_PUSHNUM_15);
+        roundtrip!(unique, OP_PUSHNUM_16);
+        roundtrip!(unique, OP_NOP);
+        roundtrip!(unique, OP_VER);
+        roundtrip!(unique, OP_IF);
+        roundtrip!(unique, OP_NOTIF);
+        roundtrip!(unique, OP_VERIF);
+        roundtrip!(unique, OP_VERNOTIF);
+        roundtrip!(unique, OP_ELSE);
+        roundtrip!(unique, OP_ENDIF);
+        roundtrip!(unique, OP_VERIFY);
+        roundtrip!(unique, OP_RETURN);
+        roundtrip!(unique, OP_TOALTSTACK);
+        roundtrip!(unique, OP_FROMALTSTACK);
+        roundtrip!(unique, OP_2DROP);
+        roundtrip!(unique, OP_2DUP);
+        roundtrip!(unique, OP_3DUP);
+        roundtrip!(unique, OP_2OVER);
+        roundtrip!(unique, OP_2ROT);
+        roundtrip!(unique, OP_2SWAP);
+        roundtrip!(unique, OP_IFDUP);
+        roundtrip!(unique, OP_DEPTH);
+        roundtrip!(unique, OP_DROP);
+        roundtrip!(unique, OP_DUP);
+        roundtrip!(unique, OP_NIP);
+        roundtrip!(unique, OP_OVER);
+        roundtrip!(unique, OP_PICK);
+        roundtrip!(unique, OP_ROLL);
+        roundtrip!(unique, OP_ROT);
+        roundtrip!(unique, OP_SWAP);
+        roundtrip!(unique, OP_TUCK);
+        roundtrip!(unique, OP_CAT);
+        roundtrip!(unique, OP_SUBSTR);
+        roundtrip!(unique, OP_LEFT);
+        roundtrip!(unique, OP_RIGHT);
+        roundtrip!(unique, OP_SIZE);
+        roundtrip!(unique, OP_INVERT);
+        roundtrip!(unique, OP_AND);
+        roundtrip!(unique, OP_OR);
+        roundtrip!(unique, OP_XOR);
+        roundtrip!(unique, OP_EQUAL);
+        roundtrip!(unique, OP_EQUALVERIFY);
+        roundtrip!(unique, OP_RESERVED1);
+        roundtrip!(unique, OP_RESERVED2);
+        roundtrip!(unique, OP_1ADD);
+        roundtrip!(unique, OP_1SUB);
+        roundtrip!(unique, OP_2MUL);
+        roundtrip!(unique, OP_2DIV);
+        roundtrip!(unique, OP_NEGATE);
+        roundtrip!(unique, OP_ABS);
+        roundtrip!(unique, OP_NOT);
+        roundtrip!(unique, OP_0NOTEQUAL);
+        roundtrip!(unique, OP_ADD);
+        roundtrip!(unique, OP_SUB);
+        roundtrip!(unique, OP_MUL);
+        roundtrip!(unique, OP_DIV);
+        roundtrip!(unique, OP_MOD);
+        roundtrip!(unique, OP_LSHIFT);
+        roundtrip!(unique, OP_RSHIFT);
+        roundtrip!(unique, OP_BOOLAND);
+        roundtrip!(unique, OP_BOOLOR);
+        roundtrip!(unique, OP_NUMEQUAL);
+        roundtrip!(unique, OP_NUMEQUALVERIFY);
+        roundtrip!(unique, OP_NUMNOTEQUAL);
+        roundtrip!(unique, OP_LESSTHAN);
+        roundtrip!(unique, OP_GREATERTHAN);
+        roundtrip!(unique, OP_LESSTHANOREQUAL);
+        roundtrip!(unique, OP_GREATERTHANOREQUAL);
+        roundtrip!(unique, OP_MIN);
+        roundtrip!(unique, OP_MAX);
+        roundtrip!(unique, OP_WITHIN);
+        roundtrip!(unique, OP_RIPEMD160);
+        roundtrip!(unique, OP_SHA1);
+        roundtrip!(unique, OP_SHA256);
+        roundtrip!(unique, OP_HASH160);
+        roundtrip!(unique, OP_HASH256);
+        roundtrip!(unique, OP_CODESEPARATOR);
+        roundtrip!(unique, OP_CHECKSIG);
+        roundtrip!(unique, OP_CHECKSIGVERIFY);
+        roundtrip!(unique, OP_CHECKMULTISIG);
+        roundtrip!(unique, OP_CHECKMULTISIGVERIFY);
+        roundtrip!(unique, OP_NOP1);
+        roundtrip!(unique, OP_CLTV);
+        roundtrip!(unique, OP_CSV);
+        roundtrip!(unique, OP_NOP4);
+        roundtrip!(unique, OP_NOP5);
+        roundtrip!(unique, OP_NOP6);
+        roundtrip!(unique, OP_NOP7);
+        roundtrip!(unique, OP_NOP8);
+        roundtrip!(unique, OP_NOP9);
+        roundtrip!(unique, OP_NOP10);
+        roundtrip!(unique, OP_CHECKSIGADD);
+        roundtrip!(unique, OP_RETURN_187);
+        roundtrip!(unique, OP_RETURN_188);
+        roundtrip!(unique, OP_RETURN_189);
+        roundtrip!(unique, OP_RETURN_190);
+        roundtrip!(unique, OP_RETURN_191);
+        roundtrip!(unique, OP_RETURN_192);
+        roundtrip!(unique, OP_RETURN_193);
+        roundtrip!(unique, OP_RETURN_194);
+        roundtrip!(unique, OP_RETURN_195);
+        roundtrip!(unique, OP_RETURN_196);
+        roundtrip!(unique, OP_RETURN_197);
+        roundtrip!(unique, OP_RETURN_198);
+        roundtrip!(unique, OP_RETURN_199);
+        roundtrip!(unique, OP_RETURN_200);
+        roundtrip!(unique, OP_RETURN_201);
+        roundtrip!(unique, OP_RETURN_202);
+        roundtrip!(unique, OP_RETURN_203);
+        roundtrip!(unique, OP_RETURN_204);
+        roundtrip!(unique, OP_RETURN_205);
+        roundtrip!(unique, OP_RETURN_206);
+        roundtrip!(unique, OP_RETURN_207);
+        roundtrip!(unique, OP_RETURN_208);
+        roundtrip!(unique, OP_RETURN_209);
+        roundtrip!(unique, OP_RETURN_210);
+        roundtrip!(unique, OP_RETURN_211);
+        roundtrip!(unique, OP_RETURN_212);
+        roundtrip!(unique, OP_RETURN_213);
+        roundtrip!(unique, OP_RETURN_214);
+        roundtrip!(unique, OP_RETURN_215);
+        roundtrip!(unique, OP_RETURN_216);
+        roundtrip!(unique, OP_RETURN_217);
+        roundtrip!(unique, OP_RETURN_218);
+        roundtrip!(unique, OP_RETURN_219);
+        roundtrip!(unique, OP_RETURN_220);
+        roundtrip!(unique, OP_RETURN_221);
+        roundtrip!(unique, OP_RETURN_222);
+        roundtrip!(unique, OP_RETURN_223);
+        roundtrip!(unique, OP_RETURN_224);
+        roundtrip!(unique, OP_RETURN_225);
+        roundtrip!(unique, OP_RETURN_226);
+        roundtrip!(unique, OP_RETURN_227);
+        roundtrip!(unique, OP_RETURN_228);
+        roundtrip!(unique, OP_RETURN_229);
+        roundtrip!(unique, OP_RETURN_230);
+        roundtrip!(unique, OP_RETURN_231);
+        roundtrip!(unique, OP_RETURN_232);
+        roundtrip!(unique, OP_RETURN_233);
+        roundtrip!(unique, OP_RETURN_234);
+        roundtrip!(unique, OP_RETURN_235);
+        roundtrip!(unique, OP_RETURN_236);
+        roundtrip!(unique, OP_RETURN_237);
+        roundtrip!(unique, OP_RETURN_238);
+        roundtrip!(unique, OP_RETURN_239);
+        roundtrip!(unique, OP_RETURN_240);
+        roundtrip!(unique, OP_RETURN_241);
+        roundtrip!(unique, OP_RETURN_242);
+        roundtrip!(unique, OP_RETURN_243);
+        roundtrip!(unique, OP_RETURN_244);
+        roundtrip!(unique, OP_RETURN_245);
+        roundtrip!(unique, OP_RETURN_246);
+        roundtrip!(unique, OP_RETURN_247);
+        roundtrip!(unique, OP_RETURN_248);
+        roundtrip!(unique, OP_RETURN_249);
+        roundtrip!(unique, OP_RETURN_250);
+        roundtrip!(unique, OP_RETURN_251);
+        roundtrip!(unique, OP_RETURN_252);
+        roundtrip!(unique, OP_RETURN_253);
+        roundtrip!(unique, OP_RETURN_254);
+        roundtrip!(unique, OP_INVALIDOPCODE);
+        assert_eq!(unique.len(), 256);
+    }
+}

--- a/libs/bitcoin/src/blockdata/script/borrowed.rs
+++ b/libs/bitcoin/src/blockdata/script/borrowed.rs
@@ -1,0 +1,723 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+use core::ops::{
+    Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
+
+use hashes::Hash;
+use secp256k1::{Secp256k1, Verification};
+
+use super::PushBytes;
+use crate::blockdata::fee_rate::FeeRate;
+use crate::blockdata::opcodes::all::*;
+use crate::blockdata::opcodes::{self, Opcode};
+use crate::blockdata::script::witness_version::WitnessVersion;
+use crate::blockdata::script::{
+    bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions, ScriptBuf,
+    ScriptHash, WScriptHash,
+};
+use crate::consensus::Encodable;
+use crate::key::{PublicKey, UntweakedPublicKey, WPubkeyHash};
+use crate::policy::DUST_RELAY_TX_FEE;
+use crate::prelude::*;
+use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
+
+/// Bitcoin script slice.
+///
+/// *[See also the `bitcoin::blockdata::script` module](crate::blockdata::script).*
+///
+/// `Script` is a script slice, the most primitive script type. It's usually seen in its borrowed
+/// form `&Script`. It is always encoded as a series of bytes representing the opcodes and data
+/// pushes.
+///
+/// ## Validity
+///
+/// `Script` does not have any validity invariants - it's essentially just a marked slice of
+/// bytes. This is similar to [`Path`](std::path::Path) vs [`OsStr`](std::ffi::OsStr) where they
+/// are trivially cast-able to each-other and `Path` doesn't guarantee being a usable FS path but
+/// having a newtype still has value because of added methods, readability and basic type checking.
+///
+/// Although at least data pushes could be checked not to overflow the script, bad scripts are
+/// allowed to be in a transaction (outputs just become unspendable) and there even are such
+/// transactions in the chain. Thus we must allow such scripts to be placed in the transaction.
+///
+/// ## Slicing safety
+///
+/// Slicing is similar to how `str` works: some ranges may be incorrect and indexing by
+/// `usize` is not supported. However, as opposed to `std`, we have no way of checking
+/// correctness without causing linear complexity so there are **no panics on invalid
+/// ranges!** If you supply an invalid range, you'll get a garbled script.
+///
+/// The range is considered valid if it's at a boundary of instruction. Care must be taken
+/// especially with push operations because you could get a reference to arbitrary
+/// attacker-supplied bytes that look like a valid script.
+///
+/// It is recommended to use `.instructions()` method to get an iterator over script
+/// instructions and work with that instead.
+///
+/// ## Memory safety
+///
+/// The type is `#[repr(transparent)]` for internal purposes only!
+/// No consumer crate may rely on the representation of the struct!
+///
+/// ## References
+///
+///
+/// ### Bitcoin Core References
+///
+/// * [CScript definition](https://github.com/bitcoin/bitcoin/blob/d492dc1cdaabdc52b0766bf4cba4bd73178325d0/src/script/script.h#L410)
+///
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct Script(pub(in crate::blockdata::script) [u8]);
+
+impl ToOwned for Script {
+    type Owned = ScriptBuf;
+
+    fn to_owned(&self) -> Self::Owned { ScriptBuf(self.0.to_owned()) }
+}
+
+impl Script {
+    /// Creates a new empty script.
+    #[inline]
+    pub fn new() -> &'static Script { Script::from_bytes(&[]) }
+
+    /// Treat byte slice as `Script`
+    #[inline]
+    pub fn from_bytes(bytes: &[u8]) -> &Script {
+        // SAFETY: copied from `std`
+        // The pointer was just created from a reference which is still alive.
+        // Casting slice pointer to a transparent struct wrapping that slice is sound (same
+        // layout).
+        unsafe { &*(bytes as *const [u8] as *const Script) }
+    }
+
+    /// Treat mutable byte slice as `Script`
+    #[inline]
+    pub fn from_bytes_mut(bytes: &mut [u8]) -> &mut Script {
+        // SAFETY: copied from `std`
+        // The pointer was just created from a reference which is still alive.
+        // Casting slice pointer to a transparent struct wrapping that slice is sound (same
+        // layout).
+        // Function signature prevents callers from accessing `bytes` while the returned reference
+        // is alive.
+        unsafe { &mut *(bytes as *mut [u8] as *mut Script) }
+    }
+
+    /// Returns the script data as a byte slice.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] { &self.0 }
+
+    /// Returns the script data as a mutable byte slice.
+    #[inline]
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
+
+    /// Creates a new script builder
+    pub fn builder() -> Builder { Builder::new() }
+
+    /// Returns 160-bit hash of the script.
+    #[inline]
+    pub fn script_hash(&self) -> ScriptHash { ScriptHash::hash(self.as_bytes()) }
+
+    /// Returns 256-bit hash of the script for P2WSH outputs.
+    #[inline]
+    pub fn wscript_hash(&self) -> WScriptHash { WScriptHash::hash(self.as_bytes()) }
+
+    /// Computes leaf hash of tapscript.
+    #[inline]
+    pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
+        TapLeafHash::from_script(self, LeafVersion::TapScript)
+    }
+
+    /// Returns the length in bytes of the script.
+    #[inline]
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Returns whether the script is the empty script.
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Returns a copy of the script data.
+    #[inline]
+    pub fn to_bytes(&self) -> Vec<u8> { self.0.to_owned() }
+
+    /// Returns an iterator over script bytes.
+    #[inline]
+    pub fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
+
+    /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
+    /// script").
+    #[inline]
+    pub fn to_p2wsh(&self) -> ScriptBuf { ScriptBuf::new_p2wsh(&self.wscript_hash()) }
+
+    /// Computes P2TR output with a given internal key and a single script spending path equal to
+    /// the current script, assuming that the script is a Tapscript.
+    #[inline]
+    pub fn to_p2tr<C: Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+    ) -> ScriptBuf {
+        let leaf_hash = self.tapscript_leaf_hash();
+        let merkle_root = TapNodeHash::from(leaf_hash);
+        ScriptBuf::new_p2tr(secp, internal_key, Some(merkle_root))
+    }
+
+    /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
+    ///
+    /// # Returns
+    ///
+    /// The witness version if this script is found to conform to the SegWit rules:
+    ///
+    /// > A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
+    /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
+    /// > special meaning. The value of the first push is called the "version byte". The following
+    /// > byte vector pushed is called the "witness program".
+    #[inline]
+    pub fn witness_version(&self) -> Option<WitnessVersion> {
+        let script_len = self.0.len();
+        if !(4..=42).contains(&script_len) {
+            return None;
+        }
+
+        let ver_opcode = Opcode::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
+        let push_opbyte = self.0[1]; // Second byte push opcode 2-40 bytes
+
+        if push_opbyte < OP_PUSHBYTES_2.to_u8() || push_opbyte > OP_PUSHBYTES_40.to_u8() {
+            return None;
+        }
+        // Check that the rest of the script has the correct size
+        if script_len - 2 != push_opbyte as usize {
+            return None;
+        }
+
+        WitnessVersion::try_from(ver_opcode).ok()
+    }
+
+    /// Checks whether a script pubkey is a P2SH output.
+    #[inline]
+    pub fn is_p2sh(&self) -> bool {
+        self.0.len() == 23
+            && self.0[0] == OP_HASH160.to_u8()
+            && self.0[1] == OP_PUSHBYTES_20.to_u8()
+            && self.0[22] == OP_EQUAL.to_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2PKH output.
+    #[inline]
+    pub fn is_p2pkh(&self) -> bool {
+        self.0.len() == 25
+            && self.0[0] == OP_DUP.to_u8()
+            && self.0[1] == OP_HASH160.to_u8()
+            && self.0[2] == OP_PUSHBYTES_20.to_u8()
+            && self.0[23] == OP_EQUALVERIFY.to_u8()
+            && self.0[24] == OP_CHECKSIG.to_u8()
+    }
+
+    /// Checks whether a script is push only.
+    ///
+    /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
+    /// are considered push operations.
+    #[inline]
+    pub fn is_push_only(&self) -> bool {
+        for inst in self.instructions() {
+            match inst {
+                Err(_) => return false,
+                Ok(Instruction::PushBytes(_)) => {}
+                Ok(Instruction::Op(op)) if op.to_u8() <= 0x60 => {}
+                // From Bitcoin Core
+                // if (opcode > OP_PUSHNUM_16 (0x60)) return false
+                Ok(Instruction::Op(_)) => return false,
+            }
+        }
+        true
+    }
+
+    /// Checks whether a script pubkey is a P2PK output.
+    ///
+    /// You can obtain the public key, if its valid,
+    /// by calling [`p2pk_public_key()`](Self::p2pk_public_key)
+    #[inline]
+    pub fn is_p2pk(&self) -> bool { self.p2pk_pubkey_bytes().is_some() }
+
+    /// Returns the public key if this script is P2PK with a **valid** public key.
+    ///
+    /// This may return `None` even when [`is_p2pk()`](Self::is_p2pk) returns true.
+    /// This happens when the public key is invalid (e.g. the point not being on the curve).
+    /// In this situation the script is unspendable.
+    #[inline]
+    pub fn p2pk_public_key(&self) -> Option<PublicKey> {
+        PublicKey::from_slice(self.p2pk_pubkey_bytes()?).ok()
+    }
+
+    /// Returns the bytes of the (possibly invalid) public key if this script is P2PK.
+    #[inline]
+    pub(in crate::blockdata::script) fn p2pk_pubkey_bytes(&self) -> Option<&[u8]> {
+        match self.len() {
+            67 if self.0[0] == OP_PUSHBYTES_65.to_u8() && self.0[66] == OP_CHECKSIG.to_u8() =>
+                Some(&self.0[1..66]),
+            35 if self.0[0] == OP_PUSHBYTES_33.to_u8() && self.0[34] == OP_CHECKSIG.to_u8() =>
+                Some(&self.0[1..34]),
+            _ => None,
+        }
+    }
+
+    /// Checks whether a script pubkey is a bare multisig output.
+    ///
+    /// In a bare multisig pubkey script the keys are not hashed, the script
+    /// is of the form:
+    ///
+    ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
+    #[inline]
+    pub fn is_multisig(&self) -> bool {
+        let required_sigs;
+
+        let mut instructions = self.instructions();
+        if let Some(Ok(Instruction::Op(op))) = instructions.next() {
+            if let Some(pushnum) = op.decode_pushnum() {
+                required_sigs = pushnum;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        let mut num_pubkeys: u8 = 0;
+        while let Some(Ok(instruction)) = instructions.next() {
+            match instruction {
+                Instruction::PushBytes(_) => {
+                    num_pubkeys += 1;
+                }
+                Instruction::Op(op) => {
+                    if let Some(pushnum) = op.decode_pushnum() {
+                        if pushnum != num_pubkeys {
+                            return false;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        if required_sigs > num_pubkeys {
+            return false;
+        }
+
+        if let Some(Ok(Instruction::Op(op))) = instructions.next() {
+            if op != OP_CHECKMULTISIG {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        instructions.next().is_none()
+    }
+
+    /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
+    #[inline]
+    pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
+
+    /// Checks whether a script pubkey is a P2WSH output.
+    #[inline]
+    pub fn is_p2wsh(&self) -> bool {
+        self.0.len() == 34
+            && self.witness_version() == Some(WitnessVersion::V0)
+            && self.0[1] == OP_PUSHBYTES_32.to_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2WPKH output.
+    #[inline]
+    pub fn is_p2wpkh(&self) -> bool {
+        self.0.len() == 22
+            && self.witness_version() == Some(WitnessVersion::V0)
+            && self.0[1] == OP_PUSHBYTES_20.to_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2TR output.
+    #[inline]
+    pub fn is_p2tr(&self) -> bool {
+        self.0.len() == 34
+            && self.witness_version() == Some(WitnessVersion::V1)
+            && self.0[1] == OP_PUSHBYTES_32.to_u8()
+    }
+
+    /// Check if this is an OP_RETURN output.
+    #[inline]
+    pub fn is_op_return(&self) -> bool {
+        match self.0.first() {
+            Some(b) => *b == OP_RETURN.to_u8(),
+            None => false,
+        }
+    }
+
+    /// Checks whether a script is trivially known to have no satisfying input.
+    ///
+    /// This method has potentially confusing semantics and an unclear purpose, so it's going to be
+    /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
+    #[deprecated(
+        since = "0.32.0",
+        note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
+    )]
+    #[inline]
+    pub fn is_provably_unspendable(&self) -> bool {
+        use crate::blockdata::opcodes::Class::{IllegalOp, ReturnOp};
+
+        match self.0.first() {
+            Some(b) => {
+                let first = Opcode::from(*b);
+                let class = first.classify(opcodes::ClassifyContext::Legacy);
+
+                class == ReturnOp || class == IllegalOp
+            }
+            None => false,
+        }
+    }
+
+    /// Computes the P2SH output corresponding to this redeem script.
+    pub fn to_p2sh(&self) -> ScriptBuf { ScriptBuf::new_p2sh(&self.script_hash()) }
+
+    /// Returns the script code used for spending a P2WPKH output if this script is a script pubkey
+    /// for a P2WPKH output. The `scriptCode` is described in [BIP143].
+    ///
+    /// [BIP143]: <https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki>
+    pub fn p2wpkh_script_code(&self) -> Option<ScriptBuf> {
+        if self.is_p2wpkh() {
+            // The `self` script is 0x00, 0x14, <pubkey_hash>
+            let bytes = &self.0[2..];
+            let wpkh = WPubkeyHash::from_slice(bytes).expect("length checked in is_p2wpkh()");
+            Some(ScriptBuf::p2wpkh_script_code(wpkh))
+        } else {
+            None
+        }
+    }
+
+    /// Get redeemScript following BIP16 rules regarding P2SH spending.
+    ///
+    /// This does not guarantee that this represents a P2SH input [`Script`].
+    /// It merely gets the last push of the script. Use
+    /// [`Script::is_p2sh`](crate::blockdata::script::Script::is_p2sh) on the
+    /// scriptPubKey to check whether it is actually a P2SH script.
+    pub fn redeem_script(&self) -> Option<&Script> {
+        // Script must consist entirely of pushes.
+        if self.instructions().any(|i| i.is_err() || i.unwrap().push_bytes().is_none()) {
+            return None;
+        }
+
+        if let Some(Ok(Instruction::PushBytes(b))) = self.instructions().last() {
+            Some(Script::from_bytes(b.as_bytes()))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the minimum value an output with this script should have in order to be
+    /// broadcastable on today’s Bitcoin network.
+    #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
+    pub fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
+
+    /// Returns the minimum value an output with this script should have in order to be
+    /// broadcastable on today's Bitcoin network.
+    ///
+    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+    /// This function uses the default value of 0.00003 BTC/kB (3 sat/vByte).
+    ///
+    /// To use a custom value, use [`minimal_non_dust_custom`].
+    ///
+    /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
+    pub fn minimal_non_dust(&self) -> crate::Amount {
+        self.minimal_non_dust_inner(DUST_RELAY_TX_FEE.into())
+    }
+
+    /// Returns the minimum value an output with this script should have in order to be
+    /// broadcastable on today's Bitcoin network.
+    ///
+    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+    /// This function lets you set the fee rate used in dust calculation.
+    ///
+    /// The current default value in Bitcoin Core (as of v26) is 3 sat/vByte.
+    ///
+    /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
+    ///
+    /// [`minimal_non_dust`]: Script::minimal_non_dust
+    pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
+        self.minimal_non_dust_inner(dust_relay_fee.to_sat_per_kwu() * 4)
+    }
+
+    fn minimal_non_dust_inner(&self, dust_relay_fee: u64) -> crate::Amount {
+        // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
+        // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
+        let sats = dust_relay_fee
+            .checked_mul(if self.is_op_return() {
+                0
+            } else if self.is_witness_program() {
+                32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
+                    8 + // The serialized size of the TxOut's amount field
+                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+            } else {
+                32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
+                    8 + // The serialized size of the TxOut's amount field
+                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+            })
+            .expect("dust_relay_fee or script length should not be absurdly large")
+            / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
+                    // Note: We ensure the division happens at the end, since Core performs the division at the end.
+                    //       This will make sure none of the implicit floor operations mess with the value.
+
+        crate::Amount::from_sat(sats)
+    }
+
+    /// Counts the sigops for this Script using accurate counting.
+    ///
+    /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".
+    /// This method uses "accurate" counting. This means that OP_CHECKMULTISIG and its
+    /// verify variant count for N sigops where N is the number of pubkeys used in the
+    /// multisig. However, it will count for 20 sigops if CHECKMULTISIG is not preceded by an
+    /// OP_PUSHNUM from 1 - 16 (this would be an invalid script)
+    ///
+    /// Bitcoin Core uses accurate counting for sigops contained within redeemScripts (P2SH)
+    /// and witnessScripts (P2WSH) only. It uses legacy for sigops in scriptSigs and scriptPubkeys.
+    ///
+    /// (Note: taproot scripts don't count toward the sigop count of the block,
+    /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
+    /// so do not use this to try and estimate if a taproot script goes over the sigop budget.)
+    pub fn count_sigops(&self) -> usize { self.count_sigops_internal(true) }
+
+    /// Counts the sigops for this Script using legacy counting.
+    ///
+    /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".
+    /// This method uses "legacy" counting. This means that OP_CHECKMULTISIG and its
+    /// verify variant count for 20 sigops.
+    ///
+    /// Bitcoin Core uses legacy counting for sigops contained within scriptSigs and
+    /// scriptPubkeys. It uses accurate for redeemScripts (P2SH) and witnessScripts (P2WSH).
+    ///
+    /// (Note: taproot scripts don't count toward the sigop count of the block,
+    /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
+    /// so do not use this to try and estimate if a taproot script goes over the sigop budget.)
+    pub fn count_sigops_legacy(&self) -> usize { self.count_sigops_internal(false) }
+
+    fn count_sigops_internal(&self, accurate: bool) -> usize {
+        let mut n = 0;
+        let mut pushnum_cache = None;
+        for inst in self.instructions() {
+            match inst {
+                Ok(Instruction::Op(opcode)) => {
+                    match opcode {
+                        // p2pk, p2pkh
+                        OP_CHECKSIG | OP_CHECKSIGVERIFY => {
+                            n += 1;
+                        }
+                        OP_CHECKMULTISIG | OP_CHECKMULTISIGVERIFY => {
+                            match (accurate, pushnum_cache) {
+                                (true, Some(pushnum)) => {
+                                    // Add the number of pubkeys in the multisig as sigop count
+                                    n += usize::from(pushnum);
+                                }
+                                _ => {
+                                    // MAX_PUBKEYS_PER_MULTISIG from Bitcoin Core
+                                    // https://github.com/bitcoin/bitcoin/blob/v25.0/src/script/script.h#L29-L30
+                                    n += 20;
+                                }
+                            }
+                        }
+                        _ => {
+                            pushnum_cache = opcode.decode_pushnum();
+                        }
+                    }
+                }
+                Ok(Instruction::PushBytes(_)) => {
+                    pushnum_cache = None;
+                }
+                // In Bitcoin Core it does `if (!GetOp(pc, opcode)) break;`
+                Err(_) => break,
+            }
+        }
+
+        n
+    }
+
+    /// Iterates over the script instructions.
+    ///
+    /// Each returned item is a nested enum covering opcodes, datapushes and errors.
+    /// At most one error will be returned and then the iterator will end. To instead iterate over
+    /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
+    ///
+    /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
+    #[inline]
+    pub fn instructions(&self) -> Instructions {
+        Instructions { data: self.0.iter(), enforce_minimal: false }
+    }
+
+    /// Iterates over the script instructions while enforcing minimal pushes.
+    ///
+    /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
+    /// is not minimal.
+    #[inline]
+    pub fn instructions_minimal(&self) -> Instructions {
+        Instructions { data: self.0.iter(), enforce_minimal: true }
+    }
+
+    /// Iterates over the script instructions and their indices.
+    ///
+    /// Unless the script contains an error, the returned item consists of an index pointing to the
+    /// position in the script where the instruction begins and the decoded instruction - either an
+    /// opcode or data push.
+    ///
+    /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
+    #[inline]
+    pub fn instruction_indices(&self) -> InstructionIndices {
+        InstructionIndices::from_instructions(self.instructions())
+    }
+
+    /// Iterates over the script instructions and their indices while enforcing minimal pushes.
+    ///
+    /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
+    /// returned if a push is not minimal.
+    #[inline]
+    pub fn instruction_indices_minimal(&self) -> InstructionIndices {
+        InstructionIndices::from_instructions(self.instructions_minimal())
+    }
+
+    /// Writes the human-readable assembly representation of the script to the formatter.
+    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+        bytes_to_asm_fmt(self.as_ref(), f)
+    }
+
+    /// Returns the human-readable assembly representation of the script.
+    pub fn to_asm_string(&self) -> String {
+        let mut buf = String::new();
+        self.fmt_asm(&mut buf).unwrap();
+        buf
+    }
+
+    /// Formats the script as lower-case hex.
+    ///
+    /// This is a more convenient and performant way to write `format!("{:x}", script)`.
+    /// For better performance you should generally prefer displaying the script but if `String` is
+    /// required (this is common in tests) this method can be used.
+    pub fn to_hex_string(&self) -> String { self.as_bytes().to_lower_hex_string() }
+
+    /// Returns the first opcode of the script (if there is any).
+    pub fn first_opcode(&self) -> Option<Opcode> {
+        self.as_bytes().first().copied().map(From::from)
+    }
+
+    /// Iterates the script to find the last opcode.
+    ///
+    /// Returns `None` is the instruction is data push or if the script is empty.
+    pub(in crate::blockdata::script) fn last_opcode(&self) -> Option<Opcode> {
+        match self.instructions().last() {
+            Some(Ok(Instruction::Op(op))) => Some(op),
+            _ => None,
+        }
+    }
+
+    /// Iterates the script to find the last pushdata.
+    ///
+    /// Returns `None` if the instruction is an opcode or if the script is empty.
+    pub(crate) fn last_pushdata(&self) -> Option<&PushBytes> {
+        match self.instructions().last() {
+            // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
+            Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
+            // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
+            // However we are only interested in the pushdata so we can ignore them.
+            _ => None,
+        }
+    }
+
+    /// Converts a [`Box<Script>`](Box) into a [`ScriptBuf`] without copying or allocating.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn into_script_buf(self: Box<Self>) -> ScriptBuf {
+        let rw = Box::into_raw(self) as *mut [u8];
+        // SAFETY: copied from `std`
+        // The pointer was just created from a box without deallocating
+        // Casting a transparent struct wrapping a slice to the slice pointer is sound (same
+        // layout).
+        let inner = unsafe { Box::from_raw(rw) };
+        ScriptBuf(Vec::from(inner))
+    }
+}
+
+/// Iterator over bytes of a script
+pub struct Bytes<'a>(core::iter::Copied<core::slice::Iter<'a, u8>>);
+
+impl Iterator for Bytes<'_> {
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) { self.0.size_hint() }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> { self.0.nth(n) }
+}
+
+impl DoubleEndedIterator for Bytes<'_> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> { self.0.next_back() }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> { self.0.nth_back(n) }
+}
+
+impl ExactSizeIterator for Bytes<'_> {}
+impl core::iter::FusedIterator for Bytes<'_> {}
+
+macro_rules! delegate_index {
+    ($($type:ty),* $(,)?) => {
+        $(
+            /// Script subslicing operation - read [slicing safety](#slicing-safety)!
+            impl Index<$type> for Script {
+                type Output = Self;
+
+                #[inline]
+                fn index(&self, index: $type) -> &Self::Output {
+                    Self::from_bytes(&self.0[index])
+                }
+            }
+        )*
+    }
+}
+
+delegate_index!(
+    Range<usize>,
+    RangeFrom<usize>,
+    RangeTo<usize>,
+    RangeFull,
+    RangeInclusive<usize>,
+    RangeToInclusive<usize>,
+    (Bound<usize>, Bound<usize>)
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blockdata::script::witness_program::WitnessProgram;
+
+    #[test]
+    fn shortest_witness_program() {
+        let bytes = [0x00; 2]; // Arbitrary bytes, witprog must be between 2 and 40.
+        let version = WitnessVersion::V15; // Arbitrary version number, intentionally not 0 or 1.
+
+        let p = WitnessProgram::new(version, &bytes).expect("failed to create witness program");
+        let script = ScriptBuf::new_witness_program(&p);
+
+        assert_eq!(script.witness_version(), Some(version));
+    }
+
+    #[test]
+    fn longest_witness_program() {
+        let bytes = [0x00; 40]; // Arbitrary bytes, witprog must be between 2 and 40.
+        let version = WitnessVersion::V16; // Arbitrary version number, intentionally not 0 or 1.
+
+        let p = WitnessProgram::new(version, &bytes).expect("failed to create witness program");
+        let script = ScriptBuf::new_witness_program(&p);
+
+        assert_eq!(script.witness_version(), Some(version));
+    }
+}

--- a/libs/bitcoin/src/blockdata/script/builder.rs
+++ b/libs/bitcoin/src/blockdata/script/builder.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use secp256k1::XOnlyPublicKey;
+
+use crate::blockdata::locktime::absolute;
+use crate::blockdata::opcodes::all::*;
+use crate::blockdata::opcodes::{self, Opcode};
+use crate::blockdata::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
+use crate::blockdata::transaction::Sequence;
+use crate::key::PublicKey;
+use crate::prelude::*;
+
+/// An Object which can be used to construct a script piece by piece.
+#[derive(PartialEq, Eq, Clone)]
+pub struct Builder(ScriptBuf, Option<Opcode>);
+
+impl Builder {
+    /// Creates a new empty script.
+    #[inline]
+    pub const fn new() -> Self { Builder(ScriptBuf::new(), None) }
+
+    /// Returns the length in bytes of the script.
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Checks whether the script is the empty script.
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Adds instructions to push an integer onto the stack.
+    ///
+    /// Integers are encoded as little-endian signed-magnitude numbers, but there are dedicated
+    /// opcodes to push some small integers.
+    pub fn push_int(self, data: i64) -> Builder {
+        // We can special-case -1, 1-16
+        if data == -1 || (1..=16).contains(&data) {
+            let opcode = Opcode::from((data - 1 + opcodes::OP_TRUE.to_u8() as i64) as u8);
+            self.push_opcode(opcode)
+        }
+        // We can also special-case zero
+        else if data == 0 {
+            self.push_opcode(opcodes::OP_0)
+        }
+        // Otherwise encode it as data
+        else {
+            self.push_int_non_minimal(data)
+        }
+    }
+
+    /// Adds instructions to push an integer onto the stack without optimization.
+    ///
+    /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
+    pub(in crate::blockdata) fn push_int_non_minimal(self, data: i64) -> Builder {
+        let mut buf = [0u8; 8];
+        let len = write_scriptint(&mut buf, data);
+        self.push_slice(&<&PushBytes>::from(&buf)[..len])
+    }
+
+    /// Adds instructions to push some arbitrary data onto the stack.
+    pub fn push_slice<T: AsRef<PushBytes>>(mut self, data: T) -> Builder {
+        self.0.push_slice(data);
+        self.1 = None;
+        self
+    }
+
+    /// Adds instructions to push a public key onto the stack.
+    pub fn push_key(self, key: &PublicKey) -> Builder {
+        if key.compressed {
+            self.push_slice(key.inner.serialize())
+        } else {
+            self.push_slice(key.inner.serialize_uncompressed())
+        }
+    }
+
+    /// Adds instructions to push an XOnly public key onto the stack.
+    pub fn push_x_only_key(self, x_only_key: &XOnlyPublicKey) -> Builder {
+        self.push_slice(x_only_key.serialize())
+    }
+
+    /// Adds a single opcode to the script.
+    pub fn push_opcode(mut self, data: Opcode) -> Builder {
+        self.0.push_opcode(data);
+        self.1 = Some(data);
+        self
+    }
+
+    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
+    ///
+    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
+    /// in the script right after. To save space this function appends `VERIFY` only if
+    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
+    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    ///
+    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
+    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
+    /// semantics.
+    pub fn push_verify(mut self) -> Builder {
+        // "duplicated code" because we need to update `1` field
+        match opcode_to_verify(self.1) {
+            Some(opcode) => {
+                (self.0).0.pop();
+                self.push_opcode(opcode)
+            }
+            None => self.push_opcode(OP_VERIFY),
+        }
+    }
+
+    /// Adds instructions to push an absolute lock time onto the stack.
+    pub fn push_lock_time(self, lock_time: absolute::LockTime) -> Builder {
+        self.push_int(lock_time.to_consensus_u32().into())
+    }
+
+    /// Adds instructions to push a sequence number onto the stack.
+    pub fn push_sequence(self, sequence: Sequence) -> Builder {
+        self.push_int(sequence.to_consensus_u32().into())
+    }
+
+    /// Converts the `Builder` into `ScriptBuf`.
+    pub fn into_script(self) -> ScriptBuf { self.0 }
+
+    /// Converts the `Builder` into script bytes
+    pub fn into_bytes(self) -> Vec<u8> { self.0.into() }
+
+    /// Returns the internal script
+    pub fn as_script(&self) -> &Script { &self.0 }
+
+    /// Returns script bytes
+    pub fn as_bytes(&self) -> &[u8] { self.0.as_bytes() }
+}
+
+impl Default for Builder {
+    fn default() -> Builder { Builder::new() }
+}
+
+/// Creates a new builder from an existing vector.
+impl From<Vec<u8>> for Builder {
+    fn from(v: Vec<u8>) -> Builder {
+        let script = ScriptBuf::from(v);
+        let last_op = script.last_opcode();
+        Builder(script, last_op)
+    }
+}
+
+impl fmt::Display for Builder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt_asm(f) }
+}
+
+internals::debug_from_display!(Builder);

--- a/libs/bitcoin/src/blockdata/script/instruction.rs
+++ b/libs/bitcoin/src/blockdata/script/instruction.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use crate::blockdata::opcodes::{self, Opcode};
+use crate::blockdata::script::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
+
+/// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum Instruction<'a> {
+    /// Push a bunch of data.
+    PushBytes(&'a PushBytes),
+    /// Some non-push opcode.
+    Op(Opcode),
+}
+
+impl<'a> Instruction<'a> {
+    /// Returns the opcode if the instruction is not a data push.
+    pub fn opcode(&self) -> Option<Opcode> {
+        match self {
+            Instruction::Op(op) => Some(*op),
+            Instruction::PushBytes(_) => None,
+        }
+    }
+
+    /// Returns the pushed bytes if the instruction is a data push.
+    pub fn push_bytes(&self) -> Option<&PushBytes> {
+        match self {
+            Instruction::Op(_) => None,
+            Instruction::PushBytes(bytes) => Some(bytes),
+        }
+    }
+
+    /// Returns the number interpretted by the script parser
+    /// if it can be coerced into a number.
+    ///
+    /// This does not require the script num to be minimal.
+    pub fn script_num(&self) -> Option<i64> {
+        match self {
+            Instruction::Op(op) => {
+                let v = op.to_u8();
+                match v {
+                    // OP_PUSHNUM_1 ..= OP_PUSHNUM_16
+                    0x51..=0x60 => Some(v as i64 - 0x50),
+                    // OP_PUSHNUM_NEG1
+                    0x4f => Some(-1),
+                    _ => None,
+                }
+            }
+            Instruction::PushBytes(bytes) => {
+                match super::read_scriptint_non_minimal(bytes.as_bytes()) {
+                    Ok(v) => Some(v),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Returns the number of bytes required to encode the instruction in script.
+    pub(super) fn script_serialized_len(&self) -> usize {
+        match self {
+            Instruction::Op(_) => 1,
+            Instruction::PushBytes(bytes) => ScriptBuf::reserved_len_for_slice(bytes.len()),
+        }
+    }
+}
+
+/// Iterator over a script returning parsed opcodes.
+#[derive(Debug, Clone)]
+pub struct Instructions<'a> {
+    pub(crate) data: core::slice::Iter<'a, u8>,
+    pub(crate) enforce_minimal: bool,
+}
+
+impl<'a> Instructions<'a> {
+    /// Views the remaining script as a slice.
+    ///
+    /// This is analogous to what [`core::str::Chars::as_str`] does.
+    pub fn as_script(&self) -> &'a Script { Script::from_bytes(self.data.as_slice()) }
+
+    /// Sets the iterator to end so that it won't iterate any longer.
+    pub(super) fn kill(&mut self) {
+        let len = self.data.len();
+        self.data.nth(len.max(1) - 1);
+    }
+
+    /// Takes a `len` bytes long slice from iterator and returns it, advancing the iterator.
+    ///
+    /// If the iterator is not long enough [`Error::EarlyEndOfScript`] is returned and the iterator
+    /// is killed to avoid returning an infinite stream of errors.
+    pub(super) fn take_slice_or_kill(&mut self, len: u32) -> Result<&'a PushBytes, Error> {
+        let len = len as usize;
+        if self.data.len() >= len {
+            let slice = &self.data.as_slice()[..len];
+            if len > 0 {
+                self.data.nth(len - 1);
+            }
+
+            Ok(slice.try_into().expect("len was created from u32, so can't happen"))
+        } else {
+            self.kill();
+            Err(Error::EarlyEndOfScript)
+        }
+    }
+
+    pub(super) fn next_push_data_len(
+        &mut self,
+        len: PushDataLenLen,
+        min_push_len: usize,
+    ) -> Option<Result<Instruction<'a>, Error>> {
+        let n = match read_uint_iter(&mut self.data, len as usize) {
+            Ok(n) => n,
+            // We do exhaustive matching to not forget to handle new variants if we extend
+            // `UintError` type.
+            // Overflow actually means early end of script (script is definitely shorter
+            // than `usize::MAX`)
+            Err(UintError::EarlyEndOfScript) | Err(UintError::NumericOverflow) => {
+                self.kill();
+                return Some(Err(Error::EarlyEndOfScript));
+            }
+        };
+        if self.enforce_minimal && n < min_push_len {
+            self.kill();
+            return Some(Err(Error::NonMinimalPush));
+        }
+        let result = n
+            .try_into()
+            .map_err(|_| Error::NumericOverflow)
+            .and_then(|n| self.take_slice_or_kill(n))
+            .map(Instruction::PushBytes);
+        Some(result)
+    }
+}
+
+/// Allowed length of push data length.
+///
+/// This makes it easier to prove correctness of `next_push_data_len`.
+pub(super) enum PushDataLenLen {
+    One = 1,
+    Two = 2,
+    Four = 4,
+}
+
+impl<'a> Iterator for Instructions<'a> {
+    type Item = Result<Instruction<'a>, Error>;
+
+    fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
+        let &byte = self.data.next()?;
+
+        // classify parameter does not really matter here since we are only using
+        // it for pushes and nums
+        match Opcode::from(byte).classify(opcodes::ClassifyContext::Legacy) {
+            opcodes::Class::PushBytes(n) => {
+                // make sure safety argument holds across refactorings
+                let n: u32 = n;
+
+                let op_byte = self.data.as_slice().first();
+                match (self.enforce_minimal, op_byte, n) {
+                    (true, Some(&op_byte), 1)
+                        if op_byte == 0x81 || (op_byte > 0 && op_byte <= 16) =>
+                    {
+                        self.kill();
+                        Some(Err(Error::NonMinimalPush))
+                    }
+                    (_, None, 0) => {
+                        // the iterator is already empty, may as well use this information to avoid
+                        // whole take_slice_or_kill function
+                        Some(Ok(Instruction::PushBytes(PushBytes::empty())))
+                    }
+                    _ => Some(self.take_slice_or_kill(n).map(Instruction::PushBytes)),
+                }
+            }
+            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA1) =>
+                self.next_push_data_len(PushDataLenLen::One, 76),
+            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA2) =>
+                self.next_push_data_len(PushDataLenLen::Two, 0x100),
+            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA4) =>
+                self.next_push_data_len(PushDataLenLen::Four, 0x10000),
+            // Everything else we can push right through
+            _ => Some(Ok(Instruction::Op(Opcode::from(byte)))),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.data.len() == 0 {
+            (0, Some(0))
+        } else {
+            // There will not be more instructions than bytes
+            (1, Some(self.data.len()))
+        }
+    }
+}
+
+impl<'a> core::iter::FusedIterator for Instructions<'a> {}
+
+/// Iterator over script instructions with their positions.
+///
+/// The returned indices can be used for slicing [`Script`] [safely](Script#slicing-safety).
+///
+/// This is analogous to [`core::str::CharIndices`].
+#[derive(Debug, Clone)]
+pub struct InstructionIndices<'a> {
+    instructions: Instructions<'a>,
+    pos: usize,
+}
+
+impl<'a> InstructionIndices<'a> {
+    /// Views the remaining script as a slice.
+    ///
+    /// This is analogous to what [`core::str::Chars::as_str`] does.
+    #[inline]
+    pub fn as_script(&self) -> &'a Script { self.instructions.as_script() }
+
+    /// Creates `Self` setting `pos` to 0.
+    pub(super) fn from_instructions(instructions: Instructions<'a>) -> Self {
+        InstructionIndices { instructions, pos: 0 }
+    }
+
+    pub(super) fn remaining_bytes(&self) -> usize { self.instructions.as_script().len() }
+
+    /// Modifies the iterator using `next_fn` returning the next item.
+    ///
+    /// This generically computes the new position and maps the value to be returned from iterator
+    /// method.
+    pub(super) fn next_with<F: FnOnce(&mut Self) -> Option<Result<Instruction<'a>, Error>>>(
+        &mut self,
+        next_fn: F,
+    ) -> Option<<Self as Iterator>::Item> {
+        let prev_remaining = self.remaining_bytes();
+        let prev_pos = self.pos;
+        let instruction = next_fn(self)?;
+        // No underflow: there must be less remaining bytes now than previously
+        let consumed = prev_remaining - self.remaining_bytes();
+        // No overflow: sum will never exceed slice length which itself can't exceed `usize`
+        self.pos += consumed;
+        Some(instruction.map(move |instruction| (prev_pos, instruction)))
+    }
+}
+
+impl<'a> Iterator for InstructionIndices<'a> {
+    /// The `usize` in the tuple represents index at which the returned `Instruction` is located.
+    type Item = Result<(usize, Instruction<'a>), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> { self.next_with(|this| this.instructions.next()) }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) { self.instructions.size_hint() }
+
+    // the override avoids computing pos multiple times
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.next_with(|this| this.instructions.nth(n))
+    }
+}
+
+impl core::iter::FusedIterator for InstructionIndices<'_> {}

--- a/libs/bitcoin/src/blockdata/script/mod.rs
+++ b/libs/bitcoin/src/blockdata/script/mod.rs
@@ -1,0 +1,751 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin scripts.
+//!
+//! *[See also the `Script` type](Script).*
+//!
+//! This module provides the structures and functions needed to support scripts.
+//!
+//! <details>
+//! <summary>What is Bitcoin script</summary>
+//!
+//! Scripts define Bitcoin's digital signature scheme: a signature is formed
+//! from a script (the second half of which is defined by a coin to be spent,
+//! and the first half provided by the spending transaction), and is valid iff
+//! the script leaves `TRUE` on the stack after being evaluated. Bitcoin's
+//! script is a stack-based assembly language similar in spirit to [Forth].
+//!
+//! Script is represented as a sequence of bytes on the wire, each byte representing an operation,
+//! or data to be pushed on the stack.
+//!
+//! See [Bitcoin Wiki: Script][wiki-script] for more information.
+//!
+//! [Forth]: https://en.wikipedia.org/wiki/Forth_(programming_language)
+//!
+//! [wiki-script]: https://en.bitcoin.it/wiki/Script
+//! </details>
+//!
+//! In this library we chose to keep the byte representation in memory and decode opcodes only when
+//! processing the script. This is similar to Rust choosing to represent strings as UTF-8-encoded
+//! bytes rather than slice of `char`s. In both cases the individual items can have different sizes
+//! and forcing them to be larger would waste memory and, in case of Bitcoin script, even some
+//! performance (forcing allocations).
+//!
+//! ## `Script` vs `ScriptBuf` vs `Builder`
+//!
+//! These are the most important types in this module and they are quite similar, so it may seem
+//! confusing what the differences are. `Script` is an unsized type much like `str` or `Path` are
+//! and `ScriptBuf` is an owned counterpart to `Script` just like `String` is an owned counterpart
+//! to `str`.
+//!
+//! However it is common to construct an owned script and then pass it around. For this case a
+//! builder API is more convenient. To support this we provide `Builder` type which is very similar
+//! to `ScriptBuf` but its methods take `self` instead of `&mut self` and return `Self`. It also
+//! contains a cache that may make some modifications faster. This cache is usually not needed
+//! outside of creating the script.
+//!
+//! At the time of writing there's only one operation using the cache - `push_verify`, so the cache
+//! is minimal but we may extend it in the future if needed.
+
+mod borrowed;
+mod builder;
+mod instruction;
+mod owned;
+mod push_bytes;
+#[cfg(test)]
+mod tests;
+pub mod witness_program;
+pub mod witness_version;
+
+use alloc::rc::Rc;
+#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
+use core::cmp::Ordering;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+use hashes::{hash160, sha256};
+use io::{Read, Write};
+
+use crate::blockdata::opcodes::all::*;
+use crate::blockdata::opcodes::{self, Opcode};
+use crate::consensus::{encode, Decodable, Encodable};
+use crate::internal_macros::impl_asref_push_bytes;
+use crate::prelude::*;
+use crate::OutPoint;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    borrowed::*,
+    builder::*,
+    instruction::*,
+    owned::*,
+    push_bytes::*,
+};
+
+hashes::hash_newtype! {
+    /// A hash of Bitcoin Script bytecode.
+    pub struct ScriptHash(hash160::Hash);
+    /// SegWit version of a Bitcoin Script bytecode hash.
+    pub struct WScriptHash(sha256::Hash);
+}
+impl_asref_push_bytes!(ScriptHash, WScriptHash);
+
+impl From<ScriptBuf> for ScriptHash {
+    fn from(script: ScriptBuf) -> ScriptHash { script.script_hash() }
+}
+
+impl From<&ScriptBuf> for ScriptHash {
+    fn from(script: &ScriptBuf) -> ScriptHash { script.script_hash() }
+}
+
+impl From<&Script> for ScriptHash {
+    fn from(script: &Script) -> ScriptHash { script.script_hash() }
+}
+
+impl From<ScriptBuf> for WScriptHash {
+    fn from(script: ScriptBuf) -> WScriptHash { script.wscript_hash() }
+}
+
+impl From<&ScriptBuf> for WScriptHash {
+    fn from(script: &ScriptBuf) -> WScriptHash { script.wscript_hash() }
+}
+
+impl From<&Script> for WScriptHash {
+    fn from(script: &Script) -> WScriptHash { script.wscript_hash() }
+}
+
+/// Encodes an integer in script(minimal CScriptNum) format.
+///
+/// Writes bytes into the buffer and returns the number of bytes written.
+///
+/// Note that `write_scriptint`/`read_scriptint` do not roundtrip if the value written requires
+/// more than 4 bytes, this is in line with Bitcoin Core (see [`CScriptNum::serialize`]).
+///
+/// [`CScriptNum::serialize`]: <https://github.com/bitcoin/bitcoin/blob/8ae2808a4354e8dcc697f76bacc5e2f2befe9220/src/script/script.h#L345>
+pub fn write_scriptint(out: &mut [u8; 8], n: i64) -> usize {
+    let mut len = 0;
+    if n == 0 {
+        return len;
+    }
+
+    let neg = n < 0;
+
+    let mut abs = n.unsigned_abs();
+    while abs > 0xFF {
+        out[len] = (abs & 0xFF) as u8;
+        len += 1;
+        abs >>= 8;
+    }
+    // If the number's value causes the sign bit to be set, we need an extra
+    // byte to get the correct value and correct sign bit
+    if abs & 0x80 != 0 {
+        out[len] = abs as u8;
+        len += 1;
+        out[len] = if neg { 0x80u8 } else { 0u8 };
+        len += 1;
+    }
+    // Otherwise we just set the sign bit ourselves
+    else {
+        abs |= if neg { 0x80 } else { 0 };
+        out[len] = abs as u8;
+        len += 1;
+    }
+    len
+}
+
+/// Decodes an integer in script(minimal CScriptNum) format.
+///
+/// Notice that this fails on overflow: the result is the same as in
+/// bitcoind, that only 4-byte signed-magnitude values may be read as
+/// numbers. They can be added or subtracted (and a long time ago,
+/// multiplied and divided), and this may result in numbers which
+/// can't be written out in 4 bytes or less. This is ok! The number
+/// just can't be read as a number again.
+/// This is a bit crazy and subtle, but it makes sense: you can load
+/// 32-bit numbers and do anything with them, which back when mult/div
+/// was allowed, could result in up to a 64-bit number. We don't want
+/// overflow since that's surprising --- and we don't want numbers that
+/// don't fit in 64 bits (for efficiency on modern processors) so we
+/// simply say, anything in excess of 32 bits is no longer a number.
+/// This is basically a ranged type implementation.
+///
+/// This code is based on the `CScriptNum` constructor in Bitcoin Core (see `script.h`).
+pub fn read_scriptint(v: &[u8]) -> Result<i64, Error> {
+    let last = match v.last() {
+        Some(last) => last,
+        None => return Ok(0),
+    };
+    if v.len() > 4 {
+        return Err(Error::NumericOverflow);
+    }
+    // Comment and code copied from Bitcoin Core:
+    // https://github.com/bitcoin/bitcoin/blob/447f50e4aed9a8b1d80e1891cda85801aeb80b4e/src/script/script.h#L247-L262
+    // If the most-significant-byte - excluding the sign bit - is zero
+    // then we're not minimal. Note how this test also rejects the
+    // negative-zero encoding, 0x80.
+    if (*last & 0x7f) == 0 {
+        // One exception: if there's more than one byte and the most
+        // significant bit of the second-most-significant-byte is set
+        // it would conflict with the sign bit. An example of this case
+        // is +-255, which encode to 0xff00 and 0xff80 respectively.
+        // (big-endian).
+        if v.len() <= 1 || (v[v.len() - 2] & 0x80) == 0 {
+            return Err(Error::NonMinimalPush);
+        }
+    }
+
+    Ok(scriptint_parse(v))
+}
+
+/// Decodes an integer in script format without non-minimal error.
+///
+/// The overflow error for slices over 4 bytes long is still there.
+/// See [`read_scriptint`] for a description of some subtleties of
+/// this function.
+pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i64, Error> {
+    if v.is_empty() {
+        return Ok(0);
+    }
+    if v.len() > 4 {
+        return Err(Error::NumericOverflow);
+    }
+
+    Ok(scriptint_parse(v))
+}
+
+// Caller to guarantee that `v` is not empty.
+fn scriptint_parse(v: &[u8]) -> i64 {
+    let (mut ret, sh) = v.iter().fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
+    if v[v.len() - 1] & 0x80 != 0 {
+        ret &= (1 << (sh - 1)) - 1;
+        ret = -ret;
+    }
+    ret
+}
+
+/// Decodes a boolean.
+///
+/// This is like "`read_scriptint` then map 0 to false and everything
+/// else as true", except that the overflow rules don't apply.
+#[inline]
+pub fn read_scriptbool(v: &[u8]) -> bool {
+    match v.split_last() {
+        Some((last, rest)) => !((last & !0x80 == 0x00) && rest.iter().all(|&b| b == 0)),
+        None => false,
+    }
+}
+
+// We internally use implementation based on iterator so that it automatically advances as needed
+// Errors are same as above, just different type.
+fn read_uint_iter(data: &mut core::slice::Iter<'_, u8>, size: usize) -> Result<usize, UintError> {
+    if data.len() < size {
+        Err(UintError::EarlyEndOfScript)
+    } else if size > usize::from(u16::MAX / 8) {
+        // Casting to u32 would overflow
+        Err(UintError::NumericOverflow)
+    } else {
+        let mut ret = 0;
+        for (i, item) in data.take(size).enumerate() {
+            ret = usize::from(*item)
+                // Casting is safe because we checked above to not repeat the same check in a loop
+                .checked_shl((i * 8) as u32)
+                .ok_or(UintError::NumericOverflow)?
+                .checked_add(ret)
+                .ok_or(UintError::NumericOverflow)?;
+        }
+        Ok(ret)
+    }
+}
+
+fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
+    opcode.and_then(|opcode| match opcode {
+        OP_EQUAL => Some(OP_EQUALVERIFY),
+        OP_NUMEQUAL => Some(OP_NUMEQUALVERIFY),
+        OP_CHECKSIG => Some(OP_CHECKSIGVERIFY),
+        OP_CHECKMULTISIG => Some(OP_CHECKMULTISIGVERIFY),
+        _ => None,
+    })
+}
+
+// We keep all the `Script` and `ScriptBuf` impls together since its easier to see side-by-side.
+
+impl From<ScriptBuf> for Box<Script> {
+    fn from(v: ScriptBuf) -> Self { v.into_boxed_script() }
+}
+
+impl From<ScriptBuf> for Cow<'_, Script> {
+    fn from(value: ScriptBuf) -> Self { Cow::Owned(value) }
+}
+
+impl<'a> From<Cow<'a, Script>> for ScriptBuf {
+    fn from(value: Cow<'a, Script>) -> Self {
+        match value {
+            Cow::Owned(owned) => owned,
+            Cow::Borrowed(borrwed) => borrwed.into(),
+        }
+    }
+}
+
+impl<'a> From<Cow<'a, Script>> for Box<Script> {
+    fn from(value: Cow<'a, Script>) -> Self {
+        match value {
+            Cow::Owned(owned) => owned.into(),
+            Cow::Borrowed(borrwed) => borrwed.into(),
+        }
+    }
+}
+
+impl<'a> From<&'a Script> for Box<Script> {
+    fn from(value: &'a Script) -> Self { value.to_owned().into() }
+}
+
+impl<'a> From<&'a Script> for ScriptBuf {
+    fn from(value: &'a Script) -> Self { value.to_owned() }
+}
+
+impl<'a> From<&'a Script> for Cow<'a, Script> {
+    fn from(value: &'a Script) -> Self { Cow::Borrowed(value) }
+}
+
+/// Note: This will fail to compile on old Rust for targets that don't support atomics
+#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+impl<'a> From<&'a Script> for Arc<Script> {
+    fn from(value: &'a Script) -> Self {
+        let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));
+        // SAFETY: copied from `std`
+        // The pointer was just created from an Arc without deallocating
+        // Casting a slice to a transparent struct wrapping that slice is sound (same
+        // layout).
+        unsafe { Arc::from_raw(rw as *const Script) }
+    }
+}
+
+impl<'a> From<&'a Script> for Rc<Script> {
+    fn from(value: &'a Script) -> Self {
+        let rw: *const [u8] = Rc::into_raw(Rc::from(&value.0));
+        // SAFETY: copied from `std`
+        // The pointer was just created from an Rc without deallocating
+        // Casting a slice to a transparent struct wrapping that slice is sound (same
+        // layout).
+        unsafe { Rc::from_raw(rw as *const Script) }
+    }
+}
+
+impl From<Vec<u8>> for ScriptBuf {
+    fn from(v: Vec<u8>) -> Self { ScriptBuf(v) }
+}
+
+impl From<ScriptBuf> for Vec<u8> {
+    fn from(v: ScriptBuf) -> Self { v.0 }
+}
+
+impl AsRef<Script> for Script {
+    #[inline]
+    fn as_ref(&self) -> &Script { self }
+}
+
+impl AsRef<Script> for ScriptBuf {
+    fn as_ref(&self) -> &Script { self }
+}
+
+impl AsRef<[u8]> for Script {
+    #[inline]
+    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl AsRef<[u8]> for ScriptBuf {
+    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl AsMut<Script> for Script {
+    fn as_mut(&mut self) -> &mut Script { self }
+}
+
+impl AsMut<Script> for ScriptBuf {
+    fn as_mut(&mut self) -> &mut Script { self }
+}
+
+impl AsMut<[u8]> for Script {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+}
+
+impl AsMut<[u8]> for ScriptBuf {
+    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+}
+
+impl fmt::Debug for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Script(")?;
+        self.fmt_asm(f)?;
+        f.write_str(")")
+    }
+}
+
+impl fmt::Debug for ScriptBuf {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(self.as_script(), f) }
+}
+
+impl fmt::Display for Script {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_asm(f) }
+}
+
+impl fmt::Display for ScriptBuf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.as_script(), f) }
+}
+
+impl fmt::LowerHex for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.as_bytes().as_hex(), f)
+    }
+}
+
+impl fmt::LowerHex for ScriptBuf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
+}
+
+impl fmt::UpperHex for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.as_bytes().as_hex(), f)
+    }
+}
+
+impl fmt::UpperHex for ScriptBuf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(self.as_script(), f) }
+}
+
+impl Deref for ScriptBuf {
+    type Target = Script;
+
+    fn deref(&self) -> &Self::Target { Script::from_bytes(&self.0) }
+}
+
+impl DerefMut for ScriptBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target { Script::from_bytes_mut(&mut self.0) }
+}
+
+impl Borrow<Script> for ScriptBuf {
+    fn borrow(&self) -> &Script { self }
+}
+
+impl BorrowMut<Script> for ScriptBuf {
+    fn borrow_mut(&mut self) -> &mut Script { self }
+}
+
+impl PartialEq<ScriptBuf> for Script {
+    fn eq(&self, other: &ScriptBuf) -> bool { self.eq(other.as_script()) }
+}
+
+impl PartialEq<Script> for ScriptBuf {
+    fn eq(&self, other: &Script) -> bool { self.as_script().eq(other) }
+}
+
+impl PartialOrd<Script> for ScriptBuf {
+    fn partial_cmp(&self, other: &Script) -> Option<Ordering> {
+        self.as_script().partial_cmp(other)
+    }
+}
+
+impl PartialOrd<ScriptBuf> for Script {
+    fn partial_cmp(&self, other: &ScriptBuf) -> Option<Ordering> {
+        self.partial_cmp(other.as_script())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Script {
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.collect_str(&format_args!("{:x}", self))
+        } else {
+            serializer.serialize_bytes(self.as_bytes())
+        }
+    }
+}
+
+/// Can only deserialize borrowed bytes.
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for &'de Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            use crate::serde::de::Error;
+
+            return Err(D::Error::custom(
+                "deserialization of `&Script` from human-readable formats is not possible",
+            ));
+        }
+
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = &'de Script;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("borrowed bytes")
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Script::from_bytes(v))
+            }
+        }
+        deserializer.deserialize_bytes(Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ScriptBuf {
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        (**self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ScriptBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt::Formatter;
+
+        use hex::FromHex;
+
+        if deserializer.is_human_readable() {
+            struct Visitor;
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = ScriptBuf;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script hex")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    let v = Vec::from_hex(v).map_err(E::custom)?;
+                    Ok(ScriptBuf::from(v))
+                }
+            }
+            deserializer.deserialize_str(Visitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = ScriptBuf;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script Vec<u8>")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(ScriptBuf::from(v.to_vec()))
+                }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(ScriptBuf::from(v))
+                }
+            }
+            deserializer.deserialize_byte_buf(BytesVisitor)
+        }
+    }
+}
+
+impl Encodable for Script {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        crate::consensus::encode::consensus_encode_with_size(&self.0, w)
+    }
+}
+
+impl Encodable for ScriptBuf {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for ScriptBuf {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        r: &mut R,
+    ) -> Result<Self, encode::Error> {
+        Ok(ScriptBuf(Decodable::consensus_decode_from_finite_reader(r)?))
+    }
+}
+
+/// Writes the assembly decoding of the script bytes to the formatter.
+pub(super) fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
+    // This has to be a macro because it needs to break the loop
+    macro_rules! read_push_data_len {
+        ($iter:expr, $len:literal, $formatter:expr) => {
+            match read_uint_iter($iter, $len) {
+                Ok(n) => {
+                    n
+                },
+                Err(UintError::EarlyEndOfScript) => {
+                    $formatter.write_str("<unexpected end>")?;
+                    break;
+                }
+                // We got the data in a slice which implies it being shorter than `usize::MAX`
+                // So if we got overflow, we can confidently say the number is higher than length of
+                // the slice even though we don't know the exact number. This implies attempt to push
+                // past end.
+                Err(UintError::NumericOverflow) => {
+                    $formatter.write_str("<push past end>")?;
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut iter = script.iter();
+    // Was at least one opcode emitted?
+    let mut at_least_one = false;
+    // `iter` needs to be borrowed in `read_push_data_len`, so we have to use `while let` instead
+    // of `for`.
+    while let Some(byte) = iter.next() {
+        let opcode = Opcode::from(*byte);
+
+        let data_len = if let opcodes::Class::PushBytes(n) =
+            opcode.classify(opcodes::ClassifyContext::Legacy)
+        {
+            n as usize
+        } else {
+            match opcode {
+                OP_PUSHDATA1 => {
+                    // side effects: may write and break from the loop
+                    read_push_data_len!(&mut iter, 1, f)
+                }
+                OP_PUSHDATA2 => {
+                    // side effects: may write and break from the loop
+                    read_push_data_len!(&mut iter, 2, f)
+                }
+                OP_PUSHDATA4 => {
+                    // side effects: may write and break from the loop
+                    read_push_data_len!(&mut iter, 4, f)
+                }
+                _ => 0,
+            }
+        };
+
+        if at_least_one {
+            f.write_str(" ")?;
+        } else {
+            at_least_one = true;
+        }
+        // Write the opcode
+        if opcode == OP_PUSHBYTES_0 {
+            f.write_str("OP_0")?;
+        } else {
+            write!(f, "{:?}", opcode)?;
+        }
+        // Write any pushdata
+        if data_len > 0 {
+            f.write_str(" ")?;
+            if data_len <= iter.len() {
+                for ch in iter.by_ref().take(data_len) {
+                    write!(f, "{:02x}", ch)?;
+                }
+            } else {
+                f.write_str("<push past end>")?;
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Ways that a script might fail. Not everything is split up as
+/// much as it could be; patches welcome if more detailed errors
+/// would help you.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Something did a non-minimal push; for more information see
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#push-operators>
+    NonMinimalPush,
+    /// Some opcode expected a parameter but it was missing or truncated.
+    EarlyEndOfScript,
+    /// Tried to read an array off the stack as a number when it was more than 4 bytes.
+    NumericOverflow,
+    /// Can not find the spent output.
+    UnknownSpentOutput(OutPoint),
+    /// Can not serialize the spending transaction.
+    Serialization,
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            NonMinimalPush => f.write_str("non-minimal datapush"),
+            EarlyEndOfScript => f.write_str("unexpected end of script"),
+            NumericOverflow =>
+                f.write_str("numeric overflow (number on stack larger than 4 bytes)"),
+            UnknownSpentOutput(ref point) => write!(f, "unknown spent output: {}", point),
+            Serialization =>
+                f.write_str("can not serialize the spending transaction in Transaction::verify()"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            NonMinimalPush
+            | EarlyEndOfScript
+            | NumericOverflow
+            | UnknownSpentOutput(_)
+            | Serialization => None,
+        }
+    }
+}
+
+// Our internal error proves that we only return these two cases from `read_uint_iter`.
+// Since it's private we don't bother with trait impls besides From.
+enum UintError {
+    EarlyEndOfScript,
+    NumericOverflow,
+}
+
+internals::impl_from_infallible!(UintError);
+
+impl From<UintError> for Error {
+    fn from(error: UintError) -> Self {
+        match error {
+            UintError::EarlyEndOfScript => Error::EarlyEndOfScript,
+            UintError::NumericOverflow => Error::NumericOverflow,
+        }
+    }
+}

--- a/libs/bitcoin/src/blockdata/script/mod.rs
+++ b/libs/bitcoin/src/blockdata/script/mod.rs
@@ -58,8 +58,8 @@ pub mod witness_program;
 pub mod witness_version;
 
 use alloc::rc::Rc;
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
-use alloc::sync::Arc;
+// #[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+// use alloc::sync::Arc;
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
@@ -93,27 +93,39 @@ hashes::hash_newtype! {
 impl_asref_push_bytes!(ScriptHash, WScriptHash);
 
 impl From<ScriptBuf> for ScriptHash {
-    fn from(script: ScriptBuf) -> ScriptHash { script.script_hash() }
+    fn from(script: ScriptBuf) -> ScriptHash {
+        script.script_hash()
+    }
 }
 
 impl From<&ScriptBuf> for ScriptHash {
-    fn from(script: &ScriptBuf) -> ScriptHash { script.script_hash() }
+    fn from(script: &ScriptBuf) -> ScriptHash {
+        script.script_hash()
+    }
 }
 
 impl From<&Script> for ScriptHash {
-    fn from(script: &Script) -> ScriptHash { script.script_hash() }
+    fn from(script: &Script) -> ScriptHash {
+        script.script_hash()
+    }
 }
 
 impl From<ScriptBuf> for WScriptHash {
-    fn from(script: ScriptBuf) -> WScriptHash { script.wscript_hash() }
+    fn from(script: ScriptBuf) -> WScriptHash {
+        script.wscript_hash()
+    }
 }
 
 impl From<&ScriptBuf> for WScriptHash {
-    fn from(script: &ScriptBuf) -> WScriptHash { script.wscript_hash() }
+    fn from(script: &ScriptBuf) -> WScriptHash {
+        script.wscript_hash()
+    }
 }
 
 impl From<&Script> for WScriptHash {
-    fn from(script: &Script) -> WScriptHash { script.wscript_hash() }
+    fn from(script: &Script) -> WScriptHash {
+        script.wscript_hash()
+    }
 }
 
 /// Encodes an integer in script(minimal CScriptNum) format.
@@ -217,7 +229,9 @@ pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i64, Error> {
 
 // Caller to guarantee that `v` is not empty.
 fn scriptint_parse(v: &[u8]) -> i64 {
-    let (mut ret, sh) = v.iter().fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
+    let (mut ret, sh) = v
+        .iter()
+        .fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
     if v[v.len() - 1] & 0x80 != 0 {
         ret &= (1 << (sh - 1)) - 1;
         ret = -ret;
@@ -272,11 +286,15 @@ fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
 // We keep all the `Script` and `ScriptBuf` impls together since its easier to see side-by-side.
 
 impl From<ScriptBuf> for Box<Script> {
-    fn from(v: ScriptBuf) -> Self { v.into_boxed_script() }
+    fn from(v: ScriptBuf) -> Self {
+        v.into_boxed_script()
+    }
 }
 
 impl From<ScriptBuf> for Cow<'_, Script> {
-    fn from(value: ScriptBuf) -> Self { Cow::Owned(value) }
+    fn from(value: ScriptBuf) -> Self {
+        Cow::Owned(value)
+    }
 }
 
 impl<'a> From<Cow<'a, Script>> for ScriptBuf {
@@ -298,29 +316,35 @@ impl<'a> From<Cow<'a, Script>> for Box<Script> {
 }
 
 impl<'a> From<&'a Script> for Box<Script> {
-    fn from(value: &'a Script) -> Self { value.to_owned().into() }
+    fn from(value: &'a Script) -> Self {
+        value.to_owned().into()
+    }
 }
 
 impl<'a> From<&'a Script> for ScriptBuf {
-    fn from(value: &'a Script) -> Self { value.to_owned() }
+    fn from(value: &'a Script) -> Self {
+        value.to_owned()
+    }
 }
 
 impl<'a> From<&'a Script> for Cow<'a, Script> {
-    fn from(value: &'a Script) -> Self { Cow::Borrowed(value) }
-}
-
-/// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
-impl<'a> From<&'a Script> for Arc<Script> {
     fn from(value: &'a Script) -> Self {
-        let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));
-        // SAFETY: copied from `std`
-        // The pointer was just created from an Arc without deallocating
-        // Casting a slice to a transparent struct wrapping that slice is sound (same
-        // layout).
-        unsafe { Arc::from_raw(rw as *const Script) }
+        Cow::Borrowed(value)
     }
 }
+
+// /// Note: This will fail to compile on old Rust for targets that don't support atomics
+// #[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+// impl<'a> From<&'a Script> for Arc<Script> {
+//     fn from(value: &'a Script) -> Self {
+//         let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));
+//         // SAFETY: copied from `std`
+//         // The pointer was just created from an Arc without deallocating
+//         // Casting a slice to a transparent struct wrapping that slice is sound (same
+//         // layout).
+//         unsafe { Arc::from_raw(rw as *const Script) }
+//     }
+// }
 
 impl<'a> From<&'a Script> for Rc<Script> {
     fn from(value: &'a Script) -> Self {
@@ -334,46 +358,66 @@ impl<'a> From<&'a Script> for Rc<Script> {
 }
 
 impl From<Vec<u8>> for ScriptBuf {
-    fn from(v: Vec<u8>) -> Self { ScriptBuf(v) }
+    fn from(v: Vec<u8>) -> Self {
+        ScriptBuf(v)
+    }
 }
 
 impl From<ScriptBuf> for Vec<u8> {
-    fn from(v: ScriptBuf) -> Self { v.0 }
+    fn from(v: ScriptBuf) -> Self {
+        v.0
+    }
 }
 
 impl AsRef<Script> for Script {
     #[inline]
-    fn as_ref(&self) -> &Script { self }
+    fn as_ref(&self) -> &Script {
+        self
+    }
 }
 
 impl AsRef<Script> for ScriptBuf {
-    fn as_ref(&self) -> &Script { self }
+    fn as_ref(&self) -> &Script {
+        self
+    }
 }
 
 impl AsRef<[u8]> for Script {
     #[inline]
-    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
 }
 
 impl AsRef<[u8]> for ScriptBuf {
-    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
 }
 
 impl AsMut<Script> for Script {
-    fn as_mut(&mut self) -> &mut Script { self }
+    fn as_mut(&mut self) -> &mut Script {
+        self
+    }
 }
 
 impl AsMut<Script> for ScriptBuf {
-    fn as_mut(&mut self) -> &mut Script { self }
+    fn as_mut(&mut self) -> &mut Script {
+        self
+    }
 }
 
 impl AsMut<[u8]> for Script {
     #[inline]
-    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_bytes()
+    }
 }
 
 impl AsMut<[u8]> for ScriptBuf {
-    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_bytes()
+    }
 }
 
 impl fmt::Debug for Script {
@@ -385,17 +429,23 @@ impl fmt::Debug for Script {
 }
 
 impl fmt::Debug for ScriptBuf {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(self.as_script(), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.as_script(), f)
+    }
 }
 
 impl fmt::Display for Script {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_asm(f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.fmt_asm(f)
+    }
 }
 
 impl fmt::Display for ScriptBuf {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.as_script(), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_script(), f)
+    }
 }
 
 impl fmt::LowerHex for Script {
@@ -406,7 +456,9 @@ impl fmt::LowerHex for Script {
 
 impl fmt::LowerHex for ScriptBuf {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(self.as_script(), f)
+    }
 }
 
 impl fmt::UpperHex for Script {
@@ -417,33 +469,47 @@ impl fmt::UpperHex for Script {
 
 impl fmt::UpperHex for ScriptBuf {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(self.as_script(), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(self.as_script(), f)
+    }
 }
 
 impl Deref for ScriptBuf {
     type Target = Script;
 
-    fn deref(&self) -> &Self::Target { Script::from_bytes(&self.0) }
+    fn deref(&self) -> &Self::Target {
+        Script::from_bytes(&self.0)
+    }
 }
 
 impl DerefMut for ScriptBuf {
-    fn deref_mut(&mut self) -> &mut Self::Target { Script::from_bytes_mut(&mut self.0) }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Script::from_bytes_mut(&mut self.0)
+    }
 }
 
 impl Borrow<Script> for ScriptBuf {
-    fn borrow(&self) -> &Script { self }
+    fn borrow(&self) -> &Script {
+        self
+    }
 }
 
 impl BorrowMut<Script> for ScriptBuf {
-    fn borrow_mut(&mut self) -> &mut Script { self }
+    fn borrow_mut(&mut self) -> &mut Script {
+        self
+    }
 }
 
 impl PartialEq<ScriptBuf> for Script {
-    fn eq(&self, other: &ScriptBuf) -> bool { self.eq(other.as_script()) }
+    fn eq(&self, other: &ScriptBuf) -> bool {
+        self.eq(other.as_script())
+    }
 }
 
 impl PartialEq<Script> for ScriptBuf {
-    fn eq(&self, other: &Script) -> bool { self.as_script().eq(other) }
+    fn eq(&self, other: &Script) -> bool {
+        self.as_script().eq(other)
+    }
 }
 
 impl PartialOrd<Script> for ScriptBuf {
@@ -594,7 +660,9 @@ impl Decodable for ScriptBuf {
     fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
-        Ok(ScriptBuf(Decodable::consensus_decode_from_finite_reader(r)?))
+        Ok(ScriptBuf(Decodable::consensus_decode_from_finite_reader(
+            r,
+        )?))
     }
 }
 
@@ -708,11 +776,13 @@ impl fmt::Display for Error {
         match *self {
             NonMinimalPush => f.write_str("non-minimal datapush"),
             EarlyEndOfScript => f.write_str("unexpected end of script"),
-            NumericOverflow =>
-                f.write_str("numeric overflow (number on stack larger than 4 bytes)"),
+            NumericOverflow => {
+                f.write_str("numeric overflow (number on stack larger than 4 bytes)")
+            }
             UnknownSpentOutput(ref point) => write!(f, "unknown spent output: {}", point),
-            Serialization =>
-                f.write_str("can not serialize the spending transaction in Transaction::verify()"),
+            Serialization => {
+                f.write_str("can not serialize the spending transaction in Transaction::verify()")
+            }
         }
     }
 }

--- a/libs/bitcoin/src/blockdata/script/owned.rs
+++ b/libs/bitcoin/src/blockdata/script/owned.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#[cfg(doc)]
+use core::ops::Deref;
+
+use hex::FromHex;
+use secp256k1::{Secp256k1, Verification};
+
+use crate::blockdata::opcodes::all::*;
+use crate::blockdata::opcodes::{self, Opcode};
+use crate::blockdata::script::witness_program::WitnessProgram;
+use crate::blockdata::script::witness_version::WitnessVersion;
+use crate::blockdata::script::{
+    opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
+};
+use crate::key::{
+    PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
+};
+use crate::prelude::*;
+use crate::taproot::TapNodeHash;
+
+/// An owned, growable script.
+///
+/// `ScriptBuf` is the most common script type that has the ownership over the contents of the
+/// script. It has a close relationship with its borrowed counterpart, [`Script`].
+///
+/// Just as other similar types, this implements [`Deref`], so [deref coercions] apply. Also note
+/// that all the safety/validity restrictions that apply to [`Script`] apply to `ScriptBuf` as well.
+///
+/// [deref coercions]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion
+#[derive(Default, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct ScriptBuf(pub(in crate::blockdata::script) Vec<u8>);
+
+impl ScriptBuf {
+    /// Creates a new empty script.
+    #[inline]
+    pub const fn new() -> Self { ScriptBuf(Vec::new()) }
+
+    /// Creates a new empty script with pre-allocated capacity.
+    pub fn with_capacity(capacity: usize) -> Self { ScriptBuf(Vec::with_capacity(capacity)) }
+
+    /// Pre-allocates at least `additional_len` bytes if needed.
+    ///
+    /// Reserves capacity for at least `additional_len` more bytes to be inserted in the given
+    /// script. The script may reserve more space to speculatively avoid frequent reallocations.
+    /// After calling `reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional_len`. Does nothing if capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX bytes`.
+    pub fn reserve(&mut self, additional_len: usize) { self.0.reserve(additional_len); }
+
+    /// Pre-allocates exactly `additional_len` bytes if needed.
+    ///
+    /// Unlike `reserve`, this will not deliberately over-allocate to speculatively avoid frequent
+    /// allocations. After calling `reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore,
+    /// capacity can not be relied upon to be precisely minimal. Prefer [`reserve`](Self::reserve)
+    /// if future insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX bytes`.
+    pub fn reserve_exact(&mut self, additional_len: usize) { self.0.reserve_exact(additional_len); }
+
+    /// Returns a reference to unsized script.
+    pub fn as_script(&self) -> &Script { Script::from_bytes(&self.0) }
+
+    /// Returns a mutable reference to unsized script.
+    pub fn as_mut_script(&mut self) -> &mut Script { Script::from_bytes_mut(&mut self.0) }
+
+    /// Creates a new script builder
+    pub fn builder() -> Builder { Builder::new() }
+
+    /// Generates P2PK-type of scriptPubkey.
+    pub fn new_p2pk(pubkey: &PublicKey) -> Self {
+        Builder::new().push_key(pubkey).push_opcode(OP_CHECKSIG).into_script()
+    }
+
+    /// Generates P2PKH-type of scriptPubkey.
+    pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Self {
+        Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice(pubkey_hash)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script.
+    pub fn new_p2sh(script_hash: &ScriptHash) -> Self {
+        Builder::new()
+            .push_opcode(OP_HASH160)
+            .push_slice(script_hash)
+            .push_opcode(OP_EQUAL)
+            .into_script()
+    }
+
+    /// Generates P2WPKH-type of scriptPubkey.
+    pub fn new_p2wpkh(pubkey_hash: &WPubkeyHash) -> Self {
+        // pubkey hash is 20 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
+        ScriptBuf::new_witness_program_unchecked(WitnessVersion::V0, pubkey_hash)
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
+    pub fn new_p2wsh(script_hash: &WScriptHash) -> Self {
+        // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
+        ScriptBuf::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
+    }
+
+    /// Generates P2TR for script spending path using an internal public key and some optional
+    /// script tree merkle root.
+    pub fn new_p2tr<C: Verification>(
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let (output_key, _) = internal_key.tap_tweak(secp, merkle_root);
+        // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
+        ScriptBuf::new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
+    }
+
+    /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
+    pub fn new_p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
+        // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
+        ScriptBuf::new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given [`WitnessProgram`].
+    pub fn new_witness_program(witness_program: &WitnessProgram) -> Self {
+        Builder::new()
+            .push_opcode(witness_program.version().into())
+            .push_slice(witness_program.program())
+            .into_script()
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
+    /// Does not do any checks on version or program length.
+    ///
+    /// Convenience method used by `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
+    pub(crate) fn new_witness_program_unchecked<T: AsRef<PushBytes>>(
+        version: WitnessVersion,
+        program: T,
+    ) -> Self {
+        let program = program.as_ref();
+        debug_assert!(program.len() >= 2 && program.len() <= 40);
+        // In segwit v0, the program must be 20 or 32 bytes long.
+        debug_assert!(version != WitnessVersion::V0 || program.len() == 20 || program.len() == 32);
+        Builder::new().push_opcode(version.into()).push_slice(program).into_script()
+    }
+
+    /// Creates the script code used for spending a P2WPKH output.
+    ///
+    /// The `scriptCode` is described in [BIP143].
+    ///
+    /// [BIP143]: <https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki>
+    pub fn p2wpkh_script_code(wpkh: WPubkeyHash) -> ScriptBuf {
+        Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice(wpkh)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Generates OP_RETURN-type of scriptPubkey for the given data.
+    pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+        Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
+    }
+
+    /// Creates a [`ScriptBuf`] from a hex string.
+    pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
+        let v = Vec::from_hex(s)?;
+        Ok(ScriptBuf::from_bytes(v))
+    }
+
+    /// Converts byte vector into script.
+    ///
+    /// This method doesn't (re)allocate.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self { ScriptBuf(bytes) }
+
+    /// Converts the script into a byte vector.
+    ///
+    /// This method doesn't (re)allocate.
+    pub fn into_bytes(self) -> Vec<u8> { self.0 }
+
+    /// Adds a single opcode to the script.
+    pub fn push_opcode(&mut self, data: Opcode) { self.0.push(data.to_u8()); }
+
+    /// Adds instructions to push some arbitrary data onto the stack.
+    pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
+        let data = data.as_ref();
+        self.reserve(Self::reserved_len_for_slice(data.len()));
+        self.push_slice_no_opt(data);
+    }
+
+    /// Pushes the slice without reserving
+    fn push_slice_no_opt(&mut self, data: &PushBytes) {
+        // Start with a PUSH opcode
+        match data.len() as u64 {
+            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
+                self.0.push(n as u8);
+            }
+            n if n < 0x100 => {
+                self.0.push(opcodes::Ordinary::OP_PUSHDATA1.to_u8());
+                self.0.push(n as u8);
+            }
+            n if n < 0x10000 => {
+                self.0.push(opcodes::Ordinary::OP_PUSHDATA2.to_u8());
+                self.0.push((n % 0x100) as u8);
+                self.0.push((n / 0x100) as u8);
+            }
+            n if n < 0x100000000 => {
+                self.0.push(opcodes::Ordinary::OP_PUSHDATA4.to_u8());
+                self.0.push((n % 0x100) as u8);
+                self.0.push(((n / 0x100) % 0x100) as u8);
+                self.0.push(((n / 0x10000) % 0x100) as u8);
+                self.0.push((n / 0x1000000) as u8);
+            }
+            _ => panic!("tried to put a 4bn+ sized object into a script!"),
+        }
+        // Then push the raw bytes
+        self.0.extend_from_slice(data.as_bytes());
+    }
+
+    /// Computes the sum of `len` and the length of an appropriate push opcode.
+    pub(in crate::blockdata::script) fn reserved_len_for_slice(len: usize) -> usize {
+        len + match len {
+            0..=0x4b => 1,
+            0x4c..=0xff => 2,
+            0x100..=0xffff => 3,
+            // we don't care about oversized, the other fn will panic anyway
+            _ => 5,
+        }
+    }
+
+    /// Add a single instruction to the script.
+    ///
+    /// ## Panics
+    ///
+    /// The method panics if the instruction is a data push with length greater or equal to
+    /// 0x100000000.
+    pub fn push_instruction(&mut self, instruction: Instruction<'_>) {
+        match instruction {
+            Instruction::Op(opcode) => self.push_opcode(opcode),
+            Instruction::PushBytes(bytes) => self.push_slice(bytes),
+        }
+    }
+
+    /// Like push_instruction, but avoids calling `reserve` to not re-check the length.
+    pub fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
+        match instruction {
+            Instruction::Op(opcode) => self.push_opcode(opcode),
+            Instruction::PushBytes(bytes) => self.push_slice_no_opt(bytes),
+        }
+    }
+
+    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
+    ///
+    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
+    /// in the script right after. To save space this function appends `VERIFY` only if
+    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
+    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    ///
+    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
+    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
+    /// semantics.
+    ///
+    /// This function needs to iterate over the script to find the last instruction. Prefer
+    /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
+    /// multiple times.
+    pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
+
+    /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
+    /// alternative.
+    ///
+    /// See the public fn [`Self::scan_and_push_verify`] to learn more.
+    pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
+        match opcode_to_verify(last_opcode) {
+            Some(opcode) => {
+                self.0.pop();
+                self.push_opcode(opcode);
+            }
+            None => self.push_opcode(OP_VERIFY),
+        }
+    }
+
+    /// Converts this `ScriptBuf` into a [boxed](Box) [`Script`].
+    ///
+    /// This method reallocates if the capacity is greater than length of the script but should not
+    /// when they are equal. If you know beforehand that you need to create a script of exact size
+    /// use [`reserve_exact`](Self::reserve_exact) before adding data to the script so that the
+    /// reallocation can be avoided.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    #[inline]
+    pub fn into_boxed_script(self) -> Box<Script> {
+        // Copied from PathBuf::into_boxed_path
+        let rw = Box::into_raw(self.0.into_boxed_slice()) as *mut Script;
+        unsafe { Box::from_raw(rw) }
+    }
+}
+
+impl<'a> core::iter::FromIterator<Instruction<'a>> for ScriptBuf {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Instruction<'a>>,
+    {
+        let mut script = ScriptBuf::new();
+        script.extend(iter);
+        script
+    }
+}
+
+impl<'a> Extend<Instruction<'a>> for ScriptBuf {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = Instruction<'a>>,
+    {
+        let iter = iter.into_iter();
+        // Most of Bitcoin scripts have only a few opcodes, so we can avoid reallocations in many
+        // cases.
+        if iter.size_hint().1.map(|max| max < 6).unwrap_or(false) {
+            let mut iter = iter.fuse();
+            // `MaybeUninit` might be faster but we don't want to introduce more `unsafe` than
+            // required.
+            let mut head = [None; 5];
+            let mut total_size = 0;
+            for (head, instr) in head.iter_mut().zip(&mut iter) {
+                total_size += instr.script_serialized_len();
+                *head = Some(instr);
+            }
+            // Incorrect impl of `size_hint` breaks `Iterator` contract so we're free to panic.
+            assert!(
+                iter.next().is_none(),
+                "Buggy implementation of `Iterator` on {} returns invalid upper bound",
+                core::any::type_name::<T::IntoIter>()
+            );
+            self.reserve(total_size);
+            for instr in head.iter().cloned().flatten() {
+                self.push_instruction_no_opt(instr);
+            }
+        } else {
+            for instr in iter {
+                self.push_instruction(instr);
+            }
+        }
+    }
+}

--- a/libs/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/libs/bitcoin/src/blockdata/script/push_bytes.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Contains `PushBytes` & co
+
+use core::ops::{Deref, DerefMut};
+
+#[allow(unused)]
+use crate::prelude::*;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::primitive::*;
+
+/// This module only contains required operations so that outside functions wouldn't accidentally
+/// break invariants. Therefore auditing this module should be sufficient.
+mod primitive {
+    use core::ops::{
+        Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+    };
+
+    use super::PushBytesError;
+    #[allow(unused)]
+    use crate::prelude::*;
+
+    #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
+    fn check_limit(_: usize) -> Result<(), PushBytesError> { Ok(()) }
+
+    #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
+    fn check_limit(len: usize) -> Result<(), PushBytesError> {
+        if len < 0x100000000 {
+            Ok(())
+        } else {
+            Err(PushBytesError { len })
+        }
+    }
+
+    /// Byte slices that can be in Bitcoin script.
+    ///
+    /// The encoding of Bitcoin script restricts data pushes to be less than 2^32 bytes long.
+    /// This type represents slices that are guaranteed to be within the limit so they can be put in
+    /// the script safely.
+    #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[repr(transparent)]
+    pub struct PushBytes([u8]);
+
+    impl PushBytes {
+        /// Creates `&Self` without checking the length.
+        ///
+        /// ## Safety
+        ///
+        /// The caller is responsible for checking that the length is less than the [`LIMIT`].
+        unsafe fn from_slice_unchecked(bytes: &[u8]) -> &Self {
+            &*(bytes as *const [u8] as *const PushBytes)
+        }
+
+        /// Creates `&mut Self` without checking the length.
+        ///
+        /// ## Safety
+        ///
+        /// The caller is responsible for checking that the length is less than the [`LIMIT`].
+        unsafe fn from_mut_slice_unchecked(bytes: &mut [u8]) -> &mut Self {
+            &mut *(bytes as *mut [u8] as *mut PushBytes)
+        }
+
+        /// Creates an empty `PushBytes`.
+        pub fn empty() -> &'static Self {
+            // 0 < LIMIT
+            unsafe { Self::from_slice_unchecked(&[]) }
+        }
+
+        /// Returns the underlying bytes.
+        pub fn as_bytes(&self) -> &[u8] { &self.0 }
+
+        /// Returns the underlying mutbale bytes.
+        pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
+    }
+
+    macro_rules! delegate_index {
+        ($($type:ty),* $(,)?) => {
+            $(
+                /// Script subslicing operation - read [slicing safety](#slicing-safety)!
+                impl Index<$type> for PushBytes {
+                    type Output = Self;
+
+                    #[inline]
+                    #[track_caller]
+                    fn index(&self, index: $type) -> &Self::Output {
+                        // Slicing can not make slices longer
+                        unsafe {
+                            Self::from_slice_unchecked(&self.0[index])
+                        }
+                    }
+                }
+            )*
+        }
+    }
+
+    delegate_index!(
+        Range<usize>,
+        RangeFrom<usize>,
+        RangeTo<usize>,
+        RangeFull,
+        RangeInclusive<usize>,
+        RangeToInclusive<usize>,
+        (Bound<usize>, Bound<usize>)
+    );
+
+    impl Index<usize> for PushBytes {
+        type Output = u8;
+
+        #[inline]
+        #[track_caller]
+        fn index(&self, index: usize) -> &Self::Output { &self.0[index] }
+    }
+
+    impl<'a> TryFrom<&'a [u8]> for &'a PushBytes {
+        type Error = PushBytesError;
+
+        fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+            check_limit(bytes.len())?;
+            // We've just checked the length
+            Ok(unsafe { PushBytes::from_slice_unchecked(bytes) })
+        }
+    }
+
+    impl<'a> TryFrom<&'a mut [u8]> for &'a mut PushBytes {
+        type Error = PushBytesError;
+
+        fn try_from(bytes: &'a mut [u8]) -> Result<Self, Self::Error> {
+            check_limit(bytes.len())?;
+            // We've just checked the length
+            Ok(unsafe { PushBytes::from_mut_slice_unchecked(bytes) })
+        }
+    }
+
+    macro_rules! from_array {
+        ($($len:literal),* $(,)?) => {
+            $(
+                impl<'a> From<&'a [u8; $len]> for &'a PushBytes {
+                    fn from(bytes: &'a [u8; $len]) -> Self {
+                        // Check that the macro wasn't called with a wrong number.
+                        const _: () = [(); 1][($len >= 0x100000000u64) as usize];
+                        // We know the size of array statically and we checked macro input.
+                        unsafe { PushBytes::from_slice_unchecked(bytes) }
+                    }
+                }
+
+                impl<'a> From<&'a mut [u8; $len]> for &'a mut PushBytes {
+                    fn from(bytes: &'a mut [u8; $len]) -> Self {
+                        // Macro check already above, no need to duplicate.
+                        // We know the size of array statically and we checked macro input.
+                        unsafe { PushBytes::from_mut_slice_unchecked(bytes) }
+                    }
+                }
+
+                impl AsRef<PushBytes> for [u8; $len] {
+                    fn as_ref(&self) -> &PushBytes {
+                        self.into()
+                    }
+                }
+
+                impl AsMut<PushBytes> for [u8; $len] {
+                    fn as_mut(&mut self) -> &mut PushBytes {
+                        self.into()
+                    }
+                }
+
+                impl From<[u8; $len]> for PushBytesBuf {
+                    fn from(bytes: [u8; $len]) -> Self {
+                        PushBytesBuf(Vec::from(&bytes as &[_]))
+                    }
+                }
+
+                impl<'a> From<&'a [u8; $len]> for PushBytesBuf {
+                    fn from(bytes: &'a [u8; $len]) -> Self {
+                        PushBytesBuf(Vec::from(bytes as &[_]))
+                    }
+                }
+            )*
+        }
+    }
+
+    // Sizes up to 76 to support all pubkey and signature sizes
+    from_array! {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+        71, 72, 73, 74, 75, 76
+    }
+
+    /// Owned, growable counterpart to `PushBytes`.
+    #[derive(Default, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    pub struct PushBytesBuf(Vec<u8>);
+
+    impl PushBytesBuf {
+        /// Creates a new empty `PushBytesBuf`.
+        #[inline]
+        pub const fn new() -> Self { PushBytesBuf(Vec::new()) }
+
+        /// Creates a new empty `PushBytesBuf` with reserved capacity.
+        pub fn with_capacity(capacity: usize) -> Self { PushBytesBuf(Vec::with_capacity(capacity)) }
+
+        /// Reserve capacity for `additional_capacity` bytes.
+        pub fn reserve(&mut self, additional_capacity: usize) {
+            self.0.reserve(additional_capacity)
+        }
+
+        /// Try pushing a single byte.
+        ///
+        /// ## Errors
+        ///
+        /// This method fails if `self` would exceed the limit.
+        #[allow(deprecated)]
+        pub fn push(&mut self, byte: u8) -> Result<(), PushBytesError> {
+            // This is OK on 32 bit archs since vec has its own check and this check is pointless.
+            check_limit(self.0.len().saturating_add(1))?;
+            self.0.push(byte);
+            Ok(())
+        }
+
+        /// Try appending a slice to `PushBytesBuf`
+        ///
+        /// ## Errors
+        ///
+        /// This method fails if `self` would exceed the limit.
+        pub fn extend_from_slice(&mut self, bytes: &[u8]) -> Result<(), PushBytesError> {
+            let len = self.0.len().saturating_add(bytes.len());
+            check_limit(len)?;
+            self.0.extend_from_slice(bytes);
+            Ok(())
+        }
+
+        /// Remove the last byte from buffer if any.
+        pub fn pop(&mut self) -> Option<u8> { self.0.pop() }
+
+        /// Remove the byte at `index` and return it.
+        ///
+        /// ## Panics
+        ///
+        /// This method panics if `index` is out of bounds.
+        #[track_caller]
+        pub fn remove(&mut self, index: usize) -> u8 { self.0.remove(index) }
+
+        /// Remove all bytes from buffer without affecting capacity.
+        pub fn clear(&mut self) { self.0.clear() }
+
+        /// Remove bytes from buffer past `len`.
+        pub fn truncate(&mut self, len: usize) { self.0.truncate(len) }
+
+        /// Extracts `PushBytes` slice
+        pub fn as_push_bytes(&self) -> &PushBytes {
+            // length guaranteed by our invariant
+            unsafe { PushBytes::from_slice_unchecked(&self.0) }
+        }
+
+        /// Extracts mutable `PushBytes` slice
+        pub fn as_mut_push_bytes(&mut self) -> &mut PushBytes {
+            // length guaranteed by our invariant
+            unsafe { PushBytes::from_mut_slice_unchecked(&mut self.0) }
+        }
+
+        /// Accesses inner `Vec` - provided for `super` to impl other methods.
+        pub(super) fn inner(&self) -> &Vec<u8> { &self.0 }
+    }
+
+    impl From<PushBytesBuf> for Vec<u8> {
+        fn from(value: PushBytesBuf) -> Self { value.0 }
+    }
+
+    impl TryFrom<Vec<u8>> for PushBytesBuf {
+        type Error = PushBytesError;
+
+        fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+            // check len
+            let _: &PushBytes = vec.as_slice().try_into()?;
+            Ok(PushBytesBuf(vec))
+        }
+    }
+
+    impl ToOwned for PushBytes {
+        type Owned = PushBytesBuf;
+
+        fn to_owned(&self) -> Self::Owned { PushBytesBuf(self.0.to_owned()) }
+    }
+}
+
+impl PushBytes {
+    /// Returns the number of bytes in buffer.
+    pub fn len(&self) -> usize { self.as_bytes().len() }
+
+    /// Returns true if the buffer contains zero bytes.
+    pub fn is_empty(&self) -> bool { self.as_bytes().is_empty() }
+}
+
+impl PushBytesBuf {
+    /// Returns the number of bytes in buffer.
+    pub fn len(&self) -> usize { self.inner().len() }
+
+    /// Returns the number of bytes the buffer can contain without reallocating.
+    pub fn capacity(&self) -> usize { self.inner().capacity() }
+
+    /// Returns true if the buffer contains zero bytes.
+    pub fn is_empty(&self) -> bool { self.inner().is_empty() }
+}
+
+impl AsRef<[u8]> for PushBytes {
+    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl AsMut<[u8]> for PushBytes {
+    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+}
+
+impl Deref for PushBytesBuf {
+    type Target = PushBytes;
+
+    fn deref(&self) -> &Self::Target { self.as_push_bytes() }
+}
+
+impl DerefMut for PushBytesBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target { self.as_mut_push_bytes() }
+}
+
+impl AsRef<PushBytes> for PushBytes {
+    fn as_ref(&self) -> &PushBytes { self }
+}
+
+impl AsMut<PushBytes> for PushBytes {
+    fn as_mut(&mut self) -> &mut PushBytes { self }
+}
+
+impl AsRef<PushBytes> for PushBytesBuf {
+    fn as_ref(&self) -> &PushBytes { self.as_push_bytes() }
+}
+
+impl AsMut<PushBytes> for PushBytesBuf {
+    fn as_mut(&mut self) -> &mut PushBytes { self.as_mut_push_bytes() }
+}
+
+impl Borrow<PushBytes> for PushBytesBuf {
+    fn borrow(&self) -> &PushBytes { self.as_push_bytes() }
+}
+
+impl BorrowMut<PushBytes> for PushBytesBuf {
+    fn borrow_mut(&mut self) -> &mut PushBytes { self.as_mut_push_bytes() }
+}
+
+/// Reports information about failed conversion into `PushBytes`.
+///
+/// This should not be needed by general public, except as an additional bound on `TryFrom` when
+/// converting to `WitnessProgram`.
+pub trait PushBytesErrorReport {
+    /// How many bytes the input had.
+    fn input_len(&self) -> usize;
+}
+
+impl PushBytesErrorReport for core::convert::Infallible {
+    #[inline]
+    fn input_len(&self) -> usize { match *self {} }
+}
+
+pub use error::*;
+
+#[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
+mod error {
+    use core::fmt;
+
+    /// Error returned on attempt to create too large `PushBytes`.
+    #[allow(unused)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct PushBytesError {
+        never: core::convert::Infallible,
+    }
+
+    impl super::PushBytesErrorReport for PushBytesError {
+        #[inline]
+        fn input_len(&self) -> usize { match self.never {} }
+    }
+
+    impl fmt::Display for PushBytesError {
+        fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result { match self.never {} }
+    }
+}
+
+// we have 64 bits in mind, but even for esoteric sizes, this code is correct, since it's the
+// conservative one that checks for errors
+#[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
+mod error {
+    use core::fmt;
+
+    /// Error returned on attempt to create too large `PushBytes`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct PushBytesError {
+        /// How long the input was.
+        pub(super) len: usize,
+    }
+
+    impl super::PushBytesErrorReport for PushBytesError {
+        #[inline]
+        fn input_len(&self) -> usize { self.len }
+    }
+
+    impl fmt::Display for PushBytesError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "attempt to prepare {} bytes to be pushed into script but the limit is 2^32-1",
+                self.len
+            )
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PushBytesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}

--- a/libs/bitcoin/src/blockdata/script/tests.rs
+++ b/libs/bitcoin/src/blockdata/script/tests.rs
@@ -1,0 +1,881 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::str::FromStr;
+
+use hashes::Hash;
+use hex_lit::hex;
+
+use super::*;
+use crate::consensus::encode::{deserialize, serialize};
+use crate::crypto::key::{PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey};
+use crate::FeeRate;
+
+#[test]
+#[rustfmt::skip]
+fn script() {
+    let mut comp = vec![];
+    let mut script = Builder::new();
+    assert_eq!(script.as_bytes(), &comp[..]);
+
+    // small ints
+    script = script.push_int(1);  comp.push(81u8); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_int(0);  comp.push(0u8);  assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_int(4);  comp.push(84u8); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_int(-1); comp.push(79u8); assert_eq!(script.as_bytes(), &comp[..]);
+    // forced scriptint
+    script = script.push_int_non_minimal(4); comp.extend([1u8, 4].iter().cloned()); assert_eq!(script.as_bytes(), &comp[..]);
+    // big ints
+    script = script.push_int(17); comp.extend([1u8, 17].iter().cloned()); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_int(10000); comp.extend([2u8, 16, 39].iter().cloned()); assert_eq!(script.as_bytes(), &comp[..]);
+    // notice the sign bit set here, hence the extra zero/128 at the end
+    script = script.push_int(10000000); comp.extend([4u8, 128, 150, 152, 0].iter().cloned()); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_int(-10000000); comp.extend([4u8, 128, 150, 152, 128].iter().cloned()); assert_eq!(script.as_bytes(), &comp[..]);
+
+    // data
+    script = script.push_slice(b"NRA4VR"); comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned()); assert_eq!(script.as_bytes(), &comp[..]);
+
+    // keys
+    const KEYSTR1: &str = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
+    let key = PublicKey::from_str(&KEYSTR1[2..]).unwrap();
+    script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR1)); assert_eq!(script.as_bytes(), &comp[..]);
+    const KEYSTR2: &str = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
+    let key = PublicKey::from_str(&KEYSTR2[2..]).unwrap();
+    script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR2)); assert_eq!(script.as_bytes(), &comp[..]);
+
+    // opcodes
+    script = script.push_opcode(OP_CHECKSIG); comp.push(0xACu8); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_opcode(OP_CHECKSIG); comp.push(0xACu8); assert_eq!(script.as_bytes(), &comp[..]);
+}
+
+#[test]
+fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
+    let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
+    let key = PublicKey::from_str(key_str).unwrap();
+    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let actual = p2pk.p2pk_pubkey_bytes().unwrap();
+    assert_eq!(actual.to_vec(), key.to_bytes());
+}
+
+#[test]
+fn p2pk_pubkey_bytes_no_checksig_returns_none() {
+    let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
+    let key = PublicKey::from_str(key_str).unwrap();
+    let no_checksig = Script::builder().push_key(&key).into_script();
+    assert_eq!(no_checksig.p2pk_pubkey_bytes(), None);
+}
+
+#[test]
+fn p2pk_pubkey_bytes_emptry_script_returns_none() {
+    let empty_script = Script::builder().into_script();
+    assert!(empty_script.p2pk_pubkey_bytes().is_none());
+}
+
+#[test]
+fn p2pk_pubkey_bytes_no_key_returns_none() {
+    // scripts with no key should return None
+    let no_push_bytes = Script::builder().push_opcode(OP_CHECKSIG).into_script();
+    assert!(no_push_bytes.p2pk_pubkey_bytes().is_none());
+}
+
+#[test]
+fn p2pk_pubkey_bytes_different_op_code_returns_none() {
+    let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
+    let key = PublicKey::from_str(key_str).unwrap();
+    let different_op_code = Script::builder().push_key(&key).push_opcode(OP_NOP).into_script();
+    assert!(different_op_code.p2pk_pubkey_bytes().is_none());
+}
+
+#[test]
+fn p2pk_pubkey_bytes_incorrect_key_size_returns_none() {
+    // 63 byte key
+    let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1";
+    let invalid_p2pk_script =
+        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+    assert!(invalid_p2pk_script.p2pk_pubkey_bytes().is_none());
+}
+
+#[test]
+fn p2pk_pubkey_bytes_invalid_key_returns_some() {
+    let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1ux";
+    let invalid_key_script =
+        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+    assert!(invalid_key_script.p2pk_pubkey_bytes().is_some());
+}
+
+#[test]
+fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
+    let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
+    let key = PublicKey::from_str(compressed_key_str).unwrap();
+    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let actual = p2pk.p2pk_pubkey_bytes().unwrap();
+    assert_eq!(actual.to_vec(), key.to_bytes());
+}
+
+#[test]
+fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
+    let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
+    let key = PublicKey::from_str(key_str).unwrap();
+    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let actual = p2pk.p2pk_public_key().unwrap();
+    assert_eq!(actual, key);
+}
+
+#[test]
+fn p2pk_public_key_no_checksig_returns_none() {
+    let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
+    let key = PublicKey::from_str(key_str).unwrap();
+    let no_checksig = Script::builder().push_key(&key).into_script();
+    assert_eq!(no_checksig.p2pk_public_key(), None);
+}
+
+#[test]
+fn p2pk_public_key_empty_script_returns_none() {
+    let empty_script = Script::builder().into_script();
+    assert!(empty_script.p2pk_public_key().is_none());
+}
+
+#[test]
+fn p2pk_public_key_no_key_returns_none() {
+    let no_push_bytes = Script::builder().push_opcode(OP_CHECKSIG).into_script();
+    assert!(no_push_bytes.p2pk_public_key().is_none());
+}
+
+#[test]
+fn p2pk_public_key_different_op_code_returns_none() {
+    let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
+    let key = PublicKey::from_str(key_str).unwrap();
+    let different_op_code = Script::builder().push_key(&key).push_opcode(OP_NOP).into_script();
+    assert!(different_op_code.p2pk_public_key().is_none());
+}
+
+#[test]
+fn p2pk_public_key_incorrect_size_returns_none() {
+    let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1";
+    let malformed_key_script =
+        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+    assert!(malformed_key_script.p2pk_public_key().is_none());
+}
+
+#[test]
+fn p2pk_public_key_invalid_key_returns_none() {
+    let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1ux";
+    let invalid_key_script =
+        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+    assert!(invalid_key_script.p2pk_public_key().is_none());
+}
+
+#[test]
+fn p2pk_public_key_compressed_key_returns_some() {
+    let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
+    let key = PublicKey::from_str(compressed_key_str).unwrap();
+    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let actual = p2pk.p2pk_public_key().unwrap();
+    assert_eq!(actual, key);
+}
+
+#[test]
+fn script_x_only_key() {
+    // Notice the "20" which prepends the keystr. That 20 is hexadecimal for "32". The Builder automatically adds the 32 opcode
+    // to our script in order to give a heads up to the script compiler that it should add the next 32 bytes to the stack.
+    // From: https://github.com/bitcoin-core/btcdeb/blob/e8c2750c4a4702768c52d15640ed03bf744d2601/doc/tapscript-example.md?plain=1#L43
+    const KEYSTR: &str = "209997a497d964fc1a62885b05a51166a65a90df00492c8d7cf61d6accf54803be";
+    let x_only_key = XOnlyPublicKey::from_str(&KEYSTR[2..]).unwrap();
+    let script = Builder::new().push_x_only_key(&x_only_key);
+    assert_eq!(script.into_bytes(), &hex!(KEYSTR) as &[u8]);
+}
+
+#[test]
+fn script_builder() {
+    // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in my mempool when I wrote the test
+    let script = Builder::new()
+        .push_opcode(OP_DUP)
+        .push_opcode(OP_HASH160)
+        .push_slice(hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
+        .push_opcode(OP_EQUALVERIFY)
+        .push_opcode(OP_CHECKSIG)
+        .into_script();
+    assert_eq!(script.to_hex_string(), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
+}
+
+#[test]
+fn script_generators() {
+    let pubkey =
+        PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e")
+            .unwrap();
+    assert!(ScriptBuf::new_p2pk(&pubkey).is_p2pk());
+
+    let pubkey_hash = PubkeyHash::hash(&pubkey.inner.serialize());
+    assert!(ScriptBuf::new_p2pkh(&pubkey_hash).is_p2pkh());
+
+    let wpubkey_hash = WPubkeyHash::hash(&pubkey.inner.serialize());
+    assert!(ScriptBuf::new_p2wpkh(&wpubkey_hash).is_p2wpkh());
+
+    let script = Builder::new().push_opcode(OP_NUMEQUAL).push_verify().into_script();
+    let script_hash = script.script_hash();
+    let p2sh = ScriptBuf::new_p2sh(&script_hash);
+    assert!(p2sh.is_p2sh());
+    assert_eq!(script.to_p2sh(), p2sh);
+
+    let wscript_hash = script.wscript_hash();
+    let p2wsh = ScriptBuf::new_p2wsh(&wscript_hash);
+    assert!(p2wsh.is_p2wsh());
+    assert_eq!(script.to_p2wsh(), p2wsh);
+
+    // Test data are taken from the second output of
+    // 2ccb3a1f745eb4eefcf29391460250adda5fab78aaddb902d25d3cd97d9d8e61 transaction
+    let data = hex!("aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a");
+    let op_return = ScriptBuf::new_op_return(data);
+    assert!(op_return.is_op_return());
+    assert_eq!(
+        op_return.to_hex_string(),
+        "6a24aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a"
+    );
+}
+
+#[test]
+fn script_builder_verify() {
+    let simple = Builder::new().push_verify().into_script();
+    assert_eq!(simple.to_hex_string(), "69");
+    let simple2 = Builder::from(vec![]).push_verify().into_script();
+    assert_eq!(simple2.to_hex_string(), "69");
+
+    let nonverify = Builder::new().push_verify().push_verify().into_script();
+    assert_eq!(nonverify.to_hex_string(), "6969");
+    let nonverify2 = Builder::from(vec![0x69]).push_verify().into_script();
+    assert_eq!(nonverify2.to_hex_string(), "6969");
+
+    let equal = Builder::new().push_opcode(OP_EQUAL).push_verify().into_script();
+    assert_eq!(equal.to_hex_string(), "88");
+    let equal2 = Builder::from(vec![0x87]).push_verify().into_script();
+    assert_eq!(equal2.to_hex_string(), "88");
+
+    let numequal = Builder::new().push_opcode(OP_NUMEQUAL).push_verify().into_script();
+    assert_eq!(numequal.to_hex_string(), "9d");
+    let numequal2 = Builder::from(vec![0x9c]).push_verify().into_script();
+    assert_eq!(numequal2.to_hex_string(), "9d");
+
+    let checksig = Builder::new().push_opcode(OP_CHECKSIG).push_verify().into_script();
+    assert_eq!(checksig.to_hex_string(), "ad");
+    let checksig2 = Builder::from(vec![0xac]).push_verify().into_script();
+    assert_eq!(checksig2.to_hex_string(), "ad");
+
+    let checkmultisig = Builder::new().push_opcode(OP_CHECKMULTISIG).push_verify().into_script();
+    assert_eq!(checkmultisig.to_hex_string(), "af");
+    let checkmultisig2 = Builder::from(vec![0xae]).push_verify().into_script();
+    assert_eq!(checkmultisig2.to_hex_string(), "af");
+
+    let trick_slice = Builder::new()
+        .push_slice([0xae]) // OP_CHECKMULTISIG
+        .push_verify()
+        .into_script();
+    assert_eq!(trick_slice.to_hex_string(), "01ae69");
+    let trick_slice2 = Builder::from(vec![0x01, 0xae]).push_verify().into_script();
+    assert_eq!(trick_slice2.to_hex_string(), "01ae69");
+}
+
+#[test]
+fn script_serialize() {
+    let hex_script = hex!("6c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52");
+    let script: Result<ScriptBuf, _> = deserialize(&hex_script);
+    assert!(script.is_ok());
+    assert_eq!(serialize(&script.unwrap()), &hex_script as &[u8]);
+}
+
+#[test]
+fn scriptint_round_trip() {
+    fn build_scriptint(n: i64) -> Vec<u8> {
+        let mut buf = [0u8; 8];
+        let len = write_scriptint(&mut buf, n);
+        assert!(len <= 8);
+        buf[..len].to_vec()
+    }
+
+    assert_eq!(build_scriptint(-1), vec![0x81]);
+    assert_eq!(build_scriptint(255), vec![255, 0]);
+    assert_eq!(build_scriptint(256), vec![0, 1]);
+    assert_eq!(build_scriptint(257), vec![1, 1]);
+    assert_eq!(build_scriptint(511), vec![255, 1]);
+    let test_vectors = [
+        10,
+        100,
+        255,
+        256,
+        1000,
+        10000,
+        25000,
+        200000,
+        5000000,
+        1000000000,
+        (1 << 31) - 1,
+        -((1 << 31) - 1),
+    ];
+    for &i in test_vectors.iter() {
+        assert_eq!(Ok(i), read_scriptint(&build_scriptint(i)));
+        assert_eq!(Ok(-i), read_scriptint(&build_scriptint(-i)));
+        assert_eq!(Ok(i), read_scriptint_non_minimal(&build_scriptint(i)));
+        assert_eq!(Ok(-i), read_scriptint_non_minimal(&build_scriptint(-i)));
+    }
+    assert!(read_scriptint(&build_scriptint(1 << 31)).is_err());
+    assert!(read_scriptint(&build_scriptint(-(1 << 31))).is_err());
+    assert!(read_scriptint_non_minimal(&build_scriptint(1 << 31)).is_err());
+    assert!(read_scriptint_non_minimal(&build_scriptint(-(1 << 31))).is_err());
+}
+
+#[test]
+fn non_minimal_scriptints() {
+    assert_eq!(read_scriptint(&[0x80, 0x00]), Ok(0x80));
+    assert_eq!(read_scriptint(&[0xff, 0x00]), Ok(0xff));
+    assert_eq!(read_scriptint(&[0x8f, 0x00, 0x00]), Err(Error::NonMinimalPush));
+    assert_eq!(read_scriptint(&[0x7f, 0x00]), Err(Error::NonMinimalPush));
+
+    assert_eq!(read_scriptint_non_minimal(&[0x80, 0x00]), Ok(0x80));
+    assert_eq!(read_scriptint_non_minimal(&[0xff, 0x00]), Ok(0xff));
+    assert_eq!(read_scriptint_non_minimal(&[0x8f, 0x00, 0x00]), Ok(0x8f));
+    assert_eq!(read_scriptint_non_minimal(&[0x7f, 0x00]), Ok(0x7f));
+}
+
+#[test]
+fn script_hashes() {
+    let script = ScriptBuf::from_hex("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").unwrap();
+    assert_eq!(script.script_hash().to_string(), "8292bcfbef1884f73c813dfe9c82fd7e814291ea");
+    assert_eq!(
+        script.wscript_hash().to_string(),
+        "3e1525eb183ad4f9b3c5fa3175bdca2a52e947b135bbb90383bf9f6408e2c324"
+    );
+    assert_eq!(
+        ScriptBuf::from_hex("20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac")
+            .unwrap()
+            .tapscript_leaf_hash()
+            .to_string(),
+        "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21"
+    );
+}
+
+#[test]
+fn provably_unspendable_test() {
+    // p2pk
+    assert!(!ScriptBuf::from_hex("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").unwrap().is_op_return());
+    assert!(!ScriptBuf::from_hex("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").unwrap().is_op_return());
+    // p2pkhash
+    assert!(!ScriptBuf::from_hex("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
+        .unwrap()
+        .is_op_return());
+    assert!(ScriptBuf::from_hex("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
+        .unwrap()
+        .is_op_return());
+}
+
+#[test]
+fn op_return_test() {
+    assert!(ScriptBuf::from_hex("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
+        .unwrap()
+        .is_op_return());
+    assert!(!ScriptBuf::from_hex("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
+        .unwrap()
+        .is_op_return());
+    assert!(!ScriptBuf::from_hex("").unwrap().is_op_return());
+}
+
+#[test]
+fn multisig() {
+    // First multisig? 1-of-2
+    // In block 164467, txid 60a20bd93aa49ab4b28d514ec10b06e1829ce6818ec06cd3aabd013ebcdc4bb1
+    assert!(
+        ScriptBuf::from_hex("514104cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1dfef58bbfbfaff7d8a473e7e2e6d317b87bafe8bde97e3cf8f065dec022b51d11fcdd0d348ac4410461cbdcc5409fb4b4d42b51d33381354d80e550078cb532a34bfa2fcfdeb7d76519aecc62770f5b0e4ef8551946d8a540911abe3e7854a26f39f58b25c15342af52ae")
+            .unwrap()
+            .is_multisig()
+    );
+    // 2-of-2
+    assert!(
+        ScriptBuf::from_hex("5221021c4ac2ecebc398e390e07f045aac5cc421f82f0739c1ce724d3d53964dc6537d21023a2e9155e0b62f76737605504819a2b4e5ce20653f6c397d7a178ae42ba702f452ae")
+            .unwrap()
+            .is_multisig()
+    );
+
+    // Extra opcode after OP_CHECKMULTISIG
+    assert!(
+        !ScriptBuf::from_hex("5221021c4ac2ecebc398e390e07f045aac5cc421f82f0739c1ce724d3d53964dc6537d21023a2e9155e0b62f76737605504819a2b4e5ce20653f6c397d7a178ae42ba702f452ae52")
+            .unwrap()
+            .is_multisig()
+    );
+    // Required sigs > num pubkeys
+    assert!(
+        !ScriptBuf::from_hex("5321021c4ac2ecebc398e390e07f045aac5cc421f82f0739c1ce724d3d53964dc6537d21023a2e9155e0b62f76737605504819a2b4e5ce20653f6c397d7a178ae42ba702f452ae")
+            .unwrap()
+            .is_multisig()
+    );
+    // Num pubkeys != pushnum
+    assert!(
+        !ScriptBuf::from_hex("5221021c4ac2ecebc398e390e07f045aac5cc421f82f0739c1ce724d3d53964dc6537d21023a2e9155e0b62f76737605504819a2b4e5ce20653f6c397d7a178ae42ba702f453ae")
+            .unwrap()
+            .is_multisig()
+    );
+
+    // Taproot hash from another test
+    assert!(!ScriptBuf::from_hex(
+        "20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac"
+    )
+    .unwrap()
+    .is_multisig());
+    // OP_RETURN from another test
+    assert!(!ScriptBuf::from_hex("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
+        .unwrap()
+        .is_multisig());
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn script_json_serialize() {
+    use serde_json;
+
+    let original = ScriptBuf::from_hex("827651a0698faaa9a8a7a687").unwrap();
+    let json = serde_json::to_value(&original).unwrap();
+    assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
+    let des = serde_json::from_value::<ScriptBuf>(json).unwrap();
+    assert_eq!(original, des);
+}
+
+#[test]
+fn script_asm() {
+    assert_eq!(
+        ScriptBuf::from_hex("6363636363686868686800").unwrap().to_asm_string(),
+        "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+    );
+    assert_eq!(
+        ScriptBuf::from_hex("6363636363686868686800").unwrap().to_asm_string(),
+        "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+    );
+    assert_eq!(ScriptBuf::from_hex("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").unwrap().to_asm_string(),
+               "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
+    // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
+    assert_eq!(ScriptBuf::from_hex("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap().to_asm_string(),
+               "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
+    // Various weird scripts found in transaction 6d7ed9914625c73c0288694a6819196a27ef6c08f98e1270d975a8e65a3dc09a
+    // which triggerred overflow bugs on 32-bit machines in script formatting in the past.
+    assert_eq!(
+        ScriptBuf::from_hex("01").unwrap().to_asm_string(),
+        "OP_PUSHBYTES_1 <push past end>"
+    );
+    assert_eq!(
+        ScriptBuf::from_hex("0201").unwrap().to_asm_string(),
+        "OP_PUSHBYTES_2 <push past end>"
+    );
+    assert_eq!(ScriptBuf::from_hex("4c").unwrap().to_asm_string(), "<unexpected end>");
+    assert_eq!(
+        ScriptBuf::from_hex("4c0201").unwrap().to_asm_string(),
+        "OP_PUSHDATA1 <push past end>"
+    );
+    assert_eq!(ScriptBuf::from_hex("4d").unwrap().to_asm_string(), "<unexpected end>");
+    assert_eq!(
+        ScriptBuf::from_hex("4dffff01").unwrap().to_asm_string(),
+        "OP_PUSHDATA2 <push past end>"
+    );
+    assert_eq!(
+        ScriptBuf::from_hex("4effffffff01").unwrap().to_asm_string(),
+        "OP_PUSHDATA4 <push past end>"
+    );
+}
+
+#[test]
+fn script_buf_collect() {
+    assert_eq!(&core::iter::empty::<Instruction<'_>>().collect::<ScriptBuf>(), Script::new());
+    let script = ScriptBuf::from_hex("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap();
+    assert_eq!(script.instructions().collect::<Result<ScriptBuf, _>>().unwrap(), script);
+}
+
+#[test]
+fn script_p2sh_p2p2k_template() {
+    // random outputs I picked out of the mempool
+    assert!(ScriptBuf::from_hex("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac")
+        .unwrap()
+        .is_p2pkh());
+    assert!(!ScriptBuf::from_hex("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac")
+        .unwrap()
+        .is_p2sh());
+    assert!(!ScriptBuf::from_hex("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad")
+        .unwrap()
+        .is_p2pkh());
+    assert!(!ScriptBuf::from_hex("").unwrap().is_p2pkh());
+    assert!(ScriptBuf::from_hex("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87")
+        .unwrap()
+        .is_p2sh());
+    assert!(!ScriptBuf::from_hex("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87")
+        .unwrap()
+        .is_p2pkh());
+    assert!(!ScriptBuf::from_hex("a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87")
+        .unwrap()
+        .is_p2sh());
+}
+
+#[test]
+fn script_p2pk() {
+    assert!(ScriptBuf::from_hex(
+        "21021aeaf2f8638a129a3156fbe7e5ef635226b0bafd495ff03afe2c843d7e3a4b51ac"
+    )
+    .unwrap()
+    .is_p2pk());
+    assert!(ScriptBuf::from_hex("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac").unwrap().is_p2pk());
+}
+
+#[test]
+fn p2sh_p2wsh_conversion() {
+    // Test vectors taken from Core tests/data/script_tests.json
+    // bare p2wsh
+    let redeem_script = ScriptBuf::from_hex("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac").unwrap();
+    let expected_witout =
+        ScriptBuf::from_hex("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64")
+            .unwrap();
+    assert!(redeem_script.to_p2wsh().is_p2wsh());
+    assert_eq!(redeem_script.to_p2wsh(), expected_witout);
+
+    // p2sh
+    let redeem_script = ScriptBuf::from_hex("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8").unwrap();
+    let expected_p2shout =
+        ScriptBuf::from_hex("a91491b24bf9f5288532960ac687abb035127b1d28a587").unwrap();
+    assert!(redeem_script.to_p2sh().is_p2sh());
+    assert_eq!(redeem_script.to_p2sh(), expected_p2shout);
+
+    // p2sh-p2wsh
+    let redeem_script = ScriptBuf::from_hex("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac").unwrap();
+    let expected_witout =
+        ScriptBuf::from_hex("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64")
+            .unwrap();
+    let expected_out =
+        ScriptBuf::from_hex("a914f386c2ba255cc56d20cfa6ea8b062f8b5994551887").unwrap();
+    assert!(redeem_script.to_p2sh().is_p2sh());
+    assert!(redeem_script.to_p2sh().to_p2wsh().is_p2wsh());
+    assert_eq!(redeem_script.to_p2wsh(), expected_witout);
+    assert_eq!(redeem_script.to_p2wsh().to_p2sh(), expected_out);
+}
+
+macro_rules! unwrap_all {
+    ($($var:ident),*) => {
+        $(
+            let $var = $var.unwrap();
+        )*
+    }
+}
+
+#[test]
+fn test_iterator() {
+    let zero = ScriptBuf::from_hex("00").unwrap();
+    let zeropush = ScriptBuf::from_hex("0100").unwrap();
+
+    let nonminimal = ScriptBuf::from_hex("4c0169b2").unwrap(); // PUSHDATA1 for no reason
+    let minimal = ScriptBuf::from_hex("0169b2").unwrap(); // minimal
+    let nonminimal_alt = ScriptBuf::from_hex("026900b2").unwrap(); // non-minimal number but minimal push (should be OK)
+
+    let v_zero: Result<Vec<_>, Error> = zero.instruction_indices_minimal().collect();
+    let v_zeropush: Result<Vec<_>, Error> = zeropush.instruction_indices_minimal().collect();
+
+    let v_min: Result<Vec<_>, Error> = minimal.instruction_indices_minimal().collect();
+    let v_nonmin: Result<Vec<_>, Error> = nonminimal.instruction_indices_minimal().collect();
+    let v_nonmin_alt: Result<Vec<_>, Error> =
+        nonminimal_alt.instruction_indices_minimal().collect();
+    let slop_v_min: Result<Vec<_>, Error> = minimal.instruction_indices().collect();
+    let slop_v_nonmin: Result<Vec<_>, Error> = nonminimal.instruction_indices().collect();
+    let slop_v_nonmin_alt: Result<Vec<_>, Error> = nonminimal_alt.instruction_indices().collect();
+
+    unwrap_all!(
+        v_zero,
+        v_zeropush,
+        v_min,
+        v_nonmin_alt,
+        slop_v_min,
+        slop_v_nonmin,
+        slop_v_nonmin_alt
+    );
+
+    assert_eq!(v_zero, vec![(0, Instruction::PushBytes(PushBytes::empty()))]);
+    assert_eq!(v_zeropush, vec![(0, Instruction::PushBytes([0].as_ref()))]);
+
+    assert_eq!(
+        v_min,
+        vec![(0, Instruction::PushBytes([105].as_ref())), (2, Instruction::Op(opcodes::OP_NOP3))]
+    );
+
+    assert_eq!(v_nonmin.unwrap_err(), Error::NonMinimalPush);
+
+    assert_eq!(
+        v_nonmin_alt,
+        vec![
+            (0, Instruction::PushBytes([105, 0].as_ref())),
+            (3, Instruction::Op(opcodes::OP_NOP3))
+        ]
+    );
+
+    assert_eq!(v_min, slop_v_min);
+    // indices must differ
+    assert_ne!(v_min, slop_v_nonmin);
+    // but the instructions must be equal
+    for ((_, v_min_instr), (_, slop_v_nomin_instr)) in v_min.iter().zip(&slop_v_nonmin) {
+        assert_eq!(v_min_instr, slop_v_nomin_instr);
+    }
+    assert_eq!(v_nonmin_alt, slop_v_nonmin_alt);
+}
+
+#[test]
+fn script_ord() {
+    let script_1 = Builder::new().push_slice([1, 2, 3, 4]).into_script();
+    let script_2 = Builder::new().push_int(10).into_script();
+    let script_3 = Builder::new().push_int(15).into_script();
+    let script_4 = Builder::new().push_opcode(OP_RETURN).into_script();
+
+    assert!(script_1 < script_2);
+    assert!(script_2 < script_3);
+    assert!(script_3 < script_4);
+
+    assert!(script_1 <= script_1);
+    assert!(script_1 >= script_1);
+
+    assert!(script_4 > script_3);
+    assert!(script_3 > script_2);
+    assert!(script_2 > script_1);
+}
+
+#[test]
+#[cfg(feature = "bitcoinconsensus")]
+fn test_bitcoinconsensus() {
+    // a random segwit transaction from the blockchain using native segwit
+    let spent_bytes = hex!("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d");
+    let spent = Script::from_bytes(&spent_bytes);
+    let spending = hex!("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000");
+    spent.verify(0, crate::Amount::from_sat(18393430), &spending).unwrap();
+}
+
+#[test]
+fn defult_dust_value_tests() {
+    // Check that our dust_value() calculator correctly calculates the dust limit on common
+    // well-known scriptPubKey types.
+    let script_p2wpkh = Builder::new().push_int(0).push_slice([42; 20]).into_script();
+    assert!(script_p2wpkh.is_p2wpkh());
+    assert_eq!(script_p2wpkh.minimal_non_dust(), crate::Amount::from_sat(294));
+    assert_eq!(
+        script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
+        crate::Amount::from_sat(588)
+    );
+
+    let script_p2pkh = Builder::new()
+        .push_opcode(OP_DUP)
+        .push_opcode(OP_HASH160)
+        .push_slice([42; 20])
+        .push_opcode(OP_EQUALVERIFY)
+        .push_opcode(OP_CHECKSIG)
+        .into_script();
+    assert!(script_p2pkh.is_p2pkh());
+    assert_eq!(script_p2pkh.minimal_non_dust(), crate::Amount::from_sat(546));
+    assert_eq!(
+        script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
+        crate::Amount::from_sat(1092)
+    );
+}
+
+#[test]
+fn test_script_get_sigop_count() {
+    assert_eq!(
+        Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice([42; 20])
+            .push_opcode(OP_EQUAL)
+            .into_script()
+            .count_sigops(),
+        0
+    );
+    assert_eq!(
+        Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice([42; 20])
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+            .count_sigops(),
+        1
+    );
+    assert_eq!(
+        Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice([42; 20])
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_opcode(OP_PUSHNUM_1)
+            .into_script()
+            .count_sigops(),
+        1
+    );
+    let multi = Builder::new()
+        .push_opcode(OP_PUSHNUM_1)
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_opcode(OP_PUSHNUM_3)
+        .push_opcode(OP_CHECKMULTISIG)
+        .into_script();
+    assert_eq!(multi.count_sigops(), 3);
+    assert_eq!(multi.count_sigops_legacy(), 20);
+    let multi_verify = Builder::new()
+        .push_opcode(OP_PUSHNUM_1)
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_opcode(OP_PUSHNUM_3)
+        .push_opcode(OP_CHECKMULTISIGVERIFY)
+        .push_opcode(OP_PUSHNUM_1)
+        .into_script();
+    assert_eq!(multi_verify.count_sigops(), 3);
+    assert_eq!(multi_verify.count_sigops_legacy(), 20);
+    let multi_nopushnum_pushdata = Builder::new()
+        .push_opcode(OP_PUSHNUM_1)
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_opcode(OP_CHECKMULTISIG)
+        .into_script();
+    assert_eq!(multi_nopushnum_pushdata.count_sigops(), 20);
+    assert_eq!(multi_nopushnum_pushdata.count_sigops_legacy(), 20);
+    let multi_nopushnum_op = Builder::new()
+        .push_opcode(OP_PUSHNUM_1)
+        .push_slice([3; 33])
+        .push_slice([3; 33])
+        .push_opcode(OP_DROP)
+        .push_opcode(OP_CHECKMULTISIG)
+        .into_script();
+    assert_eq!(multi_nopushnum_op.count_sigops(), 20);
+    assert_eq!(multi_nopushnum_op.count_sigops_legacy(), 20);
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_script_serde_human_and_not() {
+    let script = ScriptBuf::from(vec![0u8, 1u8, 2u8]);
+
+    // Serialize
+    let json = serde_json::to_string(&script).unwrap();
+    assert_eq!(json, "\"000102\"");
+    let bincode = bincode::serialize(&script).unwrap();
+    assert_eq!(bincode, [3, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2]); // bincode adds u64 for length, serde_cbor use varint
+
+    // Deserialize
+    assert_eq!(script, serde_json::from_str::<ScriptBuf>(&json).unwrap());
+    assert_eq!(script, bincode::deserialize::<ScriptBuf>(&bincode).unwrap());
+}
+
+#[test]
+fn test_instructions_are_fused() {
+    let script = ScriptBuf::new();
+    let mut instructions = script.instructions();
+    assert!(instructions.next().is_none());
+    assert!(instructions.next().is_none());
+    assert!(instructions.next().is_none());
+    assert!(instructions.next().is_none());
+}
+
+#[test]
+fn script_extend() {
+    fn cmp_scripts(new_script: &Script, orig_script: &[Instruction<'_>]) {
+        let mut new_instr = new_script.instructions();
+        let mut orig_instr = orig_script.iter().cloned();
+        for (new, orig) in new_instr.by_ref().zip(orig_instr.by_ref()) {
+            assert_eq!(new.unwrap(), orig);
+        }
+        assert!(new_instr.next().is_none() && orig_instr.next().is_none())
+    }
+
+    let script_5_items = [
+        Instruction::Op(OP_DUP),
+        Instruction::Op(OP_HASH160),
+        Instruction::PushBytes([42; 20].as_ref()),
+        Instruction::Op(OP_EQUALVERIFY),
+        Instruction::Op(OP_CHECKSIG),
+    ];
+    let new_script = script_5_items.iter().cloned().collect::<ScriptBuf>();
+    cmp_scripts(&new_script, &script_5_items);
+
+    let script_6_items = [
+        Instruction::Op(OP_DUP),
+        Instruction::Op(OP_HASH160),
+        Instruction::PushBytes([42; 20].as_ref()),
+        Instruction::Op(OP_EQUALVERIFY),
+        Instruction::Op(OP_CHECKSIG),
+        Instruction::Op(OP_NOP),
+    ];
+    let new_script = script_6_items.iter().cloned().collect::<ScriptBuf>();
+    cmp_scripts(&new_script, &script_6_items);
+
+    let script_7_items = [
+        Instruction::Op(OP_DUP),
+        Instruction::Op(OP_HASH160),
+        Instruction::PushBytes([42; 20].as_ref()),
+        Instruction::Op(OP_EQUALVERIFY),
+        Instruction::Op(OP_CHECKSIG),
+        Instruction::Op(OP_NOP),
+    ];
+    let new_script = script_7_items.iter().cloned().collect::<ScriptBuf>();
+    cmp_scripts(&new_script, &script_7_items);
+}
+
+#[test]
+fn read_scriptbool_zero_is_false() {
+    let v: Vec<u8> = vec![0x00, 0x00, 0x00, 0x00];
+    assert!(!read_scriptbool(&v));
+
+    let v: Vec<u8> = vec![0x00, 0x00, 0x00, 0x80]; // With sign bit set.
+    assert!(!read_scriptbool(&v));
+}
+
+#[test]
+fn read_scriptbool_non_zero_is_true() {
+    let v: Vec<u8> = vec![0x01, 0x00, 0x00, 0x00];
+    assert!(read_scriptbool(&v));
+
+    let v: Vec<u8> = vec![0x01, 0x00, 0x00, 0x80]; // With sign bit set.
+    assert!(read_scriptbool(&v));
+}
+
+#[test]
+fn instruction_script_num_parse() {
+    let push_bytes = [
+        (PushBytesBuf::from([]), Some(0)),
+        (PushBytesBuf::from([0x00]), Some(0)),
+        (PushBytesBuf::from([0x01]), Some(1)),
+        // Check all the negative 1s
+        (PushBytesBuf::from([0x81]), Some(-1)),
+        (PushBytesBuf::from([0x01, 0x80]), Some(-1)),
+        (PushBytesBuf::from([0x01, 0x00, 0x80]), Some(-1)),
+        (PushBytesBuf::from([0x01, 0x00, 0x00, 0x80]), Some(-1)),
+        // Check all the negative 0s
+        (PushBytesBuf::from([0x80]), Some(0)),
+        (PushBytesBuf::from([0x00, 0x80]), Some(0)),
+        (PushBytesBuf::from([0x00, 0x00, 0x80]), Some(0)),
+        (PushBytesBuf::from([0x00, 0x00, 0x00, 0x80]), Some(0)),
+        // Too long
+        (PushBytesBuf::from([0x01, 0x00, 0x00, 0x00, 0x80]), None),
+        // Check the position of all the bytes
+        (PushBytesBuf::from([0xef, 0xbe, 0xad, 0x5e]), Some(0x5eadbeef)),
+        // Add negative
+        (PushBytesBuf::from([0xef, 0xbe, 0xad, 0xde]), Some(-0x5eadbeef)),
+    ];
+    let ops = [
+        (Instruction::Op(opcodes::all::OP_PUSHDATA4), None),
+        (Instruction::Op(opcodes::all::OP_PUSHNUM_NEG1), Some(-1)),
+        (Instruction::Op(opcodes::all::OP_RESERVED), None),
+        (Instruction::Op(opcodes::all::OP_PUSHNUM_1), Some(1)),
+        (Instruction::Op(opcodes::all::OP_PUSHNUM_16), Some(16)),
+        (Instruction::Op(opcodes::all::OP_NOP), None),
+    ];
+    for (input, expected) in &push_bytes {
+        assert_eq!(Instruction::PushBytes(input).script_num(), *expected);
+    }
+    for (input, expected) in &ops {
+        assert_eq!(input.script_num(), *expected);
+    }
+
+    // script_num() is predicated on OP_0/OP_FALSE (0x00)
+    // being treated as an empty PushBytes
+    assert_eq!(
+        Script::from_bytes(&[0x00]).instructions().next(),
+        Some(Ok(Instruction::PushBytes(PushBytes::empty()))),
+    );
+}

--- a/libs/bitcoin/src/blockdata/script/witness_program.rs
+++ b/libs/bitcoin/src/blockdata/script/witness_program.rs
@@ -1,0 +1,162 @@
+//! The segregated witness program as defined by [BIP141].
+//!
+//! > A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte push
+//! > opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new special
+//! > meaning. The value of the first push is called the "version byte". The following byte
+//! > vector pushed is called the "witness program".
+//!
+//! [BIP141]: <https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki>
+
+use core::fmt;
+
+use hashes::Hash as _;
+use internals::array_vec::ArrayVec;
+use secp256k1::{Secp256k1, Verification};
+
+use crate::blockdata::script::witness_version::WitnessVersion;
+use crate::blockdata::script::{PushBytes, Script};
+use crate::crypto::key::{CompressedPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::taproot::TapNodeHash;
+
+/// The minimum byte size of a segregated witness program.
+pub const MIN_SIZE: usize = 2;
+
+/// The maximum byte size of a segregated witness program.
+pub const MAX_SIZE: usize = 40;
+
+/// The segregated witness program.
+///
+/// The segregated witness program is technically only the program bytes _excluding_ the witness
+/// version, however we maintain length invariants on the `program` that are governed by the version
+/// number, therefore we carry the version number around along with the program bytes.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WitnessProgram {
+    /// The segwit version associated with this witness program.
+    version: WitnessVersion,
+    /// The witness program (between 2 and 40 bytes).
+    program: ArrayVec<u8, MAX_SIZE>,
+}
+
+impl WitnessProgram {
+    /// Creates a new witness program, copying the content from the given byte slice.
+    pub fn new(version: WitnessVersion, bytes: &[u8]) -> Result<Self, Error> {
+        use Error::*;
+
+        let program_len = bytes.len();
+        if program_len < MIN_SIZE || program_len > MAX_SIZE {
+            return Err(InvalidLength(program_len));
+        }
+
+        // Specific segwit v0 check. These addresses can never spend funds sent to them.
+        if version == WitnessVersion::V0 && (program_len != 20 && program_len != 32) {
+            return Err(InvalidSegwitV0Length(program_len));
+        }
+
+        let program = ArrayVec::from_slice(bytes);
+        Ok(WitnessProgram { version, program })
+    }
+
+    /// Creates a [`WitnessProgram`] from a 20 byte pubkey hash.
+    fn new_p2wpkh(program: [u8; 20]) -> Self {
+        WitnessProgram { version: WitnessVersion::V0, program: ArrayVec::from_slice(&program) }
+    }
+
+    /// Creates a [`WitnessProgram`] from a 32 byte script hash.
+    fn new_p2wsh(program: [u8; 32]) -> Self {
+        WitnessProgram { version: WitnessVersion::V0, program: ArrayVec::from_slice(&program) }
+    }
+
+    /// Creates a [`WitnessProgram`] from a 32 byte serialize taproot xonly pubkey.
+    fn new_p2tr(program: [u8; 32]) -> Self {
+        WitnessProgram { version: WitnessVersion::V1, program: ArrayVec::from_slice(&program) }
+    }
+
+    /// Creates a [`WitnessProgram`] from `pk` for a P2WPKH output.
+    pub fn p2wpkh(pk: &CompressedPublicKey) -> Self {
+        let hash = pk.wpubkey_hash();
+        WitnessProgram::new_p2wpkh(hash.to_byte_array())
+    }
+
+    /// Creates a [`WitnessProgram`] from `script` for a P2WSH output.
+    pub fn p2wsh(script: &Script) -> Self {
+        let hash = script.wscript_hash();
+        WitnessProgram::new_p2wsh(hash.to_byte_array())
+    }
+
+    /// Creates a pay to taproot address from an untweaked key.
+    pub fn p2tr<C: Verification>(
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
+        let pubkey = output_key.to_inner().serialize();
+        WitnessProgram::new_p2tr(pubkey)
+    }
+
+    /// Creates a pay to taproot address from a pre-tweaked output key.
+    pub fn p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
+        let pubkey = output_key.to_inner().serialize();
+        WitnessProgram::new_p2tr(pubkey)
+    }
+
+    /// Returns the witness program version.
+    pub fn version(&self) -> WitnessVersion { self.version }
+
+    /// Returns the witness program.
+    pub fn program(&self) -> &PushBytes {
+        self.program
+            .as_slice()
+            .try_into()
+            .expect("witness programs are always smaller than max size of PushBytes")
+    }
+
+    /// Returns true if this witness program is for a P2WPKH output.
+    pub fn is_p2wpkh(&self) -> bool {
+        self.version == WitnessVersion::V0 && self.program.len() == 20
+    }
+
+    /// Returns true if this witness program is for a P2WPSH output.
+    pub fn is_p2wsh(&self) -> bool {
+        self.version == WitnessVersion::V0 && self.program.len() == 32
+    }
+
+    /// Returns true if this witness program is for a P2TR output.
+    pub fn is_p2tr(&self) -> bool { self.version == WitnessVersion::V1 && self.program.len() == 32 }
+}
+
+/// Witness program error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// The witness program must be between 2 and 40 bytes in length.
+    InvalidLength(usize),
+    /// A v0 witness program must be either of length 20 or 32.
+    InvalidSegwitV0Length(usize),
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            InvalidLength(len) =>
+                write!(f, "witness program must be between 2 and 40 bytes: length={}", len),
+            InvalidSegwitV0Length(len) =>
+                write!(f, "a v0 witness program must be either 20 or 32 bytes: length={}", len),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            InvalidLength(_) | InvalidSegwitV0Length(_) => None,
+        }
+    }
+}

--- a/libs/bitcoin/src/blockdata/script/witness_version.rs
+++ b/libs/bitcoin/src/blockdata/script/witness_version.rs
@@ -1,0 +1,269 @@
+//! The segregated witness version byte as defined by [BIP141].
+//!
+//! > A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte push
+//! > opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new special
+//! > meaning. The value of the first push is called the "version byte". The following byte
+//! > vector pushed is called the "witness program".
+//!
+//! [BIP141]: <https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki>
+
+use core::fmt;
+use core::str::FromStr;
+
+use bech32::Fe32;
+use internals::write_err;
+use units::{parse, ParseIntError};
+
+use crate::blockdata::opcodes::all::*;
+use crate::blockdata::opcodes::Opcode;
+use crate::blockdata::script::Instruction;
+
+/// Version of the segregated witness program.
+///
+/// Helps limit possible versions of the witness according to the specification. If a plain `u8`
+/// type was used instead it would mean that the version may be > 16, which would be incorrect.
+///
+/// First byte of `scriptPubkey` in transaction output for transactions starting with opcodes
+/// ranging from 0 to 16 (inclusive).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[repr(u8)]
+pub enum WitnessVersion {
+    /// Initial version of witness program. Used for P2WPKH and P2WPK outputs
+    V0 = 0,
+    /// Version of witness program used for Taproot P2TR outputs.
+    V1 = 1,
+    /// Future (unsupported) version of witness program.
+    V2 = 2,
+    /// Future (unsupported) version of witness program.
+    V3 = 3,
+    /// Future (unsupported) version of witness program.
+    V4 = 4,
+    /// Future (unsupported) version of witness program.
+    V5 = 5,
+    /// Future (unsupported) version of witness program.
+    V6 = 6,
+    /// Future (unsupported) version of witness program.
+    V7 = 7,
+    /// Future (unsupported) version of witness program.
+    V8 = 8,
+    /// Future (unsupported) version of witness program.
+    V9 = 9,
+    /// Future (unsupported) version of witness program.
+    V10 = 10,
+    /// Future (unsupported) version of witness program.
+    V11 = 11,
+    /// Future (unsupported) version of witness program.
+    V12 = 12,
+    /// Future (unsupported) version of witness program.
+    V13 = 13,
+    /// Future (unsupported) version of witness program.
+    V14 = 14,
+    /// Future (unsupported) version of witness program.
+    V15 = 15,
+    /// Future (unsupported) version of witness program.
+    V16 = 16,
+}
+
+impl WitnessVersion {
+    /// Returns integer version number representation for a given [`WitnessVersion`] value.
+    ///
+    /// NB: this is not the same as an integer representation of the opcode signifying witness
+    /// version in bitcoin script. Thus, there is no function to directly convert witness version
+    /// into a byte since the conversion requires context (bitcoin script or just a version number).
+    pub fn to_num(self) -> u8 { self as u8 }
+
+    /// Converts this witness version to a GF32 field element.
+    pub fn to_fe(self) -> Fe32 {
+        Fe32::try_from(self.to_num()).expect("0-16 are valid fe32 values")
+    }
+}
+
+/// Prints [`WitnessVersion`] number (from 0 to 16) as integer, without any prefix or suffix.
+impl fmt::Display for WitnessVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", *self as u8) }
+}
+
+impl FromStr for WitnessVersion {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version: u8 = parse::int(s)?;
+        Ok(WitnessVersion::try_from(version)?)
+    }
+}
+
+impl TryFrom<bech32::Fe32> for WitnessVersion {
+    type Error = TryFromError;
+
+    fn try_from(value: Fe32) -> Result<Self, Self::Error> { Self::try_from(value.to_u8()) }
+}
+
+impl TryFrom<u8> for WitnessVersion {
+    type Error = TryFromError;
+
+    fn try_from(no: u8) -> Result<Self, Self::Error> {
+        use WitnessVersion::*;
+
+        Ok(match no {
+            0 => V0,
+            1 => V1,
+            2 => V2,
+            3 => V3,
+            4 => V4,
+            5 => V5,
+            6 => V6,
+            7 => V7,
+            8 => V8,
+            9 => V9,
+            10 => V10,
+            11 => V11,
+            12 => V12,
+            13 => V13,
+            14 => V14,
+            15 => V15,
+            16 => V16,
+            invalid => return Err(TryFromError { invalid }),
+        })
+    }
+}
+
+impl TryFrom<Opcode> for WitnessVersion {
+    type Error = TryFromError;
+
+    fn try_from(opcode: Opcode) -> Result<Self, Self::Error> {
+        match opcode.to_u8() {
+            0 => Ok(WitnessVersion::V0),
+            version if version >= OP_PUSHNUM_1.to_u8() && version <= OP_PUSHNUM_16.to_u8() =>
+                WitnessVersion::try_from(version - OP_PUSHNUM_1.to_u8() + 1),
+            invalid => Err(TryFromError { invalid }),
+        }
+    }
+}
+
+impl<'a> TryFrom<Instruction<'a>> for WitnessVersion {
+    type Error = TryFromInstructionError;
+
+    fn try_from(instruction: Instruction) -> Result<Self, Self::Error> {
+        match instruction {
+            Instruction::Op(op) => Ok(WitnessVersion::try_from(op)?),
+            Instruction::PushBytes(bytes) if bytes.is_empty() => Ok(WitnessVersion::V0),
+            Instruction::PushBytes(_) => Err(TryFromInstructionError::DataPush),
+        }
+    }
+}
+
+impl From<WitnessVersion> for Fe32 {
+    fn from(version: WitnessVersion) -> Self { version.to_fe() }
+}
+
+impl From<WitnessVersion> for Opcode {
+    fn from(version: WitnessVersion) -> Opcode {
+        match version {
+            WitnessVersion::V0 => OP_PUSHBYTES_0,
+            no => Opcode::from(OP_PUSHNUM_1.to_u8() + no.to_num() - 1),
+        }
+    }
+}
+
+/// Error parsing [`WitnessVersion`] from a string.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FromStrError {
+    /// Unable to parse integer from string.
+    Unparsable(ParseIntError),
+    /// String contained an invalid witness version number.
+    Invalid(TryFromError),
+}
+
+internals::impl_from_infallible!(FromStrError);
+
+impl fmt::Display for FromStrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FromStrError::*;
+
+        match *self {
+            Unparsable(ref e) => write_err!(f, "integer parse error"; e),
+            Invalid(ref e) => write_err!(f, "invalid version number"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromStrError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromStrError::*;
+
+        match *self {
+            Unparsable(ref e) => Some(e),
+            Invalid(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ParseIntError> for FromStrError {
+    fn from(e: ParseIntError) -> Self { Self::Unparsable(e) }
+}
+
+impl From<TryFromError> for FromStrError {
+    fn from(e: TryFromError) -> Self { Self::Invalid(e) }
+}
+
+/// Error attempting to create a [`WitnessVersion`] from an [`Instruction`]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TryFromInstructionError {
+    /// Cannot not convert OP to a witness version.
+    TryFrom(TryFromError),
+    /// Cannot create a witness version from non-zero data push.
+    DataPush,
+}
+
+internals::impl_from_infallible!(TryFromInstructionError);
+
+impl fmt::Display for TryFromInstructionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use TryFromInstructionError::*;
+
+        match *self {
+            TryFrom(ref e) => write_err!(f, "opcode is not a valid witness version"; e),
+            DataPush => write!(f, "non-zero data push opcode is not a valid witness version"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromInstructionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use TryFromInstructionError::*;
+
+        match *self {
+            TryFrom(ref e) => Some(e),
+            DataPush => None,
+        }
+    }
+}
+
+impl From<TryFromError> for TryFromInstructionError {
+    fn from(e: TryFromError) -> Self { Self::TryFrom(e) }
+}
+
+/// Error attempting to create a [`WitnessVersion`] from an integer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TryFromError {
+    /// The invalid non-witness version integer.
+    invalid: u8,
+}
+
+impl TryFromError {
+    /// Returns the invalid non-witness version integer.
+    pub fn invalid_version(&self) -> u8 { self.invalid }
+}
+
+impl fmt::Display for TryFromError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid witness script version: {}", self.invalid)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromError {}

--- a/libs/bitcoin/src/blockdata/transaction.rs
+++ b/libs/bitcoin/src/blockdata/transaction.rs
@@ -1,0 +1,2730 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin transactions.
+//!
+//! A transaction describes a transfer of money. It consumes previously-unspent
+//! transaction outputs and produces new ones, satisfying the condition to spend
+//! the old outputs (typically a digital signature with a specific key must be
+//! provided) and defining the condition to spend the new ones. The use of digital
+//! signatures ensures that coins cannot be spent by unauthorized parties.
+//!
+//! This module provides the structures and functions needed to support transactions.
+//!
+
+use core::str::FromStr;
+use core::{cmp, fmt};
+
+use hashes::{sha256d, Hash};
+use internals::write_err;
+use io::{Read, Write};
+use units::parse::{self, ParseIntError};
+
+use super::Weight;
+use crate::blockdata::locktime::absolute::{self, Height, Time};
+use crate::blockdata::locktime::relative::{self, TimeOverflowError};
+use crate::blockdata::script::{Script, ScriptBuf};
+use crate::blockdata::witness::Witness;
+use crate::blockdata::FeeRate;
+use crate::consensus::{encode, Decodable, Encodable};
+use crate::error::{ContainsPrefixError, MissingPrefixError, PrefixedHexError, UnprefixedHexError};
+use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
+use crate::prelude::*;
+#[cfg(doc)]
+use crate::sighash::{EcdsaSighashType, TapSighashType};
+use crate::{Amount, SignedAmount, VarInt};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[cfg(feature = "bitcoinconsensus")]
+#[doc(inline)]
+pub use crate::consensus::validation::TxVerifyError;
+
+hashes::hash_newtype! {
+    /// A bitcoin transaction hash/transaction ID.
+    ///
+    /// For compatibility with the existing Bitcoin infrastructure and historical and current
+    /// versions of the Bitcoin Core software itself, this and other [`sha256d::Hash`] types, are
+    /// serialized in reverse byte order when converted to a hex string via [`std::fmt::Display`]
+    /// trait operations. See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
+    pub struct Txid(sha256d::Hash);
+
+    /// A bitcoin witness transaction ID.
+    pub struct Wtxid(sha256d::Hash);
+}
+impl_hashencode!(Txid);
+impl_hashencode!(Wtxid);
+
+/// The marker MUST be a 1-byte zero value: 0x00. (BIP-141)
+const SEGWIT_MARKER: u8 = 0x00;
+/// The flag MUST be a 1-byte non-zero value. Currently, 0x01 MUST be used. (BIP-141)
+const SEGWIT_FLAG: u8 = 0x01;
+
+/// A reference to a transaction output.
+///
+/// ### Bitcoin Core References
+///
+/// * [COutPoint definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L26)
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct OutPoint {
+    /// The referenced transaction's txid.
+    pub txid: Txid,
+    /// The index of the referenced output in its transaction's vout.
+    pub vout: u32,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_struct_human_string_impl!(OutPoint, "an OutPoint", txid, vout);
+
+impl OutPoint {
+    /// The number of bytes that an outpoint contributes to the size of a transaction.
+    const SIZE: usize = 32 + 4; // The serialized lengths of txid and vout.
+
+    /// Creates a new [`OutPoint`].
+    #[inline]
+    pub const fn new(txid: Txid, vout: u32) -> OutPoint {
+        OutPoint { txid, vout }
+    }
+
+    /// Creates a "null" `OutPoint`.
+    ///
+    /// This value is used for coinbase transactions because they don't have any previous outputs.
+    #[inline]
+    pub fn null() -> OutPoint {
+        OutPoint {
+            txid: Hash::all_zeros(),
+            vout: u32::MAX,
+        }
+    }
+
+    /// Checks if an `OutPoint` is "null".
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::consensus::params;
+    /// use bitcoin::constants::genesis_block;
+    /// use bitcoin::Network;
+    ///
+    /// let block = genesis_block(&params::MAINNET);
+    /// let tx = &block.txdata[0];
+    ///
+    /// // Coinbase transactions don't have any previous output.
+    /// assert!(tx.input[0].previous_output.is_null());
+    /// ```
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        *self == OutPoint::null()
+    }
+}
+
+impl Default for OutPoint {
+    fn default() -> Self {
+        OutPoint::null()
+    }
+}
+
+impl fmt::Display for OutPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.txid, self.vout)
+    }
+}
+
+/// An error in parsing an OutPoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseOutPointError {
+    /// Error in TXID part.
+    Txid(hex::HexToArrayError),
+    /// Error in vout part.
+    Vout(crate::error::ParseIntError),
+    /// Error in general format.
+    Format,
+    /// Size exceeds max.
+    TooLong,
+    /// Vout part is not strictly numeric without leading zeroes.
+    VoutNotCanonical,
+}
+
+internals::impl_from_infallible!(ParseOutPointError);
+
+impl fmt::Display for ParseOutPointError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParseOutPointError::*;
+
+        match *self {
+            Txid(ref e) => write_err!(f, "error parsing TXID"; e),
+            Vout(ref e) => write_err!(f, "error parsing vout"; e),
+            Format => write!(f, "OutPoint not in <txid>:<vout> format"),
+            TooLong => write!(f, "vout should be at most 10 digits"),
+            VoutNotCanonical => write!(f, "no leading zeroes or + allowed in vout part"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseOutPointError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ParseOutPointError::*;
+
+        match self {
+            Txid(e) => Some(e),
+            Vout(e) => Some(e),
+            Format | TooLong | VoutNotCanonical => None,
+        }
+    }
+}
+
+/// Parses a string-encoded transaction index (vout).
+///
+/// Does not permit leading zeroes or non-digit characters.
+fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
+    if s.len() > 1 {
+        let first = s.chars().next().unwrap();
+        if first == '0' || first == '+' {
+            return Err(ParseOutPointError::VoutNotCanonical);
+        }
+    }
+    parse::int(s).map_err(ParseOutPointError::Vout)
+}
+
+impl core::str::FromStr for OutPoint {
+    type Err = ParseOutPointError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > 75 {
+            // 64 + 1 + 10
+            return Err(ParseOutPointError::TooLong);
+        }
+        let find = s.find(':');
+        if find.is_none() || find != s.rfind(':') {
+            return Err(ParseOutPointError::Format);
+        }
+        let colon = find.unwrap();
+        if colon == 0 || colon == s.len() - 1 {
+            return Err(ParseOutPointError::Format);
+        }
+        Ok(OutPoint {
+            txid: s[..colon].parse().map_err(ParseOutPointError::Txid)?,
+            vout: parse_vout(&s[colon + 1..])?,
+        })
+    }
+}
+
+/// Bitcoin transaction input.
+///
+/// It contains the location of the previous transaction's output,
+/// that it spends and set of scripts that satisfy its spending
+/// conditions.
+///
+/// ### Bitcoin Core References
+///
+/// * [CTxIn definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L65)
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct TxIn {
+    /// The reference to the previous output that is being used as an input.
+    pub previous_output: OutPoint,
+    /// The script which pushes values on the stack which will cause
+    /// the referenced output's script to be accepted.
+    pub script_sig: ScriptBuf,
+    /// The sequence number, which suggests to miners which of two
+    /// conflicting transactions should be preferred, or 0xFFFFFFFF
+    /// to ignore this feature. This is generally never used since
+    /// the miner behavior cannot be enforced.
+    pub sequence: Sequence,
+    /// Witness data: an array of byte-arrays.
+    /// Note that this field is *not* (de)serialized with the rest of the TxIn in
+    /// Encodable/Decodable, as it is (de)serialized at the end of the full
+    /// Transaction. It *is* (de)serialized with the rest of the TxIn in other
+    /// (de)serialization routines.
+    pub witness: Witness,
+}
+
+impl TxIn {
+    /// Returns the input base weight.
+    ///
+    /// Base weight excludes the witness and script.
+    const BASE_WEIGHT: Weight =
+        Weight::from_vb_unwrap(OutPoint::SIZE as u64 + Sequence::SIZE as u64);
+
+    /// Returns true if this input enables the [`absolute::LockTime`] (aka `nLockTime`) of its
+    /// [`Transaction`].
+    ///
+    /// `nLockTime` is enabled if *any* input enables it. See [`Transaction::is_lock_time_enabled`]
+    ///  to check the overall state. If none of the inputs enables it, the lock time value is simply
+    ///  ignored. If this returns false and OP_CHECKLOCKTIMEVERIFY is used in the redeem script with
+    ///  this input then the script execution will fail [BIP-0065].
+    ///
+    /// [BIP-65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+    pub fn enables_lock_time(&self) -> bool {
+        self.sequence != Sequence::MAX
+    }
+
+    /// The weight of the TxIn when it's included in a legacy transaction (i.e., a transaction
+    /// having only legacy inputs).
+    ///
+    /// The witness weight is ignored here even when the witness is non-empty.
+    /// If you want the witness to be taken into account, use `TxIn::segwit_weight` instead.
+    ///
+    /// Keep in mind that when adding a TxIn to a transaction, the total weight of the transaction
+    /// might increase more than `TxIn::legacy_weight`. This happens when the new input added causes
+    /// the input length `VarInt` to increase its encoding length.
+    pub fn legacy_weight(&self) -> Weight {
+        Weight::from_non_witness_data_size(self.base_size() as u64)
+    }
+
+    /// The weight of the TxIn when it's included in a segwit transaction (i.e., a transaction
+    /// having at least one segwit input).
+    ///
+    /// This always takes into account the witness, even when empty, in which
+    /// case 1WU for the witness length varint (`00`) is included.
+    ///
+    /// Keep in mind that when adding a TxIn to a transaction, the total weight of the transaction
+    /// might increase more than `TxIn::segwit_weight`. This happens when:
+    /// - the new input added causes the input length `VarInt` to increase its encoding length
+    /// - the new input is the first segwit input added - this will add an additional 2WU to the
+    ///   transaction weight to take into account the segwit marker
+    pub fn segwit_weight(&self) -> Weight {
+        Weight::from_non_witness_data_size(self.base_size() as u64)
+            + Weight::from_witness_data_size(self.witness.size() as u64)
+    }
+
+    /// Returns the base size of this input.
+    ///
+    /// Base size excludes the witness data (see [`Self::total_size`]).
+    pub fn base_size(&self) -> usize {
+        let mut size = OutPoint::SIZE;
+
+        size += VarInt::from(self.script_sig.len()).size();
+        size += self.script_sig.len();
+
+        size + Sequence::SIZE
+    }
+
+    /// Returns the total number of bytes that this input contributes to a transaction.
+    ///
+    /// Total size includes the witness data (for base size see [`Self::base_size`]).
+    pub fn total_size(&self) -> usize {
+        self.base_size() + self.witness.size()
+    }
+}
+
+impl Default for TxIn {
+    fn default() -> TxIn {
+        TxIn {
+            previous_output: OutPoint::default(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::default(),
+        }
+    }
+}
+
+/// Bitcoin transaction input sequence number.
+///
+/// The sequence field is used for:
+/// - Indicating whether absolute lock-time (specified in `lock_time` field of [`Transaction`])
+///   is enabled.
+/// - Indicating and encoding [BIP-68] relative lock-times.
+/// - Indicating whether a transaction opts-in to [BIP-125] replace-by-fee.
+///
+/// Note that transactions spending an output with `OP_CHECKLOCKTIMEVERIFY`MUST NOT use
+/// `Sequence::MAX` for the corresponding input. [BIP-65]
+///
+/// [BIP-65]: <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
+/// [BIP-68]: <https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki>
+/// [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki>
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Sequence(pub u32);
+
+impl Sequence {
+    /// The maximum allowable sequence number.
+    ///
+    /// This sequence number disables absolute lock time and replace-by-fee.
+    pub const MAX: Self = Sequence(0xFFFFFFFF);
+    /// Zero value sequence.
+    ///
+    /// This sequence number enables replace-by-fee and absolute lock time.
+    pub const ZERO: Self = Sequence(0);
+    /// The sequence number that enables absolute lock time but disables replace-by-fee
+    /// and relative lock time.
+    pub const ENABLE_LOCKTIME_NO_RBF: Self = Sequence::MIN_NO_RBF;
+    /// The sequence number that enables replace-by-fee and absolute lock time but
+    /// disables relative lock time.
+    pub const ENABLE_RBF_NO_LOCKTIME: Self = Sequence(0xFFFFFFFD);
+
+    /// The number of bytes that a sequence number contributes to the size of a transaction.
+    const SIZE: usize = 4; // Serialized length of a u32.
+
+    /// The lowest sequence number that does not opt-in for replace-by-fee.
+    ///
+    /// A transaction is considered to have opted in to replacement of itself
+    /// if any of it's inputs have a `Sequence` number less than this value
+    /// (Explicit Signalling [BIP-125]).
+    ///
+    /// [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki]>
+    const MIN_NO_RBF: Self = Sequence(0xFFFFFFFE);
+    /// BIP-68 relative lock time disable flag mask.
+    const LOCK_TIME_DISABLE_FLAG_MASK: u32 = 0x80000000;
+    /// BIP-68 relative lock time type flag mask.
+    const LOCK_TYPE_MASK: u32 = 0x00400000;
+
+    /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
+    #[inline]
+    pub fn enables_absolute_lock_time(&self) -> bool {
+        *self != Sequence::MAX
+    }
+
+    /// Returns `true` if the sequence number indicates that the transaction is finalized.
+    ///
+    /// Instead of this method please consider using `!enables_absolute_lock_time` because it
+    /// is equivalent and improves readability for those not steeped in Bitcoin folklore.
+    ///
+    /// ## Historical note
+    ///
+    /// The term 'final' is an archaic Bitcoin term, it may have come about because the sequence
+    /// number in the original Bitcoin code was intended to be incremented in order to replace a
+    /// transaction, so once the sequence number got to `u64::MAX` it could no longer be increased,
+    /// hence it was 'final'.
+    ///
+    ///
+    /// Some other references to the term:
+    /// - `CTxIn::SEQUENCE_FINAL` in the Bitcoin Core code.
+    /// - [BIP-112]: "BIP 68 prevents a non-final transaction from being selected for inclusion in a
+    ///   block until the corresponding input has reached the specified age"
+    ///
+    /// [BIP-112]: <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
+    #[inline]
+    pub fn is_final(&self) -> bool {
+        !self.enables_absolute_lock_time()
+    }
+
+    /// Returns true if the transaction opted-in to BIP125 replace-by-fee.
+    ///
+    /// Replace by fee is signaled by the sequence being less than 0xfffffffe which is checked by
+    /// this method. Note, this is the highest "non-final" value (see [`Sequence::is_final`]).
+    #[inline]
+    pub fn is_rbf(&self) -> bool {
+        *self < Sequence::MIN_NO_RBF
+    }
+
+    /// Returns `true` if the sequence has a relative lock-time.
+    #[inline]
+    pub fn is_relative_lock_time(&self) -> bool {
+        self.0 & Sequence::LOCK_TIME_DISABLE_FLAG_MASK == 0
+    }
+
+    /// Returns `true` if the sequence number encodes a block based relative lock-time.
+    #[inline]
+    pub fn is_height_locked(&self) -> bool {
+        self.is_relative_lock_time() & (self.0 & Sequence::LOCK_TYPE_MASK == 0)
+    }
+
+    /// Returns `true` if the sequence number encodes a time interval based relative lock-time.
+    #[inline]
+    pub fn is_time_locked(&self) -> bool {
+        self.is_relative_lock_time() & (self.0 & Sequence::LOCK_TYPE_MASK > 0)
+    }
+
+    /// Creates a `Sequence` from an prefixed hex string.
+    pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
+        let stripped = if let Some(stripped) = s.strip_prefix("0x") {
+            stripped
+        } else if let Some(stripped) = s.strip_prefix("0X") {
+            stripped
+        } else {
+            return Err(MissingPrefixError::new(s).into());
+        };
+
+        let sequence = parse::hex_u32(stripped)?;
+        Ok(Self::from_consensus(sequence))
+    }
+
+    /// Creates a `Sequence` from an unprefixed hex string.
+    pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
+        if s.starts_with("0x") || s.starts_with("0X") {
+            return Err(ContainsPrefixError::new(s).into());
+        }
+        let lock_time = parse::hex_u32(s)?;
+        Ok(Self::from_consensus(lock_time))
+    }
+
+    /// Creates a relative lock-time using block height.
+    #[inline]
+    pub fn from_height(height: u16) -> Self {
+        Sequence(u32::from(height))
+    }
+
+    /// Creates a relative lock-time using time intervals where each interval is equivalent
+    /// to 512 seconds.
+    ///
+    /// Encoding finer granularity of time for relative lock-times is not supported in Bitcoin
+    #[inline]
+    pub fn from_512_second_intervals(intervals: u16) -> Self {
+        Sequence(u32::from(intervals) | Sequence::LOCK_TYPE_MASK)
+    }
+
+    /// Creates a relative lock-time from seconds, converting the seconds into 512 second
+    /// interval with floor division.
+    ///
+    /// Will return an error if the input cannot be encoded in 16 bits.
+    #[inline]
+    pub fn from_seconds_floor(seconds: u32) -> Result<Self, TimeOverflowError> {
+        if let Ok(interval) = u16::try_from(seconds / 512) {
+            Ok(Sequence::from_512_second_intervals(interval))
+        } else {
+            Err(TimeOverflowError::new(seconds))
+        }
+    }
+
+    /// Creates a relative lock-time from seconds, converting the seconds into 512 second
+    /// interval with ceiling division.
+    ///
+    /// Will return an error if the input cannot be encoded in 16 bits.
+    #[inline]
+    pub fn from_seconds_ceil(seconds: u32) -> Result<Self, TimeOverflowError> {
+        if let Ok(interval) = u16::try_from((seconds + 511) / 512) {
+            Ok(Sequence::from_512_second_intervals(interval))
+        } else {
+            Err(TimeOverflowError::new(seconds))
+        }
+    }
+
+    /// Creates a sequence from a u32 value.
+    #[inline]
+    pub fn from_consensus(n: u32) -> Self {
+        Sequence(n)
+    }
+
+    /// Returns the inner 32bit integer value of Sequence.
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 {
+        self.0
+    }
+
+    /// Creates a [`relative::LockTime`] from this [`Sequence`] number.
+    #[inline]
+    pub fn to_relative_lock_time(&self) -> Option<relative::LockTime> {
+        use crate::locktime::relative::{Height, LockTime, Time};
+
+        if !self.is_relative_lock_time() {
+            return None;
+        }
+
+        let lock_value = self.low_u16();
+
+        if self.is_time_locked() {
+            Some(LockTime::from(Time::from_512_second_intervals(lock_value)))
+        } else {
+            Some(LockTime::from(Height::from(lock_value)))
+        }
+    }
+
+    /// Returns the low 16 bits from sequence number.
+    ///
+    /// BIP-68 only uses the low 16 bits for relative lock value.
+    fn low_u16(&self) -> u16 {
+        self.0 as u16
+    }
+}
+
+impl Default for Sequence {
+    /// The default value of sequence is 0xffffffff.
+    fn default() -> Self {
+        Sequence::MAX
+    }
+}
+
+impl From<Sequence> for u32 {
+    fn from(sequence: Sequence) -> u32 {
+        sequence.0
+    }
+}
+
+impl fmt::Display for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // 10 because its 8 digits + 2 for the '0x'
+        write!(f, "Sequence({:#010x})", self.0)
+    }
+}
+
+impl FromStr for Sequence {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse::int::<u32, &str>(s).map(Sequence::from_consensus)
+    }
+}
+
+impl TryFrom<&str> for Sequence {
+    type Error = ParseIntError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Sequence::from_str(s)
+    }
+}
+
+impl TryFrom<String> for Sequence {
+    type Error = ParseIntError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Sequence::from_str(&s)
+    }
+}
+
+impl TryFrom<Box<str>> for Sequence {
+    type Error = ParseIntError;
+
+    fn try_from(s: Box<str>) -> Result<Self, Self::Error> {
+        Sequence::from_str(&s)
+    }
+}
+
+/// Bitcoin transaction output.
+///
+/// Defines new coins to be created as a result of the transaction,
+/// along with spending conditions ("script", aka "output script"),
+/// which an input spending it must satisfy.
+///
+/// An output that is not yet spent by an input is called Unspent Transaction Output ("UTXO").
+///
+/// ### Bitcoin Core References
+///
+/// * [CTxOut definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L148)
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct TxOut {
+    /// The value of the output, in satoshis.
+    pub value: Amount,
+    /// The script which must be satisfied for the output to be spent.
+    pub script_pubkey: ScriptBuf,
+}
+
+impl TxOut {
+    /// This is used as a "null txout" in consensus signing code.
+    pub const NULL: Self = TxOut {
+        value: Amount::from_sat(0xffffffffffffffff),
+        script_pubkey: ScriptBuf::new(),
+    };
+
+    /// The weight of this output.
+    ///
+    /// Keep in mind that when adding a [`TxOut`] to a [`Transaction`] the total weight of the
+    /// transaction might increase more than `TxOut::weight`. This happens when the new output added
+    /// causes the output length `VarInt` to increase its encoding length.
+    ///
+    /// # Panics
+    ///
+    /// If output size * 4 overflows, this should never happen under normal conditions. Use
+    /// `Weght::from_vb_checked(self.size() as u64)` if you are concerned.
+    pub fn weight(&self) -> Weight {
+        // Size is equivalent to virtual size since all bytes of a TxOut are non-witness bytes.
+        Weight::from_vb(self.size() as u64).expect("should never happen under normal conditions")
+    }
+
+    /// Returns the total number of bytes that this output contributes to a transaction.
+    ///
+    /// There is no difference between base size vs total size for outputs.
+    pub fn size(&self) -> usize {
+        size_from_script_pubkey(&self.script_pubkey)
+    }
+
+    /// Creates a `TxOut` with given script and the smallest possible `value` that is **not** dust
+    /// per current Core policy.
+    ///
+    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+    /// This function uses the default value of 0.00003 BTC/kB (3 sat/vByte).
+    ///
+    /// To use a custom value, use [`minimal_non_dust_custom`].
+    ///
+    /// [`minimal_non_dust_custom`]: TxOut::minimal_non_dust_custom
+    pub fn minimal_non_dust(script_pubkey: ScriptBuf) -> Self {
+        TxOut {
+            value: script_pubkey.minimal_non_dust(),
+            script_pubkey,
+        }
+    }
+
+    /// Creates a `TxOut` with given script and the smallest possible `value` that is **not** dust
+    /// per current Core policy.
+    ///
+    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+    /// This function lets you set the fee rate used in dust calculation.
+    ///
+    /// The current default value in Bitcoin Core (as of v26) is 3 sat/vByte.
+    ///
+    /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
+    ///
+    /// [`minimal_non_dust`]: TxOut::minimal_non_dust
+    pub fn minimal_non_dust_custom(script_pubkey: ScriptBuf, dust_relay_fee: FeeRate) -> Self {
+        TxOut {
+            value: script_pubkey.minimal_non_dust_custom(dust_relay_fee),
+            script_pubkey,
+        }
+    }
+}
+
+/// Returns the total number of bytes that this script pubkey would contribute to a transaction.
+fn size_from_script_pubkey(script_pubkey: &Script) -> usize {
+    let len = script_pubkey.len();
+    Amount::SIZE + VarInt::from(len).size() + len
+}
+
+/// Bitcoin transaction.
+///
+/// An authenticated movement of coins.
+///
+/// See [Bitcoin Wiki: Transaction][wiki-transaction] for more information.
+///
+/// [wiki-transaction]: https://en.bitcoin.it/wiki/Transaction
+///
+/// ### Bitcoin Core References
+///
+/// * [CTtransaction definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L279)
+///
+/// ### Serialization notes
+///
+/// If any inputs have nonempty witnesses, the entire transaction is serialized
+/// in the post-BIP141 Segwit format which includes a list of witnesses. If all
+/// inputs have empty witnesses, the transaction is serialized in the pre-BIP141
+/// format.
+///
+/// There is one major exception to this: to avoid deserialization ambiguity,
+/// if the transaction has no inputs, it is serialized in the BIP141 style. Be
+/// aware that this differs from the transaction format in PSBT, which _never_
+/// uses BIP141. (Ordinarily there is no conflict, since in PSBT transactions
+/// are always unsigned and therefore their inputs have empty witnesses.)
+///
+/// The specific ambiguity is that Segwit uses the flag bytes `0001` where an old
+/// serializer would read the number of transaction inputs. The old serializer
+/// would interpret this as "no inputs, one output", which means the transaction
+/// is invalid, and simply reject it. Segwit further specifies that this encoding
+/// should *only* be used when some input has a nonempty witness; that is,
+/// witness-less transactions should be encoded in the traditional format.
+///
+/// However, in protocols where transactions may legitimately have 0 inputs, e.g.
+/// when parties are cooperatively funding a transaction, the "00 means Segwit"
+/// heuristic does not work. Since Segwit requires such a transaction be encoded
+/// in the original transaction format (since it has no inputs and therefore
+/// no input witnesses), a traditionally encoded transaction may have the `0001`
+/// Segwit flag in it, which confuses most Segwit parsers including the one in
+/// Bitcoin Core.
+///
+/// We therefore deviate from the spec by always using the Segwit witness encoding
+/// for 0-input transactions, which results in unambiguously parseable transactions.
+///
+/// ### A note on ordering
+///
+/// This type implements `Ord`, even though it contains a locktime, which is not
+/// itself `Ord`. This was done to simplify applications that may need to hold
+/// transactions inside a sorted container. We have ordered the locktimes based
+/// on their representation as a `u32`, which is not a semantically meaningful
+/// order, and therefore the ordering on `Transaction` itself is not semantically
+/// meaningful either.
+///
+/// The ordering is, however, consistent with the ordering present in this library
+/// before this change, so users should not notice any breakage (here) when
+/// transitioning from 0.29 to 0.30.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Transaction {
+    /// The protocol version, is currently expected to be 1 or 2 (BIP 68).
+    pub version: Version,
+    /// Block height or timestamp. Transaction cannot be included in a block until this height/time.
+    ///
+    /// ### Relevant BIPs
+    ///
+    /// * [BIP-65 OP_CHECKLOCKTIMEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+    /// * [BIP-113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
+    pub lock_time: absolute::LockTime,
+    /// List of transaction inputs.
+    pub input: Vec<TxIn>,
+    /// List of transaction outputs.
+    pub output: Vec<TxOut>,
+}
+
+impl cmp::PartialOrd for Transaction {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl cmp::Ord for Transaction {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.version
+            .cmp(&other.version)
+            .then(
+                self.lock_time
+                    .to_consensus_u32()
+                    .cmp(&other.lock_time.to_consensus_u32()),
+            )
+            .then(self.input.cmp(&other.input))
+            .then(self.output.cmp(&other.output))
+    }
+}
+
+impl Transaction {
+    // https://github.com/bitcoin/bitcoin/blob/44b05bf3fef2468783dcebf651654fdd30717e7e/src/policy/policy.h#L27
+    /// Maximum transaction weight for Bitcoin Core 25.0.
+    pub const MAX_STANDARD_WEIGHT: Weight = Weight::from_wu(400_000);
+
+    /// Computes a "normalized TXID" which does not include any signatures.
+    ///
+    /// This method is deprecated.  Use `compute_ntxid` instead.
+    #[deprecated(
+        since = "0.31.0",
+        note = "ntxid has been renamed to compute_ntxid to note that it's computationally expensive.  use compute_ntxid() instead."
+    )]
+    pub fn ntxid(&self) -> sha256d::Hash {
+        self.compute_ntxid()
+    }
+
+    /// Computes a "normalized TXID" which does not include any signatures.
+    ///
+    /// This gives a way to identify a transaction that is "the same" as
+    /// another in the sense of having same inputs and outputs.
+    #[doc(alias = "ntxid")]
+    pub fn compute_ntxid(&self) -> sha256d::Hash {
+        let cloned_tx = Transaction {
+            version: self.version,
+            lock_time: self.lock_time,
+            input: self
+                .input
+                .iter()
+                .map(|txin| TxIn {
+                    script_sig: ScriptBuf::new(),
+                    witness: Witness::default(),
+                    ..*txin
+                })
+                .collect(),
+            output: self.output.clone(),
+        };
+        cloned_tx.compute_txid().into()
+    }
+
+    /// Computes the [`Txid`].
+    ///
+    /// This method is deprecated.  Use `compute_txid` instead.
+    #[deprecated(
+        since = "0.31.0",
+        note = "txid has been renamed to compute_txid to note that it's computationally expensive.  use compute_txid() instead."
+    )]
+    pub fn txid(&self) -> Txid {
+        self.compute_txid()
+    }
+
+    /// Computes the [`Txid`].
+    ///
+    /// Hashes the transaction **excluding** the segwit data (i.e. the marker, flag bytes, and the
+    /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
+    /// this will be equal to [`Transaction::compute_wtxid()`].
+    #[doc(alias = "txid")]
+    pub fn compute_txid(&self) -> Txid {
+        let mut enc = Txid::engine();
+        self.version
+            .consensus_encode(&mut enc)
+            .expect("engines don't error");
+        self.input
+            .consensus_encode(&mut enc)
+            .expect("engines don't error");
+        self.output
+            .consensus_encode(&mut enc)
+            .expect("engines don't error");
+        self.lock_time
+            .consensus_encode(&mut enc)
+            .expect("engines don't error");
+        Txid::from_engine(enc)
+    }
+
+    /// Computes the segwit version of the transaction id.
+    ///
+    /// This method is deprecated.  Use `compute_wtxid` instead.
+    #[deprecated(
+        since = "0.31.0",
+        note = "wtxid has been renamed to compute_wtxid to note that it's computationally expensive.  use compute_wtxid() instead."
+    )]
+    pub fn wtxid(&self) -> Wtxid {
+        self.compute_wtxid()
+    }
+
+    /// Computes the segwit version of the transaction id.
+    ///
+    /// Hashes the transaction **including** all segwit data (i.e. the marker, flag bytes, and the
+    /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
+    /// this will be equal to [`Transaction::txid()`].
+    #[doc(alias = "wtxid")]
+    pub fn compute_wtxid(&self) -> Wtxid {
+        let mut enc = Wtxid::engine();
+        self.consensus_encode(&mut enc)
+            .expect("engines don't error");
+        Wtxid::from_engine(enc)
+    }
+
+    /// Returns the weight of this transaction, as defined by BIP-141.
+    ///
+    /// > Transaction weight is defined as Base transaction size * 3 + Total transaction size (ie.
+    /// > the same method as calculating Block weight from Base size and Total size).
+    ///
+    /// For transactions with an empty witness, this is simply the consensus-serialized size times
+    /// four. For transactions with a witness, this is the non-witness consensus-serialized size
+    /// multiplied by three plus the with-witness consensus-serialized size.
+    ///
+    /// For transactions with no inputs, this function will return a value 2 less than the actual
+    /// weight of the serialized transaction. The reason is that zero-input transactions, post-segwit,
+    /// cannot be unambiguously serialized; we make a choice that adds two extra bytes. For more
+    /// details see [BIP 141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
+    /// which uses a "input count" of `0x00` as a `marker` for a Segwit-encoded transaction.
+    ///
+    /// If you need to use 0-input transactions, we strongly recommend you do so using the PSBT
+    /// API. The unsigned transaction encoded within PSBT is always a non-segwit transaction
+    /// and can therefore avoid this ambiguity.
+    #[inline]
+    pub fn weight(&self) -> Weight {
+        // This is the exact definition of a weight unit, as defined by BIP-141 (quote above).
+        let wu = self.base_size() * 3 + self.total_size();
+        Weight::from_wu_usize(wu)
+    }
+
+    /// Returns the base transaction size.
+    ///
+    /// > Base transaction size is the size of the transaction serialised with the witness data stripped.
+    pub fn base_size(&self) -> usize {
+        let mut size: usize = 4; // Serialized length of a u32 for the version number.
+
+        size += VarInt::from(self.input.len()).size();
+        size += self
+            .input
+            .iter()
+            .map(|input| input.base_size())
+            .sum::<usize>();
+
+        size += VarInt::from(self.output.len()).size();
+        size += self
+            .output
+            .iter()
+            .map(|output| output.size())
+            .sum::<usize>();
+
+        size + absolute::LockTime::SIZE
+    }
+
+    /// Returns the total transaction size.
+    ///
+    /// > Total transaction size is the transaction size in bytes serialized as described in BIP144,
+    /// > including base data and witness data.
+    #[inline]
+    pub fn total_size(&self) -> usize {
+        let mut size: usize = 4; // Serialized length of a u32 for the version number.
+        let uses_segwit = self.uses_segwit_serialization();
+
+        if uses_segwit {
+            size += 2; // 1 byte for the marker and 1 for the flag.
+        }
+
+        size += VarInt::from(self.input.len()).size();
+        size += self
+            .input
+            .iter()
+            .map(|input| {
+                if uses_segwit {
+                    input.total_size()
+                } else {
+                    input.base_size()
+                }
+            })
+            .sum::<usize>();
+
+        size += VarInt::from(self.output.len()).size();
+        size += self
+            .output
+            .iter()
+            .map(|output| output.size())
+            .sum::<usize>();
+
+        size + absolute::LockTime::SIZE
+    }
+
+    /// Returns the "virtual size" (vsize) of this transaction.
+    ///
+    /// Will be `ceil(weight / 4.0)`. Note this implements the virtual size as per [`BIP141`], which
+    /// is different to what is implemented in Bitcoin Core. The computation should be the same for
+    /// any remotely sane transaction, and a standardness-rule-correct version is available in the
+    /// [`policy`] module.
+    ///
+    /// > Virtual transaction size is defined as Transaction weight / 4 (rounded up to the next integer).
+    ///
+    /// [`BIP141`]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
+    /// [`policy`]: ../../policy/index.html
+    #[inline]
+    pub fn vsize(&self) -> usize {
+        // No overflow because it's computed from data in memory
+        self.weight().to_vbytes_ceil() as usize
+    }
+
+    /// Checks if this is a coinbase transaction.
+    ///
+    /// The first transaction in the block distributes the mining reward and is called the coinbase
+    /// transaction. It is impossible to check if the transaction is first in the block, so this
+    /// function checks the structure of the transaction instead - the previous output must be
+    /// all-zeros (creates satoshis "out of thin air").
+    #[doc(alias = "is_coin_base")] // method previously had this name
+    pub fn is_coinbase(&self) -> bool {
+        self.input.len() == 1 && self.input[0].previous_output.is_null()
+    }
+
+    /// Returns `true` if the transaction itself opted in to be BIP-125-replaceable (RBF).
+    ///
+    /// # Warning
+    ///
+    /// **Incorrectly relying on RBF may lead to monetary loss!**
+    ///
+    /// This **does not** cover the case where a transaction becomes replaceable due to ancestors
+    /// being RBF. Please note that transactions **may be replaced** even if they **do not** include
+    /// the RBF signal: <https://bitcoinops.org/en/newsletters/2022/10/19/#transaction-replacement-option>.
+    pub fn is_explicitly_rbf(&self) -> bool {
+        self.input.iter().any(|input| input.sequence.is_rbf())
+    }
+
+    /// Returns true if this [`Transaction`]'s absolute timelock is satisfied at `height`/`time`.
+    ///
+    /// # Returns
+    ///
+    /// By definition if the lock time is not enabled the transaction's absolute timelock is
+    /// considered to be satisfied i.e., there are no timelock constraints restricting this
+    /// transaction from being mined immediately.
+    pub fn is_absolute_timelock_satisfied(&self, height: Height, time: Time) -> bool {
+        if !self.is_lock_time_enabled() {
+            return true;
+        }
+        self.lock_time.is_satisfied_by(height, time)
+    }
+
+    /// Returns `true` if this transactions nLockTime is enabled ([BIP-65]).
+    ///
+    /// [BIP-65]: https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
+    pub fn is_lock_time_enabled(&self) -> bool {
+        self.input.iter().any(|i| i.enables_lock_time())
+    }
+
+    /// Returns an iterator over lengths of `script_pubkey`s in the outputs.
+    ///
+    /// This is useful in combination with [`predict_weight`] if you have the transaction already
+    /// constructed with a dummy value in the fee output which you'll adjust after calculating the
+    /// weight.
+    pub fn script_pubkey_lens(&self) -> impl Iterator<Item = usize> + '_ {
+        self.output.iter().map(|txout| txout.script_pubkey.len())
+    }
+
+    /// Counts the total number of sigops.
+    ///
+    /// This value is for pre-taproot transactions only.
+    ///
+    /// > In taproot, a different mechanism is used. Instead of having a global per-block limit,
+    /// > there is a per-transaction-input limit, proportional to the size of that input.
+    /// > ref: <https://bitcoin.stackexchange.com/questions/117356/what-is-sigop-signature-operation#117359>
+    ///
+    /// The `spent` parameter is a closure/function that looks up the output being spent by each input
+    /// It takes in an [`OutPoint`] and returns a [`TxOut`]. If you can't provide this, a placeholder of
+    /// `|_| None` can be used. Without access to the previous [`TxOut`], any sigops in a redeemScript (P2SH)
+    /// as well as any segwit sigops will not be counted for that input.
+    pub fn total_sigop_cost<S>(&self, mut spent: S) -> usize
+    where
+        S: FnMut(&OutPoint) -> Option<TxOut>,
+    {
+        let mut cost = self.count_p2pk_p2pkh_sigops().saturating_mul(4);
+
+        // coinbase tx is correctly handled because `spent` will always returns None.
+        cost = cost.saturating_add(self.count_p2sh_sigops(&mut spent).saturating_mul(4));
+        cost.saturating_add(self.count_witness_sigops(&mut spent))
+    }
+
+    /// Gets the sigop count.
+    ///
+    /// Counts sigops for this transaction's input scriptSigs and output scriptPubkeys i.e., doesn't
+    /// count sigops in the redeemScript for p2sh or the sigops in the witness (use
+    /// `count_p2sh_sigops` and `count_witness_sigops` respectively).
+    fn count_p2pk_p2pkh_sigops(&self) -> usize {
+        let mut count: usize = 0;
+        for input in &self.input {
+            // 0 for p2wpkh, p2wsh, and p2sh (including wrapped segwit).
+            count = count.saturating_add(input.script_sig.count_sigops_legacy());
+        }
+        for output in &self.output {
+            count = count.saturating_add(output.script_pubkey.count_sigops_legacy());
+        }
+        count
+    }
+
+    /// Does not include wrapped segwit (see `count_witness_sigops`).
+    fn count_p2sh_sigops<S>(&self, spent: &mut S) -> usize
+    where
+        S: FnMut(&OutPoint) -> Option<TxOut>,
+    {
+        fn count_sigops(prevout: &TxOut, input: &TxIn) -> usize {
+            let mut count: usize = 0;
+            if prevout.script_pubkey.is_p2sh() {
+                if let Some(redeem) = input.script_sig.last_pushdata() {
+                    count =
+                        count.saturating_add(Script::from_bytes(redeem.as_bytes()).count_sigops());
+                }
+            }
+            count
+        }
+
+        let mut count: usize = 0;
+        for input in &self.input {
+            if let Some(prevout) = spent(&input.previous_output) {
+                count = count.saturating_add(count_sigops(&prevout, input));
+            }
+        }
+        count
+    }
+
+    /// Includes wrapped segwit (returns 0 for taproot spends).
+    fn count_witness_sigops<S>(&self, spent: &mut S) -> usize
+    where
+        S: FnMut(&OutPoint) -> Option<TxOut>,
+    {
+        fn count_sigops_with_witness_program(witness: &Witness, witness_program: &Script) -> usize {
+            if witness_program.is_p2wpkh() {
+                1
+            } else if witness_program.is_p2wsh() {
+                // Treat the last item of the witness as the witnessScript
+                return witness
+                    .last()
+                    .map(Script::from_bytes)
+                    .map(|s| s.count_sigops())
+                    .unwrap_or(0);
+            } else {
+                0
+            }
+        }
+
+        fn count_sigops(prevout: TxOut, input: &TxIn) -> usize {
+            let script_sig = &input.script_sig;
+            let witness = &input.witness;
+
+            let witness_program = if prevout.script_pubkey.is_witness_program() {
+                &prevout.script_pubkey
+            } else if prevout.script_pubkey.is_p2sh() && script_sig.is_push_only() {
+                // If prevout is P2SH and scriptSig is push only
+                // then we wrap the last push (redeemScript) in a Script
+                if let Some(push_bytes) = script_sig.last_pushdata() {
+                    Script::from_bytes(push_bytes.as_bytes())
+                } else {
+                    return 0;
+                }
+            } else {
+                return 0;
+            };
+
+            // This will return 0 if the redeemScript wasn't a witness program
+            count_sigops_with_witness_program(witness, witness_program)
+        }
+
+        let mut count: usize = 0;
+        for input in &self.input {
+            if let Some(prevout) = spent(&input.previous_output) {
+                count = count.saturating_add(count_sigops(prevout, input));
+            }
+        }
+        count
+    }
+
+    /// Returns whether or not to serialize transaction as specified in BIP-144.
+    fn uses_segwit_serialization(&self) -> bool {
+        if self.input.iter().any(|input| !input.witness.is_empty()) {
+            return true;
+        }
+        // To avoid serialization ambiguity, no inputs means we use BIP141 serialization (see
+        // `Transaction` docs for full explanation).
+        self.input.is_empty()
+    }
+
+    /// Returns a reference to the input at `input_index` if it exists.
+    #[inline]
+    pub fn tx_in(&self, input_index: usize) -> Result<&TxIn, InputsIndexError> {
+        self.input.get(input_index).ok_or(
+            IndexOutOfBoundsError {
+                index: input_index,
+                length: self.input.len(),
+            }
+            .into(),
+        )
+    }
+
+    /// Returns a reference to the output at `output_index` if it exists.
+    #[inline]
+    pub fn tx_out(&self, output_index: usize) -> Result<&TxOut, OutputsIndexError> {
+        self.output.get(output_index).ok_or(
+            IndexOutOfBoundsError {
+                index: output_index,
+                length: self.output.len(),
+            }
+            .into(),
+        )
+    }
+}
+
+/// Error attempting to do an out of bounds access on the transaction inputs vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputsIndexError(pub IndexOutOfBoundsError);
+
+impl fmt::Display for InputsIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "invalid input index"; self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InputsIndexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl From<IndexOutOfBoundsError> for InputsIndexError {
+    fn from(e: IndexOutOfBoundsError) -> Self {
+        Self(e)
+    }
+}
+
+/// Error attempting to do an out of bounds access on the transaction outputs vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputsIndexError(pub IndexOutOfBoundsError);
+
+impl fmt::Display for OutputsIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "invalid output index"; self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for OutputsIndexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl From<IndexOutOfBoundsError> for OutputsIndexError {
+    fn from(e: IndexOutOfBoundsError) -> Self {
+        Self(e)
+    }
+}
+
+/// Error attempting to do an out of bounds access on a vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct IndexOutOfBoundsError {
+    /// Attempted index access.
+    pub index: usize,
+    /// Length of the vector where access was attempted.
+    pub length: usize,
+}
+
+impl fmt::Display for IndexOutOfBoundsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "index {} is out-of-bounds for vector with length {}",
+            self.index, self.length
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IndexOutOfBoundsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+/// The transaction version.
+///
+/// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
+///
+/// Standardness of the inner `i32` is not an invariant because you are free to create transactions
+/// of any version, transactions with non-standard version numbers will not be relayed by the
+/// Bitcoin network.
+///
+/// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
+#[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Version(pub i32);
+
+impl Version {
+    /// The original Bitcoin transaction version (pre-BIP-68).
+    pub const ONE: Self = Self(1);
+
+    /// The second Bitcoin transaction version (post-BIP-68).
+    pub const TWO: Self = Self(2);
+
+    /// Creates a non-standard transaction version.
+    pub fn non_standard(version: i32) -> Version {
+        Self(version)
+    }
+
+    /// Returns true if this transaction version number is considered standard.
+    pub fn is_standard(&self) -> bool {
+        *self == Version::ONE || *self == Version::TWO
+    }
+}
+
+impl Encodable for Version {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for Version {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Decodable::consensus_decode(r).map(Version)
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl_consensus_encoding!(TxOut, value, script_pubkey);
+
+impl Encodable for OutPoint {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let len = self.txid.consensus_encode(w)?;
+        Ok(len + self.vout.consensus_encode(w)?)
+    }
+}
+impl Decodable for OutPoint {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(OutPoint {
+            txid: Decodable::consensus_decode(r)?,
+            vout: Decodable::consensus_decode(r)?,
+        })
+    }
+}
+
+impl Encodable for TxIn {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.previous_output.consensus_encode(w)?;
+        len += self.script_sig.consensus_encode(w)?;
+        len += self.sequence.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+impl Decodable for TxIn {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        r: &mut R,
+    ) -> Result<Self, encode::Error> {
+        Ok(TxIn {
+            previous_output: Decodable::consensus_decode_from_finite_reader(r)?,
+            script_sig: Decodable::consensus_decode_from_finite_reader(r)?,
+            sequence: Decodable::consensus_decode_from_finite_reader(r)?,
+            witness: Witness::default(),
+        })
+    }
+}
+
+impl Encodable for Sequence {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for Sequence {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Decodable::consensus_decode(r).map(Sequence)
+    }
+}
+
+impl Encodable for Transaction {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.version.consensus_encode(w)?;
+
+        // Legacy transaction serialization format only includes inputs and outputs.
+        if !self.uses_segwit_serialization() {
+            len += self.input.consensus_encode(w)?;
+            len += self.output.consensus_encode(w)?;
+        } else {
+            // BIP-141 (segwit) transaction serialization also includes marker, flag, and witness data.
+            len += SEGWIT_MARKER.consensus_encode(w)?;
+            len += SEGWIT_FLAG.consensus_encode(w)?;
+            len += self.input.consensus_encode(w)?;
+            len += self.output.consensus_encode(w)?;
+            for input in &self.input {
+                len += input.witness.consensus_encode(w)?;
+            }
+        }
+        len += self.lock_time.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
+impl Decodable for Transaction {
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        r: &mut R,
+    ) -> Result<Self, encode::Error> {
+        let version = Version::consensus_decode_from_finite_reader(r)?;
+        let input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
+        // segwit
+        if input.is_empty() {
+            let segwit_flag = u8::consensus_decode_from_finite_reader(r)?;
+            match segwit_flag {
+                // BIP144 input witnesses
+                1 => {
+                    let mut input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
+                    let output = Vec::<TxOut>::consensus_decode_from_finite_reader(r)?;
+                    for txin in input.iter_mut() {
+                        txin.witness = Decodable::consensus_decode_from_finite_reader(r)?;
+                    }
+                    if !input.is_empty() && input.iter().all(|input| input.witness.is_empty()) {
+                        Err(encode::Error::ParseFailed(
+                            "witness flag set but no witnesses present",
+                        ))
+                    } else {
+                        Ok(Transaction {
+                            version,
+                            input,
+                            output,
+                            lock_time: Decodable::consensus_decode_from_finite_reader(r)?,
+                        })
+                    }
+                }
+                // We don't support anything else
+                x => Err(encode::Error::UnsupportedSegwitFlag(x)),
+            }
+        // non-segwit
+        } else {
+            Ok(Transaction {
+                version,
+                input,
+                output: Decodable::consensus_decode_from_finite_reader(r)?,
+                lock_time: Decodable::consensus_decode_from_finite_reader(r)?,
+            })
+        }
+    }
+}
+
+impl From<Transaction> for Txid {
+    fn from(tx: Transaction) -> Txid {
+        tx.compute_txid()
+    }
+}
+
+impl From<&Transaction> for Txid {
+    fn from(tx: &Transaction) -> Txid {
+        tx.compute_txid()
+    }
+}
+
+impl From<Transaction> for Wtxid {
+    fn from(tx: Transaction) -> Wtxid {
+        tx.compute_wtxid()
+    }
+}
+
+impl From<&Transaction> for Wtxid {
+    fn from(tx: &Transaction) -> Wtxid {
+        tx.compute_wtxid()
+    }
+}
+
+/// Computes the value of an output accounting for the cost of spending it.
+///
+/// The effective value is the value of an output value minus the amount to spend it.  That is, the
+/// effective_value can be calculated as: value - (fee_rate * weight).
+///
+/// Note: the effective value of a [`Transaction`] may increase less than the effective value of
+/// a [`TxOut`] when adding another [`TxOut`] to the transaction.  This happens when the new
+/// [`TxOut`] added causes the output length `VarInt` to increase its encoding length.
+///
+/// # Arguments
+///
+/// * `fee_rate` - the fee rate of the transaction being created.
+/// * `satisfaction_weight` - satisfied spending conditions weight.
+pub fn effective_value(
+    fee_rate: FeeRate,
+    satisfaction_weight: Weight,
+    value: Amount,
+) -> Option<SignedAmount> {
+    let weight = satisfaction_weight.checked_add(TxIn::BASE_WEIGHT)?;
+    let signed_input_fee = fee_rate.checked_mul_by_weight(weight)?.to_signed().ok()?;
+    value.to_signed().ok()?.checked_sub(signed_input_fee)
+}
+
+/// Predicts the weight of a to-be-constructed transaction.
+///
+/// This function computes the weight of a transaction which is not fully known. All that is needed
+/// is the lengths of scripts and witness elements.
+///
+/// # Arguments
+///
+/// * `inputs` - an iterator which returns `InputWeightPrediction` for each input of the
+///   to-be-constructed transaction.
+/// * `output_script_lens` - an iterator which returns the length of `script_pubkey` of each output
+///   of the to-be-constructed transaction.
+///
+/// Note that lengths of the scripts and witness elements must be non-serialized, IOW *without* the
+/// preceding compact size. The length of preceding compact size is computed and added inside the
+/// function for convenience.
+///
+/// If you  have the transaction already constructed (except for signatures) with a dummy value for
+/// fee output you can use the return value of [`Transaction::script_pubkey_lens`] method directly
+/// as the second argument.
+///
+/// # Usage
+///
+/// When signing a transaction one doesn't know the signature before knowing the transaction fee and
+/// the transaction fee is not known before knowing the transaction size which is not known before
+/// knowing the signature. This apparent dependency cycle can be broken by knowing the length of the
+/// signature without knowing the contents of the signature e.g., we know all Schnorr signatures
+/// are 64 bytes long.
+///
+/// Additionally, some protocols may require calculating the amounts before knowing various parts
+/// of the transaction (assuming their length is known).
+///
+/// # Notes on integer overflow
+///
+/// Overflows are intentionally not checked because one of the following holds:
+///
+/// * The transaction is valid (obeys the block size limit) and the code feeds correct values to
+///   this function - no overflow can happen.
+/// * The transaction will be so large it doesn't fit in the memory - overflow will happen but
+///   then the transaction will fail to construct and even if one serialized it on disk directly
+///   it'd be invalid anyway so overflow doesn't matter.
+/// * The values fed into this function are inconsistent with the actual lengths the transaction
+///   will have - the code is already broken and checking overflows doesn't help. Unfortunately
+///   this probably cannot be avoided.
+pub fn predict_weight<I, O>(inputs: I, output_script_lens: O) -> Weight
+where
+    I: IntoIterator<Item = InputWeightPrediction>,
+    O: IntoIterator<Item = usize>,
+{
+    // This fold() does three things:
+    // 1) Counts the inputs and returns the sum as `input_count`.
+    // 2) Sums all of the input weights and returns the sum as `partial_input_weight`
+    //    For every input: script_size * 4 + witness_size
+    //    Since script_size is non-witness data, it gets a 4x multiplier.
+    // 3) Counts the number of inputs that have a witness data and returns the count as
+    //    `num_inputs_with_witnesses`.
+    let (input_count, partial_input_weight, inputs_with_witnesses) = inputs.into_iter().fold(
+        (0, 0, 0),
+        |(count, partial_input_weight, inputs_with_witnesses), prediction| {
+            (
+                count + 1,
+                partial_input_weight + prediction.weight().to_wu() as usize,
+                inputs_with_witnesses + (prediction.witness_size > 0) as usize,
+            )
+        },
+    );
+
+    // This fold() does two things:
+    // 1) Counts the outputs and returns the sum as `output_count`.
+    // 2) Sums the output script sizes and returns the sum as `output_scripts_size`.
+    //    script_len + the length of a VarInt struct that stores the value of script_len
+    let (output_count, output_scripts_size) = output_script_lens.into_iter().fold(
+        (0, 0),
+        |(output_count, total_scripts_size), script_len| {
+            let script_size = script_len + VarInt(script_len as u64).size();
+            (output_count + 1, total_scripts_size + script_size)
+        },
+    );
+    predict_weight_internal(
+        input_count,
+        partial_input_weight,
+        inputs_with_witnesses,
+        output_count,
+        output_scripts_size,
+    )
+}
+
+const fn predict_weight_internal(
+    input_count: usize,
+    partial_input_weight: usize,
+    inputs_with_witnesses: usize,
+    output_count: usize,
+    output_scripts_size: usize,
+) -> Weight {
+    // Lengths of txid, index and sequence: (32, 4, 4).
+    // Multiply the lengths by 4 since the fields are all non-witness fields.
+    let input_weight = partial_input_weight + input_count * 4 * (32 + 4 + 4);
+
+    // The value field of a TxOut is 8 bytes.
+    let output_size = 8 * output_count + output_scripts_size;
+    let non_input_size =
+    // version:
+        4 +
+    // count varints:
+        VarInt(input_count as u64).size() +
+        VarInt(output_count as u64).size() +
+        output_size +
+    // lock_time
+        4;
+    let weight = if inputs_with_witnesses == 0 {
+        non_input_size * 4 + input_weight
+    } else {
+        non_input_size * 4 + input_weight + input_count - inputs_with_witnesses + 2
+    };
+    Weight::from_wu(weight as u64)
+}
+
+/// Predicts the weight of a to-be-constructed transaction in const context.
+///
+/// This is a `const` version of [`predict_weight`] which only allows slices due to current Rust
+/// limitations around `const fn`. Because of these limitations it may be less efficient than
+/// `predict_weight` and thus is intended to be only used in `const` context.
+///
+/// Please see the documentation of `predict_weight` to learn more about this function.
+pub const fn predict_weight_from_slices(
+    inputs: &[InputWeightPrediction],
+    output_script_lens: &[usize],
+) -> Weight {
+    let mut partial_input_weight = 0;
+    let mut inputs_with_witnesses = 0;
+
+    // for loops not supported in const fn
+    let mut i = 0;
+    while i < inputs.len() {
+        let prediction = inputs[i];
+        partial_input_weight += prediction.weight().to_wu() as usize;
+        inputs_with_witnesses += (prediction.witness_size > 0) as usize;
+        i += 1;
+    }
+
+    let mut output_scripts_size = 0;
+
+    i = 0;
+    while i < output_script_lens.len() {
+        let script_len = output_script_lens[i];
+        output_scripts_size += script_len + VarInt(script_len as u64).size();
+        i += 1;
+    }
+
+    predict_weight_internal(
+        inputs.len(),
+        partial_input_weight,
+        inputs_with_witnesses,
+        output_script_lens.len(),
+        output_scripts_size,
+    )
+}
+
+/// Weight prediction of an individual input.
+///
+/// This helper type collects information about an input to be used in [`predict_weight`] function.
+/// It can only be created using the [`new`](InputWeightPrediction::new) function or using other
+/// associated constants/methods.
+#[derive(Copy, Clone, Debug)]
+pub struct InputWeightPrediction {
+    script_size: usize,
+    witness_size: usize,
+}
+
+impl InputWeightPrediction {
+    /// Input weight prediction corresponding to spending of P2WPKH output with the largest possible
+    /// DER-encoded signature.
+    ///
+    /// If the input in your transaction uses P2WPKH you can use this instead of
+    /// [`InputWeightPrediction::new`].
+    ///
+    /// This is useful when you **do not** use [signature grinding] and want to ensure you are not
+    /// under-paying. See [`ground_p2wpkh`](Self::ground_p2wpkh) if you do use signature grinding.
+    ///
+    /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
+    pub const P2WPKH_MAX: Self = InputWeightPrediction::from_slice(0, &[72, 33]);
+
+    /// Input weight prediction corresponding to spending of a P2PKH output with the largest possible
+    /// DER-encoded signature, and a compressed public key.
+    ///
+    /// If the input in your transaction uses P2PKH with a compressed key, you can use this instead of
+    /// [`InputWeightPrediction::new`].
+    ///
+    /// This is useful when you **do not** use [signature grinding] and want to ensure you are not
+    /// under-paying. See [`ground_p2pkh_compressed`](Self::ground_p2pkh_compressed) if you do use
+    /// signature grinding.
+    ///
+    /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
+    pub const P2PKH_COMPRESSED_MAX: Self = InputWeightPrediction::from_slice(107, &[]);
+
+    /// Input weight prediction corresponding to spending of a P2PKH output with the largest possible
+    /// DER-encoded signature, and an uncompressed public key.
+    ///
+    /// If the input in your transaction uses P2PKH with an uncompressed key, you can use this instead of
+    /// [`InputWeightPrediction::new`].
+    pub const P2PKH_UNCOMPRESSED_MAX: Self = InputWeightPrediction::from_slice(139, &[]);
+
+    /// Input weight prediction corresponding to spending of taproot output using the key and
+    /// default sighash.
+    ///
+    /// If the input in your transaction uses Taproot key spend you can use this instead of
+    /// [`InputWeightPrediction::new`].
+    pub const P2TR_KEY_DEFAULT_SIGHASH: Self = InputWeightPrediction::from_slice(0, &[64]);
+
+    /// Input weight prediction corresponding to spending of taproot output using the key and
+    /// **non**-default sighash.
+    ///
+    /// If the input in your transaction uses Taproot key spend you can use this instead of
+    /// [`InputWeightPrediction::new`].
+    pub const P2TR_KEY_NON_DEFAULT_SIGHASH: Self = InputWeightPrediction::from_slice(0, &[65]);
+
+    /// Input weight prediction corresponding to spending of P2WPKH output using [signature
+    /// grinding].
+    ///
+    /// If the input in your transaction uses P2WPKH and you use signature grinding you can use this
+    /// instead of [`InputWeightPrediction::new`]. See [`P2WPKH_MAX`](Self::P2WPKH_MAX) if you don't
+    /// use signature grinding.
+    ///
+    /// Note: `bytes_to_grind` is usually `1` because of exponential cost of higher values.
+    ///
+    /// # Panics
+    ///
+    /// The funcion panics in const context and debug builds if `bytes_to_grind` is higher than 62.
+    ///
+    /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
+    pub const fn ground_p2wpkh(bytes_to_grind: usize) -> Self {
+        // Written to trigger const/debug panic for unreasonably high values.
+        let der_signature_size = 10 + (62 - bytes_to_grind);
+        InputWeightPrediction::from_slice(0, &[der_signature_size, 33])
+    }
+
+    /// Input weight prediction corresponding to spending of a P2PKH output using [signature
+    /// grinding], and a compressed public key.
+    ///
+    /// If the input in your transaction uses compressed P2PKH and you use signature grinding you
+    /// can use this instead of [`InputWeightPrediction::new`]. See
+    /// [`P2PKH_COMPRESSED_MAX`](Self::P2PKH_COMPRESSED_MAX) if you don't use signature grinding.
+    ///
+    /// Note: `bytes_to_grind` is usually `1` because of exponential cost of higher values.
+    ///
+    /// # Panics
+    ///
+    /// The funcion panics in const context and debug builds if `bytes_to_grind` is higher than 62.
+    ///
+    /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
+    pub const fn ground_p2pkh_compressed(bytes_to_grind: usize) -> Self {
+        // Written to trigger const/debug panic for unreasonably high values.
+        let der_signature_size = 10 + (62 - bytes_to_grind);
+
+        InputWeightPrediction::from_slice(2 + 33 + der_signature_size, &[])
+    }
+
+    /// Computes the prediction for a single input.
+    pub fn new<T>(input_script_len: usize, witness_element_lengths: T) -> Self
+    where
+        T: IntoIterator,
+        T::Item: Borrow<usize>,
+    {
+        let (count, total_size) =
+            witness_element_lengths
+                .into_iter()
+                .fold((0, 0), |(count, total_size), elem_len| {
+                    let elem_len = *elem_len.borrow();
+                    let elem_size = elem_len + VarInt(elem_len as u64).size();
+                    (count + 1, total_size + elem_size)
+                });
+        let witness_size = if count > 0 {
+            total_size + VarInt(count as u64).size()
+        } else {
+            0
+        };
+        let script_size = input_script_len + VarInt(input_script_len as u64).size();
+
+        InputWeightPrediction {
+            script_size,
+            witness_size,
+        }
+    }
+
+    /// Computes the prediction for a single input in `const` context.
+    ///
+    /// This is a `const` version of [`new`](Self::new) which only allows slices due to current Rust
+    /// limitations around `const fn`. Because of these limitations it may be less efficient than
+    /// `new` and thus is intended to be only used in `const` context.
+    pub const fn from_slice(input_script_len: usize, witness_element_lengths: &[usize]) -> Self {
+        let mut i = 0;
+        let mut total_size = 0;
+        // for loops not supported in const fn
+        while i < witness_element_lengths.len() {
+            let elem_len = witness_element_lengths[i];
+            let elem_size = elem_len + VarInt(elem_len as u64).size();
+            total_size += elem_size;
+            i += 1;
+        }
+        let witness_size = if !witness_element_lengths.is_empty() {
+            total_size + VarInt(witness_element_lengths.len() as u64).size()
+        } else {
+            0
+        };
+        let script_size = input_script_len + VarInt(input_script_len as u64).size();
+
+        InputWeightPrediction {
+            script_size,
+            witness_size,
+        }
+    }
+
+    /// Tallies the total weight added to a transaction by an input with this weight prediction,
+    /// not counting potential witness flag bytes or the witness count varint.
+    pub const fn weight(&self) -> Weight {
+        Weight::from_wu_usize(self.script_size * 4 + self.witness_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use hex::{test_hex_unwrap as hex, FromHex};
+
+    use super::*;
+    use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::sighash::EcdsaSighashType;
+
+    const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
+
+    #[test]
+    fn encode_to_unsized_writer() {
+        let mut buf = [0u8; 1024];
+        let raw_tx = hex!(SOME_TX);
+        let tx: Transaction = Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
+
+        let size = tx.consensus_encode(&mut &mut buf[..]).unwrap();
+        assert_eq!(size, SOME_TX.len() / 2);
+        assert_eq!(raw_tx, &buf[..size]);
+    }
+
+    #[test]
+    fn outpoint() {
+        assert_eq!(
+            OutPoint::from_str("i don't care"),
+            Err(ParseOutPointError::Format)
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:1:1"
+            ),
+            Err(ParseOutPointError::Format)
+        );
+        assert_eq!(
+            OutPoint::from_str("5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:"),
+            Err(ParseOutPointError::Format)
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:11111111111"
+            ),
+            Err(ParseOutPointError::TooLong)
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:01"
+            ),
+            Err(ParseOutPointError::VoutNotCanonical)
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:+42"
+            ),
+            Err(ParseOutPointError::VoutNotCanonical)
+        );
+        assert_eq!(
+            OutPoint::from_str("i don't care:1"),
+            Err(ParseOutPointError::Txid(
+                "i don't care".parse::<Txid>().unwrap_err()
+            ))
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X:1"
+            ),
+            Err(ParseOutPointError::Txid(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X"
+                    .parse::<Txid>()
+                    .unwrap_err()
+            ))
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:lol"
+            ),
+            Err(ParseOutPointError::Vout(
+                parse::int::<u32, _>("lol").unwrap_err()
+            ))
+        );
+
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:42"
+            ),
+            Ok(OutPoint {
+                txid: "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456"
+                    .parse()
+                    .unwrap(),
+                vout: 42,
+            })
+        );
+        assert_eq!(
+            OutPoint::from_str(
+                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:0"
+            ),
+            Ok(OutPoint {
+                txid: "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456"
+                    .parse()
+                    .unwrap(),
+                vout: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn txin() {
+        let txin: Result<TxIn, _> = deserialize(&hex!("a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff"));
+        assert!(txin.is_ok());
+    }
+
+    #[test]
+    fn txin_default() {
+        let txin = TxIn::default();
+        assert_eq!(txin.previous_output, OutPoint::default());
+        assert_eq!(txin.script_sig, ScriptBuf::new());
+        assert_eq!(txin.sequence, Sequence::from_consensus(0xFFFFFFFF));
+        assert_eq!(txin.previous_output, OutPoint::default());
+        assert_eq!(txin.witness.len(), 0);
+    }
+
+    #[test]
+    fn is_coinbase() {
+        use crate::blockdata::constants;
+        use crate::network::Network;
+
+        let genesis = constants::genesis_block(Network::Bitcoin);
+        assert!(genesis.txdata[0].is_coinbase());
+        let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        assert!(!tx.is_coinbase());
+    }
+
+    #[test]
+    fn nonsegwit_transaction() {
+        let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
+        let tx: Result<Transaction, _> = deserialize(&tx_bytes);
+        assert!(tx.is_ok());
+        let realtx = tx.unwrap();
+        // All these tests aren't really needed because if they fail, the hash check at the end
+        // will also fail. But these will show you where the failure is so I'll leave them in.
+        assert_eq!(realtx.version, Version::ONE);
+        assert_eq!(realtx.input.len(), 1);
+        // In particular this one is easy to get backward -- in bitcoin hashes are encoded
+        // as little-endian 256-bit numbers rather than as data strings.
+        assert_eq!(
+            format!("{:x}", realtx.input[0].previous_output.txid),
+            "ce9ea9f6f5e422c6a9dbcddb3b9a14d1c78fab9ab520cb281aa2a74a09575da1".to_string()
+        );
+        assert_eq!(realtx.input[0].previous_output.vout, 1);
+        assert_eq!(realtx.output.len(), 1);
+        assert_eq!(realtx.lock_time, absolute::LockTime::ZERO);
+
+        assert_eq!(
+            format!("{:x}", realtx.compute_txid()),
+            "a6eab3c14ab5272a58a5ba91505ba1a4b6d7a3a9fcbd187b6cd99a7b6d548cb7".to_string()
+        );
+        assert_eq!(
+            format!("{:x}", realtx.compute_wtxid()),
+            "a6eab3c14ab5272a58a5ba91505ba1a4b6d7a3a9fcbd187b6cd99a7b6d548cb7".to_string()
+        );
+        assert_eq!(
+            realtx.weight().to_wu() as usize,
+            tx_bytes.len() * WITNESS_SCALE_FACTOR
+        );
+        assert_eq!(realtx.total_size(), tx_bytes.len());
+        assert_eq!(realtx.vsize(), tx_bytes.len());
+        assert_eq!(realtx.base_size(), tx_bytes.len());
+    }
+
+    #[test]
+    fn segwit_invalid_transaction() {
+        let tx_bytes = hex!("0000fd000001021921212121212121212121f8b372b0239cc1dff600000000004f4f4f4f4f4f4f4f000000000000000000000000000000333732343133380d000000000000000000000000000000ff000000000009000dff000000000000000800000000000000000d");
+        let tx: Result<Transaction, _> = deserialize(&tx_bytes);
+        assert!(tx.is_err());
+        assert!(tx
+            .unwrap_err()
+            .to_string()
+            .contains("witness flag set but no witnesses present"));
+    }
+
+    #[test]
+    fn segwit_transaction() {
+        let tx_bytes = hex!(
+            "02000000000101595895ea20179de87052b4046dfe6fd515860505d6511a9004cf12a1f93cac7c01000000\
+            00ffffffff01deb807000000000017a9140f3444e271620c736808aa7b33e370bd87cb5a078702483045022\
+            100fb60dad8df4af2841adc0346638c16d0b8035f5e3f3753b88db122e70c79f9370220756e6633b17fd271\
+            0e626347d28d60b0a2d6cbb41de51740644b9fb3ba7751040121028fa937ca8cba2197a37c007176ed89410\
+            55d3bcb8627d085e94553e62f057dcc00000000"
+        );
+        let tx: Result<Transaction, _> = deserialize(&tx_bytes);
+        assert!(tx.is_ok());
+        let realtx = tx.unwrap();
+        // All these tests aren't really needed because if they fail, the hash check at the end
+        // will also fail. But these will show you where the failure is so I'll leave them in.
+        assert_eq!(realtx.version, Version::TWO);
+        assert_eq!(realtx.input.len(), 1);
+        // In particular this one is easy to get backward -- in bitcoin hashes are encoded
+        // as little-endian 256-bit numbers rather than as data strings.
+        assert_eq!(
+            format!("{:x}", realtx.input[0].previous_output.txid),
+            "7cac3cf9a112cf04901a51d605058615d56ffe6d04b45270e89d1720ea955859".to_string()
+        );
+        assert_eq!(realtx.input[0].previous_output.vout, 1);
+        assert_eq!(realtx.output.len(), 1);
+        assert_eq!(realtx.lock_time, absolute::LockTime::ZERO);
+
+        assert_eq!(
+            format!("{:x}", realtx.compute_txid()),
+            "f5864806e3565c34d1b41e716f72609d00b55ea5eac5b924c9719a842ef42206".to_string()
+        );
+        assert_eq!(
+            format!("{:x}", realtx.compute_wtxid()),
+            "80b7d8a82d5d5bf92905b06f2014dd699e03837ca172e3a59d51426ebbe3e7f5".to_string()
+        );
+        const EXPECTED_WEIGHT: Weight = Weight::from_wu(442);
+        assert_eq!(realtx.weight(), EXPECTED_WEIGHT);
+        assert_eq!(realtx.total_size(), tx_bytes.len());
+        assert_eq!(realtx.vsize(), 111);
+
+        let expected_strippedsize = (442 - realtx.total_size()) / 3;
+        assert_eq!(realtx.base_size(), expected_strippedsize);
+
+        // Construct a transaction without the witness data.
+        let mut tx_without_witness = realtx;
+        tx_without_witness
+            .input
+            .iter_mut()
+            .for_each(|input| input.witness.clear());
+        assert_eq!(
+            tx_without_witness.total_size(),
+            tx_without_witness.total_size()
+        );
+        assert_eq!(tx_without_witness.total_size(), expected_strippedsize);
+    }
+
+    // We temporarily abuse `Transaction` for testing consensus serde adapter.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn consensus_serde() {
+        use crate::consensus::serde as con_serde;
+        let json = "\"010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3603da1b0e00045503bd5704c7dd8a0d0ced13bb5785010800000000000a636b706f6f6c122f4e696e6a61506f6f6c2f5345475749542fffffffff02b4e5a212000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9edf91c46b49eb8a29089980f02ee6b57e7d63d33b18b4fddac2bcd7db2a39837040120000000000000000000000000000000000000000000000000000000000000000000000000\"";
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let tx =
+            con_serde::With::<con_serde::Hex>::deserialize::<'_, Transaction, _>(&mut deserializer)
+                .unwrap();
+        let tx_bytes = Vec::from_hex(&json[1..(json.len() - 1)]).unwrap();
+        let expected = deserialize::<Transaction>(&tx_bytes).unwrap();
+        assert_eq!(tx, expected);
+        let mut bytes = Vec::new();
+        let mut serializer = serde_json::Serializer::new(&mut bytes);
+        con_serde::With::<con_serde::Hex>::serialize(&tx, &mut serializer).unwrap();
+        assert_eq!(bytes, json.as_bytes())
+    }
+
+    #[test]
+    fn transaction_version() {
+        let tx_bytes = hex!("ffffff7f0100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000");
+        let tx: Result<Transaction, _> = deserialize(&tx_bytes);
+        assert!(tx.is_ok());
+        let realtx = tx.unwrap();
+        assert_eq!(realtx.version, Version::non_standard(2147483647));
+
+        let tx2_bytes = hex!("000000800100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000");
+        let tx2: Result<Transaction, _> = deserialize(&tx2_bytes);
+        assert!(tx2.is_ok());
+        let realtx2 = tx2.unwrap();
+        assert_eq!(realtx2.version, Version::non_standard(-2147483648));
+    }
+
+    #[test]
+    fn tx_no_input_deserialization() {
+        let tx_bytes = hex!(
+            "010000000001000100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000"
+        );
+        let tx: Transaction = deserialize(&tx_bytes).expect("deserialize tx");
+
+        assert_eq!(tx.input.len(), 0);
+        assert_eq!(tx.output.len(), 1);
+
+        let reser = serialize(&tx);
+        assert_eq!(tx_bytes, reser);
+    }
+
+    #[test]
+    fn ntxid() {
+        let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
+        let mut tx: Transaction = deserialize(&tx_bytes).unwrap();
+
+        let old_ntxid = tx.compute_ntxid();
+        assert_eq!(
+            format!("{:x}", old_ntxid),
+            "c3573dbea28ce24425c59a189391937e00d255150fa973d59d61caf3a06b601d"
+        );
+        // changing sigs does not affect it
+        tx.input[0].script_sig = ScriptBuf::new();
+        assert_eq!(old_ntxid, tx.compute_ntxid());
+        // changing pks does
+        tx.output[0].script_pubkey = ScriptBuf::new();
+        assert!(old_ntxid != tx.compute_ntxid());
+    }
+
+    #[test]
+    fn txid() {
+        // segwit tx from Liquid integration tests, txid/hash from Core decoderawtransaction
+        let tx_bytes = hex!(
+            "01000000000102ff34f95a672bb6a4f6ff4a7e90fa8c7b3be7e70ffc39bc99be3bda67942e836c00000000\
+             23220020cde476664d3fa347b8d54ef3aee33dcb686a65ced2b5207cbf4ec5eda6b9b46e4f414d4c934ad8\
+             1d330314e888888e3bd22c7dde8aac2ca9227b30d7c40093248af7812201000000232200200af6f6a071a6\
+             9d5417e592ed99d256ddfd8b3b2238ac73f5da1b06fc0b2e79d54f414d4c0ba0c8f505000000001976a914\
+             dcb5898d9036afad9209e6ff0086772795b1441088ac033c0f000000000017a914889f8c10ff2bd4bb9dab\
+             b68c5c0d700a46925e6c87033c0f000000000017a914889f8c10ff2bd4bb9dabb68c5c0d700a46925e6c87\
+             033c0f000000000017a914889f8c10ff2bd4bb9dabb68c5c0d700a46925e6c87033c0f000000000017a914\
+             889f8c10ff2bd4bb9dabb68c5c0d700a46925e6c87033c0f000000000017a914889f8c10ff2bd4bb9dabb6\
+             8c5c0d700a46925e6c87033c0f000000000017a914889f8c10ff2bd4bb9dabb68c5c0d700a46925e6c8703\
+             3c0f000000000017a914889f8c10ff2bd4bb9dabb68c5c0d700a46925e6c87033c0f000000000017a91488\
+             9f8c10ff2bd4bb9dabb68c5c0d700a46925e6c87033c0f000000000017a914889f8c10ff2bd4bb9dabb68c\
+             5c0d700a46925e6c87033c0f000000000017a914889f8c10ff2bd4bb9dabb68c5c0d700a46925e6c870500\
+             47304402200380b8663e727d7e8d773530ef85d5f82c0b067c97ae927800a0876a1f01d8e2022021ee611e\
+             f6507dfd217add2cd60a8aea3cbcfec034da0bebf3312d19577b8c290147304402207bd9943ce1c2c5547b\
+             120683fd05d78d23d73be1a5b5a2074ff586b9c853ed4202202881dcf435088d663c9af7b23efb3c03b9db\
+             c0c899b247aa94a74d9b4b3c84f501483045022100ba12bba745af3f18f6e56be70f8382ca8e107d1ed5ce\
+             aa3e8c360d5ecf78886f022069b38ebaac8fe6a6b97b497cbbb115f3176f7213540bef08f9292e5a72de52\
+             de01695321023c9cd9c6950ffee24772be948a45dc5ef1986271e46b686cb52007bac214395a2102756e27\
+             cb004af05a6e9faed81fd68ff69959e3c64ac8c9f6cd0e08fd0ad0e75d2103fa40da236bd82202a985a910\
+             4e851080b5940812685769202a3b43e4a8b13e6a53ae050048304502210098b9687b81d725a7970d1eee91\
+             ff6b89bc9832c2e0e3fb0d10eec143930b006f02206f77ce19dc58ecbfef9221f81daad90bb4f468df3912\
+             12abc4f084fe2cc9bdef01483045022100e5479f81a3ad564103da5e2ec8e12f61f3ac8d312ab68763c1dd\
+             d7bae94c20610220789b81b7220b27b681b1b2e87198897376ba9d033bc387f084c8b8310c8539c2014830\
+             45022100aa1cc48a2d256c0e556616444cc08ae4959d464e5ffff2ae09e3550bdab6ce9f02207192d5e332\
+             9a56ba7b1ead724634d104f1c3f8749fe6081e6233aee3e855817a016953210260de9cc68658c61af984e3\
+             ab0281d17cfca1cc035966d335f474932d5e6c5422210355fbb768ce3ce39360277345dbb5f376e706459e\
+             5a2b5e0e09a535e61690647021023222ceec58b94bd25925dd9743dae6b928737491bd940fc5dd7c6f5d5f\
+             2adc1e53ae00000000"
+        );
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+
+        assert_eq!(
+            format!("{:x}", tx.compute_wtxid()),
+            "d6ac4a5e61657c4c604dcde855a1db74ec6b3e54f32695d72c5e11c7761ea1b4"
+        );
+        assert_eq!(
+            format!("{:x}", tx.compute_txid()),
+            "9652aa62b0e748caeec40c4cb7bc17c6792435cc3dfe447dd1ca24f912a1c6ec"
+        );
+        assert_eq!(format!("{:.10x}", tx.compute_txid()), "9652aa62b0");
+        assert_eq!(tx.weight(), Weight::from_wu(2718));
+
+        // non-segwit tx from my mempool
+        let tx_bytes = hex!(
+            "01000000010c7196428403d8b0c88fcb3ee8d64f56f55c8973c9ab7dd106bb4f3527f5888d000000006a47\
+             30440220503a696f55f2c00eee2ac5e65b17767cd88ed04866b5637d3c1d5d996a70656d02202c9aff698f\
+             343abb6d176704beda63fcdec503133ea4f6a5216b7f925fa9910c0121024d89b5a13d6521388969209df2\
+             7a8469bd565aff10e8d42cef931fad5121bfb8ffffffff02b825b404000000001976a914ef79e7ee9fff98\
+             bcfd08473d2b76b02a48f8c69088ac0000000000000000296a273236303039343836393731373233313237\
+             3633313032313332353630353838373931323132373000000000"
+        );
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+
+        assert_eq!(
+            format!("{:x}", tx.compute_wtxid()),
+            "971ed48a62c143bbd9c87f4bafa2ef213cfa106c6e140f111931d0be307468dd"
+        );
+        assert_eq!(
+            format!("{:x}", tx.compute_txid()),
+            "971ed48a62c143bbd9c87f4bafa2ef213cfa106c6e140f111931d0be307468dd"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn txn_encode_decode() {
+        let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        serde_round_trip!(tx);
+    }
+
+    // Test decoding transaction `4be105f158ea44aec57bf12c5817d073a712ab131df6f37786872cfc70734188`
+    // from testnet, which is the first BIP144-encoded transaction I encountered.
+    #[test]
+    #[cfg(feature = "serde")]
+    fn segwit_tx_decode() {
+        let tx_bytes = hex!("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3603da1b0e00045503bd5704c7dd8a0d0ced13bb5785010800000000000a636b706f6f6c122f4e696e6a61506f6f6c2f5345475749542fffffffff02b4e5a212000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9edf91c46b49eb8a29089980f02ee6b57e7d63d33b18b4fddac2bcd7db2a39837040120000000000000000000000000000000000000000000000000000000000000000000000000");
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        assert_eq!(tx.weight(), Weight::from_wu(780));
+        serde_round_trip!(tx);
+
+        let consensus_encoded = serialize(&tx);
+        assert_eq!(consensus_encoded, tx_bytes);
+    }
+
+    #[test]
+    fn sighashtype_fromstr_display() {
+        let sighashtypes = vec![
+            ("SIGHASH_ALL", EcdsaSighashType::All),
+            ("SIGHASH_NONE", EcdsaSighashType::None),
+            ("SIGHASH_SINGLE", EcdsaSighashType::Single),
+            (
+                "SIGHASH_ALL|SIGHASH_ANYONECANPAY",
+                EcdsaSighashType::AllPlusAnyoneCanPay,
+            ),
+            (
+                "SIGHASH_NONE|SIGHASH_ANYONECANPAY",
+                EcdsaSighashType::NonePlusAnyoneCanPay,
+            ),
+            (
+                "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY",
+                EcdsaSighashType::SinglePlusAnyoneCanPay,
+            ),
+        ];
+        for (s, sht) in sighashtypes {
+            assert_eq!(sht.to_string(), s);
+            assert_eq!(EcdsaSighashType::from_str(s).unwrap(), sht);
+        }
+        let sht_mistakes = vec![
+            "SIGHASH_ALL | SIGHASH_ANYONECANPAY",
+            "SIGHASH_NONE |SIGHASH_ANYONECANPAY",
+            "SIGHASH_SINGLE| SIGHASH_ANYONECANPAY",
+            "SIGHASH_ALL SIGHASH_ANYONECANPAY",
+            "SIGHASH_NONE |",
+            "SIGHASH_SIGNLE",
+            "sighash_none",
+            "Sighash_none",
+            "SigHash_None",
+            "SigHash_NONE",
+        ];
+        for s in sht_mistakes {
+            assert_eq!(
+                EcdsaSighashType::from_str(s).unwrap_err().to_string(),
+                format!("unrecognized SIGHASH string '{}'", s)
+            );
+        }
+    }
+
+    // #[test]
+    // fn huge_witness() {
+    //     deserialize::<Transaction>(&hex!(include_str!("../../tests/data/huge_witness.hex").trim()))
+    //         .unwrap();
+    // }
+
+    #[test]
+    #[cfg(feature = "bitcoinconsensus")]
+    fn transaction_verify() {
+        use std::collections::HashMap;
+
+        use crate::blockdata::witness::Witness;
+
+        // a random recent segwit transaction from blockchain using both old and segwit inputs
+        let mut spending: Transaction = deserialize(hex!("020000000001031cfbc8f54fbfa4a33a30068841371f80dbfe166211242213188428f437445c91000000006a47304402206fbcec8d2d2e740d824d3d36cc345b37d9f65d665a99f5bd5c9e8d42270a03a8022013959632492332200c2908459547bf8dbf97c65ab1a28dec377d6f1d41d3d63e012103d7279dfb90ce17fe139ba60a7c41ddf605b25e1c07a4ddcb9dfef4e7d6710f48feffffff476222484f5e35b3f0e43f65fc76e21d8be7818dd6a989c160b1e5039b7835fc00000000171600140914414d3c94af70ac7e25407b0689e0baa10c77feffffffa83d954a62568bbc99cc644c62eb7383d7c2a2563041a0aeb891a6a4055895570000000017160014795d04cc2d4f31480d9a3710993fbd80d04301dffeffffff06fef72f000000000017a91476fd7035cd26f1a32a5ab979e056713aac25796887a5000f00000000001976a914b8332d502a529571c6af4be66399cd33379071c588ac3fda0500000000001976a914fc1d692f8de10ae33295f090bea5fe49527d975c88ac522e1b00000000001976a914808406b54d1044c429ac54c0e189b0d8061667e088ac6eb68501000000001976a914dfab6085f3a8fb3e6710206a5a959313c5618f4d88acbba20000000000001976a914eb3026552d7e3f3073457d0bee5d4757de48160d88ac0002483045022100bee24b63212939d33d513e767bc79300051f7a0d433c3fcf1e0e3bf03b9eb1d70220588dc45a9ce3a939103b4459ce47500b64e23ab118dfc03c9caa7d6bfc32b9c601210354fd80328da0f9ae6eef2b3a81f74f9a6f66761fadf96f1d1d22b1fd6845876402483045022100e29c7e3a5efc10da6269e5fc20b6a1cb8beb92130cc52c67e46ef40aaa5cac5f0220644dd1b049727d991aece98a105563416e10a5ac4221abac7d16931842d5c322012103960b87412d6e169f30e12106bdf70122aabb9eb61f455518322a18b920a4dfa887d30700")
+            .as_slice()).unwrap();
+        let spent1: Transaction = deserialize(hex!("020000000001040aacd2c49f5f3c0968cfa8caf9d5761436d95385252e3abb4de8f5dcf8a582f20000000017160014bcadb2baea98af0d9a902e53a7e9adff43b191e9feffffff96cd3c93cac3db114aafe753122bd7d1afa5aa4155ae04b3256344ecca69d72001000000171600141d9984579ceb5c67ebfbfb47124f056662fe7adbfeffffffc878dd74d3a44072eae6178bb94b9253177db1a5aaa6d068eb0e4db7631762e20000000017160014df2a48cdc53dae1aba7aa71cb1f9de089d75aac3feffffffe49f99275bc8363f5f593f4eec371c51f62c34ff11cc6d8d778787d340d6896c0100000017160014229b3b297a0587e03375ab4174ef56eeb0968735feffffff03360d0f00000000001976a9149f44b06f6ee92ddbc4686f71afe528c09727a5c788ac24281b00000000001976a9140277b4f68ff20307a2a9f9b4487a38b501eb955888ac227c0000000000001976a9148020cd422f55eef8747a9d418f5441030f7c9c7788ac0247304402204aa3bd9682f9a8e101505f6358aacd1749ecf53a62b8370b97d59243b3d6984f02200384ad449870b0e6e89c92505880411285ecd41cf11e7439b973f13bad97e53901210205b392ffcb83124b1c7ce6dd594688198ef600d34500a7f3552d67947bbe392802473044022033dfd8d190a4ae36b9f60999b217c775b96eb10dee3a1ff50fb6a75325719106022005872e4e36d194e49ced2ebcf8bb9d843d842e7b7e0eb042f4028396088d292f012103c9d7cbf369410b090480de2aa15c6c73d91b9ffa7d88b90724614b70be41e98e0247304402207d952de9e59e4684efed069797e3e2d993e9f98ec8a9ccd599de43005fe3f713022076d190cc93d9513fc061b1ba565afac574e02027c9efbfa1d7b71ab8dbb21e0501210313ad44bc030cc6cb111798c2bf3d2139418d751c1e79ec4e837ce360cc03b97a024730440220029e75edb5e9413eb98d684d62a077b17fa5b7cc19349c1e8cc6c4733b7b7452022048d4b9cae594f03741029ff841e35996ef233701c1ea9aa55c301362ea2e2f68012103590657108a72feb8dc1dec022cf6a230bb23dc7aaa52f4032384853b9f8388baf9d20700")
+            .as_slice()).unwrap();
+        let spent2: Transaction = deserialize(hex!("0200000000010166c3d39490dc827a2594c7b17b7d37445e1f4b372179649cd2ce4475e3641bbb0100000017160014e69aa750e9bff1aca1e32e57328b641b611fc817fdffffff01e87c5d010000000017a914f3890da1b99e44cd3d52f7bcea6a1351658ea7be87024830450221009eb97597953dc288de30060ba02d4e91b2bde1af2ecf679c7f5ab5989549aa8002202a98f8c3bd1a5a31c0d72950dd6e2e3870c6c5819a6c3db740e91ebbbc5ef4800121023f3d3b8e74b807e32217dea2c75c8d0bd46b8665b3a2d9b3cb310959de52a09bc9d20700")
+            .as_slice()).unwrap();
+        let spent3: Transaction = deserialize(hex!("01000000027a1120a30cef95422638e8dab9dedf720ec614b1b21e451a4957a5969afb869d000000006a47304402200ecc318a829a6cad4aa9db152adbf09b0cd2de36f47b53f5dade3bc7ef086ca702205722cda7404edd6012eedd79b2d6f24c0a0c657df1a442d0a2166614fb164a4701210372f4b97b34e9c408741cd1fc97bcc7ffdda6941213ccfde1cb4075c0f17aab06ffffffffc23b43e5a18e5a66087c0d5e64d58e8e21fcf83ce3f5e4f7ecb902b0e80a7fb6010000006b483045022100f10076a0ea4b4cf8816ed27a1065883efca230933bf2ff81d5db6258691ff75202206b001ef87624e76244377f57f0c84bc5127d0dd3f6e0ef28b276f176badb223a01210309a3a61776afd39de4ed29b622cd399d99ecd942909c36a8696cfd22fc5b5a1affffffff0200127a000000000017a914f895e1dd9b29cb228e9b06a15204e3b57feaf7cc8769311d09000000001976a9144d00da12aaa51849d2583ae64525d4a06cd70fde88ac00000000")
+            .as_slice()).unwrap();
+
+        let mut spent = HashMap::new();
+        spent.insert(spent1.compute_txid(), spent1);
+        spent.insert(spent2.compute_txid(), spent2);
+        spent.insert(spent3.compute_txid(), spent3);
+        let mut spent2 = spent.clone();
+        let mut spent3 = spent.clone();
+
+        spending
+            .verify(|point: &OutPoint| {
+                if let Some(tx) = spent.remove(&point.txid) {
+                    return tx.output.get(point.vout as usize).cloned();
+                }
+                None
+            })
+            .unwrap();
+
+        // test that we fail with repeated use of same input
+        let mut double_spending = spending.clone();
+        let re_use = double_spending.input[0].clone();
+        double_spending.input.push(re_use);
+
+        assert!(double_spending
+            .verify(|point: &OutPoint| {
+                if let Some(tx) = spent2.remove(&point.txid) {
+                    return tx.output.get(point.vout as usize).cloned();
+                }
+                None
+            })
+            .is_err());
+
+        // test that we get a failure if we corrupt a signature
+        let mut witness: Vec<_> = spending.input[1].witness.to_vec();
+        witness[0][10] = 42;
+        spending.input[1].witness = Witness::from_slice(&witness);
+
+        let error = spending
+            .verify(|point: &OutPoint| {
+                if let Some(tx) = spent3.remove(&point.txid) {
+                    return tx.output.get(point.vout as usize).cloned();
+                }
+                None
+            })
+            .err()
+            .unwrap();
+
+        match error {
+            TxVerifyError::ScriptVerification(_) => {}
+            _ => panic!("Wrong error type"),
+        }
+    }
+
+    #[test]
+    fn sequence_number() {
+        let seq_final = Sequence::from_consensus(0xFFFFFFFF);
+        let seq_non_rbf = Sequence::from_consensus(0xFFFFFFFE);
+        let block_time_lock = Sequence::from_consensus(0xFFFF);
+        let unit_time_lock = Sequence::from_consensus(0x40FFFF);
+        let lock_time_disabled = Sequence::from_consensus(0x80000000);
+
+        assert!(seq_final.is_final());
+        assert!(!seq_final.is_rbf());
+        assert!(!seq_final.is_relative_lock_time());
+        assert!(!seq_non_rbf.is_rbf());
+        assert!(block_time_lock.is_relative_lock_time());
+        assert!(block_time_lock.is_height_locked());
+        assert!(block_time_lock.is_rbf());
+        assert!(unit_time_lock.is_relative_lock_time());
+        assert!(unit_time_lock.is_time_locked());
+        assert!(unit_time_lock.is_rbf());
+        assert!(!lock_time_disabled.is_relative_lock_time());
+    }
+
+    #[test]
+    fn sequence_from_hex_lower() {
+        let sequence = Sequence::from_hex("0xffffffff").unwrap();
+        assert_eq!(sequence, Sequence::MAX);
+    }
+
+    #[test]
+    fn sequence_from_hex_upper() {
+        let sequence = Sequence::from_hex("0XFFFFFFFF").unwrap();
+        assert_eq!(sequence, Sequence::MAX);
+    }
+
+    #[test]
+    fn sequence_from_unprefixed_hex_lower() {
+        let sequence = Sequence::from_unprefixed_hex("ffffffff").unwrap();
+        assert_eq!(sequence, Sequence::MAX);
+    }
+
+    #[test]
+    fn sequence_from_unprefixed_hex_upper() {
+        let sequence = Sequence::from_unprefixed_hex("FFFFFFFF").unwrap();
+        assert_eq!(sequence, Sequence::MAX);
+    }
+
+    #[test]
+    fn sequence_from_str_hex_invalid_hex_should_err() {
+        let hex = "0xzb93";
+        let result = Sequence::from_hex(hex);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn effective_value_happy_path() {
+        let value = Amount::from_str("1 cBTC").unwrap();
+        let fee_rate = FeeRate::from_sat_per_kwu(10);
+        let satisfaction_weight = Weight::from_wu(204);
+        let effective_value = effective_value(fee_rate, satisfaction_weight, value).unwrap();
+
+        // 10 sat/kwu * (204wu + BASE_WEIGHT) = 4 sats
+        let expected_fee = SignedAmount::from_str("4 sats").unwrap();
+        let expected_effective_value = value.to_signed().unwrap() - expected_fee;
+        assert_eq!(effective_value, expected_effective_value);
+    }
+
+    #[test]
+    fn effective_value_fee_rate_does_not_overflow() {
+        let eff_value = effective_value(FeeRate::MAX, Weight::ZERO, Amount::ZERO);
+        assert!(eff_value.is_none());
+    }
+
+    #[test]
+    fn effective_value_weight_does_not_overflow() {
+        let eff_value = effective_value(FeeRate::ZERO, Weight::MAX, Amount::ZERO);
+        assert!(eff_value.is_none());
+    }
+
+    #[test]
+    fn effective_value_value_does_not_overflow() {
+        let eff_value = effective_value(FeeRate::ZERO, Weight::ZERO, Amount::MAX);
+        assert!(eff_value.is_none());
+    }
+
+    #[test]
+    fn txin_txout_weight() {
+        // [(is_segwit, tx_hex, expected_weight)]
+        let txs = [
+                // one segwit input (P2WPKH)
+                (true, "020000000001018a763b78d3e17acea0625bf9e52b0dc1beb2241b2502185348ba8ff4a253176e0100000000ffffffff0280d725000000000017a914c07ed639bd46bf7087f2ae1dfde63b815a5f8b488767fda20300000000160014869ec8520fa2801c8a01bfdd2e82b19833cd0daf02473044022016243edad96b18c78b545325aaff80131689f681079fb107a67018cb7fb7830e02205520dae761d89728f73f1a7182157f6b5aecf653525855adb7ccb998c8e6143b012103b9489bde92afbcfa85129a82ffa512897105d1a27ad9806bded27e0532fc84e700000000", Weight::from_wu(565)),
+                // one segwit input (P2WSH)
+                (true, "01000000000101a3ccad197118a2d4975fadc47b90eacfdeaf8268adfdf10ed3b4c3b7e1ad14530300000000ffffffff0200cc5501000000001976a91428ec6f21f4727bff84bb844e9697366feeb69f4d88aca2a5100d00000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220548f11130353b3a8f943d2f14260345fc7c20bde91704c9f1cbb5456355078cd0220383ed4ed39b079b618bcb279bbc1f2ca18cb028c4641cb522c9c5868c52a0dc20147304402203c332ecccb3181ca82c0600520ee51fee80d3b4a6ab110945e59475ec71e44ac0220679a11f3ca9993b04ccebda3c834876f353b065bb08f50076b25f5bb93c72ae1016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000", Weight::from_wu(766)),
+                // one segwit input (P2WPKH) and two legacy inputs (P2PKH)
+                (true, "010000000001036b6b6ac7e34e97c53c1cc74c99c7948af2e6aac75d8778004ae458d813456764000000006a473044022001deec7d9075109306320b3754188f81a8236d0d232b44bc69f8309115638b8f02204e17a5194a519cf994d0afeea1268740bdc10616b031a521113681cc415e815c012103488d3272a9fad78ee887f0684cb8ebcfc06d0945e1401d002e590c7338b163feffffffffc75bd7aa6424aee972789ec28ba181254ee6d8311b058d165bd045154d7660b0000000006b483045022100c8641bcbee3e4c47a00417875015d8c5d5ea918fb7e96f18c6ffe51bc555b401022074e2c46f5b1109cd79e39a9aa203eadd1d75356415e51d80928a5fb5feb0efee0121033504b4c6dfc3a5daaf7c425aead4c2dbbe4e7387ce8e6be2648805939ecf7054ffffffff494df3b205cd9430a26f8e8c0dc0bb80496fbc555a524d6ea307724bc7e60eee0100000000ffffffff026d861500000000001976a9145c54ed1360072ebaf56e87693b88482d2c6a101588ace407000000000000160014761e31e2629c6e11936f2f9888179d60a5d4c1f900000247304402201fa38a67a63e58b67b6cfffd02f59121ca1c8a1b22e1efe2573ae7e4b4f06c2b022002b9b431b58f6e36b3334fb14eaecee7d2f06967a77ef50d8d5f90dda1057f0c01210257dc6ce3b1100903306f518ee8fa113d778e403f118c080b50ce079fba40e09a00000000", Weight::from_wu(1755)),
+                // three legacy inputs (P2PKH)
+                (false, "0100000003e4d7be4314204a239d8e00691128dca7927e19a7339c7948bde56f669d27d797010000006b483045022100b988a858e2982e2daaf0755b37ad46775d6132057934877a5badc91dee2f66ff022020b967c1a2f0916007662ec609987e951baafa6d4fda23faaad70715611d6a2501210254a2dccd8c8832d4677dc6f0e562eaaa5d11feb9f1de2c50a33832e7c6190796ffffffff9e22eb1b3f24c260187d716a8a6c2a7efb5af14a30a4792a6eeac3643172379c000000006a47304402207df07f0cd30dca2cf7bed7686fa78d8a37fe9c2254dfdca2befed54e06b779790220684417b8ff9f0f6b480546a9e90ecee86a625b3ea1e4ca29b080da6bd6c5f67e01210254a2dccd8c8832d4677dc6f0e562eaaa5d11feb9f1de2c50a33832e7c6190796ffffffff1123df3bfb503b59769731da103d4371bc029f57979ebce68067768b958091a1000000006a47304402207a016023c2b0c4db9a7d4f9232fcec2193c2f119a69125ad5bcedcba56dd525e02206a734b3a321286c896759ac98ebfd9d808df47f1ce1fbfbe949891cc3134294701210254a2dccd8c8832d4677dc6f0e562eaaa5d11feb9f1de2c50a33832e7c6190796ffffffff0200c2eb0b000000001976a914e5eb3e05efad136b1405f5c2f9adb14e15a35bb488ac88cfff1b000000001976a9144846db516db3130b7a3c92253599edec6bc9630b88ac00000000", Weight::from_wu(2080)),
+                // one segwit input (P2TR)
+                (true, "01000000000101b5cee87f1a60915c38bb0bc26aaf2b67be2b890bbc54bb4be1e40272e0d2fe0b0000000000ffffffff025529000000000000225120106daad8a5cb2e6fc74783714273bad554a148ca2d054e7a19250e9935366f3033760000000000002200205e6d83c44f57484fd2ef2a62b6d36cdcd6b3e06b661e33fd65588a28ad0dbe060141df9d1bfce71f90d68bf9e9461910b3716466bfe035c7dbabaa7791383af6c7ef405a3a1f481488a91d33cd90b098d13cb904323a3e215523aceaa04e1bb35cdb0100000000", Weight::from_wu(617)),
+                // one legacy input (P2PKH)
+                (false, "0100000001c336895d9fa674f8b1e294fd006b1ac8266939161600e04788c515089991b50a030000006a47304402204213769e823984b31dcb7104f2c99279e74249eacd4246dabcf2575f85b365aa02200c3ee89c84344ae326b637101a92448664a8d39a009c8ad5d147c752cbe112970121028b1b44b4903c9103c07d5a23e3c7cf7aeb0ba45ddbd2cfdce469ab197381f195fdffffff040000000000000000536a4c5058325bb7b7251cf9e36cac35d691bd37431eeea426d42cbdecca4db20794f9a4030e6cb5211fabf887642bcad98c9994430facb712da8ae5e12c9ae5ff314127d33665000bb26c0067000bb0bf00322a50c300000000000017a9145ca04fdc0a6d2f4e3f67cfeb97e438bb6287725f8750c30000000000001976a91423086a767de0143523e818d4273ddfe6d9e4bbcc88acc8465003000000001976a914c95cbacc416f757c65c942f9b6b8a20038b9b12988ac00000000", Weight::from_wu(1396)),
+            ];
+
+        let empty_transaction_weight = Transaction {
+            version: Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        }
+        .weight();
+
+        for (is_segwit, tx, expected_weight) in &txs {
+            let txin_weight = if *is_segwit {
+                TxIn::segwit_weight
+            } else {
+                TxIn::legacy_weight
+            };
+            let tx: Transaction = deserialize(Vec::from_hex(tx).unwrap().as_slice()).unwrap();
+            assert_eq!(*is_segwit, tx.uses_segwit_serialization());
+
+            let mut calculated_weight = empty_transaction_weight
+                + tx.input
+                    .iter()
+                    .fold(Weight::ZERO, |sum, i| sum + txin_weight(i))
+                + tx.output
+                    .iter()
+                    .fold(Weight::ZERO, |sum, o| sum + o.weight());
+
+            // The empty tx uses segwit serialization but a legacy tx does not.
+            if !tx.uses_segwit_serialization() {
+                calculated_weight -= Weight::from_wu(2);
+            }
+
+            assert_eq!(calculated_weight, *expected_weight);
+            assert_eq!(tx.weight(), *expected_weight);
+        }
+    }
+
+    #[test]
+    fn tx_sigop_count() {
+        let tx_hexes = [
+            // 0 sigops (p2pkh in + p2wpkh out)
+            (
+                "0200000001725aab4d23f76ad10bb569a68f8702ebfb8b076e015179ff9b9425234953\
+                ac63000000006a47304402204cae7dc9bb68b588dd6b8afb8b881b752fd65178c25693e\
+                a6d5d9a08388fd2a2022011c753d522d5c327741a6d922342c86e05c928309d7e566f68\
+                8148432e887028012103f14b11cfb58b113716e0fa277ab4a32e4d3ed64c6b09b1747ef\
+                7c828d5b06a94fdffffff01e5d4830100000000160014e98527b55cae861e5b9c3a6794\
+                86514c012d6fce00000000",
+                0,                                             // Expected (Some)
+                return_none as fn(&OutPoint) -> Option<TxOut>, // spent fn
+                0,                                             // Expected (None)
+            ),
+            // 5 sigops (p2wpkh in + p2pkh out (x4))
+            (
+                "020000000001018c47330b1c4d30e7e2244e8ccb56d411b71e10073bb42fa1813f3f01\
+                e144cc4d0100000000fdffffff01f7e30300000000001976a9143b49fd16f7562cfeedc\
+                6a4ba84805f8c2f8e1a2c88ac024830450221009a4dbf077a63f6e4c3628a5fef2a09ec\
+                6f7ca4a4d95bc8bb69195b6b671e9272022074da9ffff5a677fc7b37d66bb4ff1f316c9\
+                dbacb92058291d84cd4b83f7c63c9012103d013e9e53c9ca8dd2ddffab1e9df27811503\
+                feea7eb0700ff058851bbb37d99000000000",
+                5,
+                return_p2wpkh,
+                4,
+            ),
+            // 8 sigops (P2WSH 3-of-4 MS (4) in + P2WSH out + P2PKH out (1x4))
+            (
+                "01000000000101e70d7b4d957122909a665070b0c5bbb693982d09e4e66b9e6b7a8390\
+                ce65ef1f0100000000ffffffff02095f2b0000000000220020800a016ea57a08f30c273\
+                ae7624f8f91c505ccbd3043829349533f317168248c52594500000000001976a914607f\
+                643372477c044c6d40b814288e40832a602688ac05004730440220282943649e687b5a3\
+                bda9403c16f363c2ee2be0ec43fb8df40a08b96a4367d47022014e8f36938eef41a09ee\
+                d77a815b0fa120a35f25e3a185310f050959420cee360147304402201e555f894036dd5\
+                78045701e03bf10e093d7e93cd9997e44c1fc65a7b669852302206893f7261e52c9d779\
+                5ba39d99aad30663da43ed675c389542805469fa8eb26a014730440220510fc99bc37d6\
+                dbfa7e8724f4802cebdb17b012aaf70ce625e22e6158b139f40022022e9b811751d491f\
+                bdec7691b697e88ba84315f6739b9e3bd4425ac40563aed2018b5321029ddecf0cc2013\
+                514961550e981a0b8b60e7952f70561a5bb552aa7f075e71e3c2103316195a59c35a3b2\
+                7b6dfcc3192cc10a7a6bbccd5658dfbe98ca62a13d6a02c121034629d906165742def4e\
+                f53c6dade5dcbf88b775774cad151e35ae8285e613b0221035826a29938de2076950811\
+                13c58bcf61fe6adacc3aacceb21c4827765781572d54ae00000000",
+                8,
+                return_p2wsh,
+                4,
+            ),
+            // 5 sigops (P2SH-P2WPKH in (1), 2 P2SH outs (0), 1 P2PKH out (1x4))
+            (
+                "010000000001018aec7e0729ba5a2d284303c89b3f397e92d54472a225d28eb0ae2fa6\
+                5a7d1a2e02000000171600145ad5db65f313ab76726eb178c2fd8f21f977838dfdfffff\
+                f03102700000000000017a914dca89e03ba124c2c70e55533f91100f2d9dab04587f2d7\
+                1d00000000001976a91442a34f4b0a65bc81278b665d37fd15910d261ec588ac292c3b0\
+                00000000017a91461978dcebd0db2da0235c1ba3e8087f9fd74c57f8702473044022000\
+                9226f8def30a8ffa53e55ca5d71a72a64cd20ae7f3112562e3413bd0731d2c0220360d2\
+                20435e67eef7f2bf0258d1dded706e3824f06d961ba9eeaed300b16c2cc012103180cff\
+                753d3e4ee1aa72b2b0fd72ce75956d04f4c19400a3daed0b18c3ab831e00000000",
+                5,
+                return_p2sh,
+                4,
+            ),
+            // 12 sigops (1 P2SH 2-of-3 MS in (3x4), P2SH outs (0))
+            (
+                "010000000115fe9ec3dc964e41f5267ea26cfe505f202bf3b292627496b04bece84da9\
+                b18903000000fc004730440220442827f1085364bda58c5884cee7b289934083362db6d\
+                fb627dc46f6cdbf5793022078cfa524252c381f2a572f0c41486e2838ca94aa268f2384\
+                d0e515744bf0e1e9014730440220160e49536bb29a49c7626744ee83150174c22fa40d5\
+                8fb4cd554a907a6a7b825022045f6cf148504b334064686795f0968c689e542f475b8ef\
+                5a5fa42383948226a3014c69522103e54bc61efbcb8eeff3a5ab2a92a75272f5f6820e3\
+                8e3d28edb54beb06b86c0862103a553e30733d7a8df6d390d59cc136e2c9d9cf4e808f3\
+                b6ab009beae68dd60822210291c5a54bb8b00b6f72b90af0ac0ecaf78fab026d8eded28\
+                2ad95d4d65db268c953aeffffffff024c4f0d000000000017a9146ebf0484bd5053f727\
+                c755a750aa4c815dfa112887a06b12020000000017a91410065dd50b3a7f299fef3b1c5\
+                3b8216399916ab08700000000",
+                12,
+                return_p2sh,
+                0,
+            ),
+            // 3 sigops (1 P2SH-P2WSH 2-of-3 MS in (3), P2SH + P2WSH outs (0))
+            (
+                "0100000000010117a31277a8ba3957be351fe4cffd080e05e07f9ee1594d638f55dd7d\
+                707a983c01000000232200203a33fc9628c29f36a492d9fd811fd20231fbd563f7863e7\
+                9c4dc0ed34ea84b15ffffffff033bed03000000000017a914fb00d9a49663fd8ae84339\
+                8ae81299a1941fb8d287429404000000000017a9148fe08d81882a339cf913281eca8af\
+                39110507c798751ab1300000000002200208819e4bac0109b659de6b9168b83238a050b\
+                ef16278e470083b39d28d2aa5a6904004830450221009faf81f72ec9b14a39f0f0e12f0\
+                1a7175a4fe3239cd9a015ff2085985a9b0e3f022059e1aaf96c9282298bdc9968a46d8a\
+                d28e7299799835cf982b02c35e217caeae0147304402202b1875355ee751e0c8b21990b\
+                7ea73bd84dfd3bd17477b40fc96552acba306ad02204913bc43acf02821a3403132aa0c\
+                33ac1c018d64a119f6cb55dfb8f408d997ef01695221023c15bf3436c0b4089e0ed0428\
+                5101983199d0967bd6682d278821c1e2ac3583621034d924ccabac6d190ce8343829834\
+                cac737aa65a9abe521bcccdcc3882d97481f21035d01d092bb0ebcb793ba3ffa0aeb143\
+                2868f5277d5d3d2a7d2bc1359ec13abbd53aee1560c00",
+                3,
+                return_p2sh,
+                0,
+            ),
+            // 80 sigops (1 P2PKH ins (0), 1 BARE MS outs (20x4))
+            (
+                "0100000001628c1726fecd23331ae9ff2872341b82d2c03180aa64f9bceefe457448db\
+                e579020000006a47304402204799581a5b34ae5adca21ef22c55dbfcee58527127c95d0\
+                1413820fe7556ed970220391565b24dc47ce57fe56bf029792f821a392cdb5a3d45ed85\
+                c158997e7421390121037b2fb5b602e51c493acf4bf2d2423bcf63a09b3b99dfb7bd3c8\
+                d74733b5d66f5ffffffff011c0300000000000069512103a29472a1848105b2225f0eca\
+                5c35ada0b0abbc3c538818a53eca177f4f4dcd9621020c8fd41b65ae6b980c072c5a9f3\
+                aec9f82162c92eb4c51d914348f4390ac39122102222222222222222222222222222222\
+                222222222222222222222222222222222253ae00000000",
+                80,
+                return_none,
+                80,
+            ),
+        ];
+
+        // All we need is to trigger 3 cases for prevout
+        fn return_p2sh(_outpoint: &OutPoint) -> Option<TxOut> {
+            Some(
+                deserialize(&hex!(
+                    "cc721b000000000017a91428203c10cc8f18a77412caaa83dabaf62b8fbb0f87"
+                ))
+                .unwrap(),
+            )
+        }
+        fn return_p2wpkh(_outpoint: &OutPoint) -> Option<TxOut> {
+            Some(
+                deserialize(&hex!(
+                    "e695779d000000001600141c6977423aa4b82a0d7f8496cdf3fc2f8b4f580c"
+                ))
+                .unwrap(),
+            )
+        }
+        fn return_p2wsh(_outpoint: &OutPoint) -> Option<TxOut> {
+            Some(
+                deserialize(&hex!(
+                    "66b51e0900000000220020dbd6c9d5141617eff823176aa226eb69153c1e31334ac37469251a2539fc5c2b"
+                ))
+                .unwrap(),
+            )
+        }
+        fn return_none(_outpoint: &OutPoint) -> Option<TxOut> {
+            None
+        }
+
+        for (hx, expected, spent_fn, expected_none) in tx_hexes.iter() {
+            let tx_bytes = hex!(hx);
+            let tx: Transaction = deserialize(&tx_bytes).unwrap();
+            assert_eq!(tx.total_sigop_cost(spent_fn), *expected);
+            assert_eq!(tx.total_sigop_cost(return_none), *expected_none);
+        }
+    }
+
+    #[test]
+    fn weight_predictions() {
+        // TXID 3d3381f968e3a73841cba5e73bf47dcea9f25a9f7663c51c81f1db8229a309a0
+        let tx_raw = hex!(
+            "01000000000103fc9aa70afba04da865f9821734b556cca9fb5710\
+             fc1338b97fba811033f755e308000000000000000019b37457784d\
+             d04936f011f733b8016c247a9ef08d40007a54a5159d1fc62ee216\
+             00000000000000004c4f2937c6ccf8256d9711a19df1ae62172297\
+             0bf46be925ff15f490efa1633d01000000000000000002c0e1e400\
+             0000000017a9146983f776902c1d1d0355ae0962cb7bc69e9afbde\
+             8706a1e600000000001600144257782711458506b89f255202d645\
+             e25c41144702483045022100dcada0499865a49d0aab8cb113c5f8\
+             3fd5a97abc793f97f3f53aa4b9d1192ed702202094c7934666a30d\
+             6adb1cc9e3b6bc14d2ffebd3200f3908c40053ef2df640b5012103\
+             15434bb59b615a383ae87316e784fc11835bb97fab33fdd2578025\
+             e9968d516e0247304402201d90b3197650569eba4bc0e0b1e2dca7\
+             7dfac7b80d4366f335b67e92e0546e4402203b4be1d443ad7e3a5e\
+             a92aafbcdc027bf9ccf5fe68c0bc8f3ebb6ab806c5464c012103e0\
+             0d92b0fe60731a54fdbcc6920934159db8ffd69d55564579b69a22\
+             ec5bb7530247304402205ab83b734df818e64d8b9e86a8a75f9d00\
+             5c0c6e1b988d045604853ab9ccbde002205a580235841df609d6bd\
+             67534bdcd301999b18e74e197e9e476cdef5fdcbf822012102ebb3\
+             e8a4638ede4721fb98e44e3a3cd61fecfe744461b85e0b6a6a1017\
+             5d5aca00000000"
+        );
+
+        let tx = Transaction::consensus_decode::<&[u8]>(&mut tx_raw.as_ref()).unwrap();
+        let input_weights = vec![
+            InputWeightPrediction::P2WPKH_MAX,
+            InputWeightPrediction::ground_p2wpkh(1),
+            InputWeightPrediction::ground_p2wpkh(1),
+        ];
+        // Outputs: [P2SH, P2WPKH]
+
+        // Confirm the transaction's predicted weight matches its actual weight.
+        let predicted = predict_weight(input_weights, tx.script_pubkey_lens());
+        let expected = tx.weight();
+        assert_eq!(predicted, expected);
+
+        // Confirm signature grinding input weight predictions are aligned with constants.
+        assert_eq!(
+            InputWeightPrediction::ground_p2wpkh(0).weight(),
+            InputWeightPrediction::P2WPKH_MAX.weight()
+        );
+        assert_eq!(
+            InputWeightPrediction::ground_p2pkh_compressed(0).weight(),
+            InputWeightPrediction::P2PKH_COMPRESSED_MAX.weight()
+        );
+    }
+
+    #[test]
+    fn sequence_debug_output() {
+        let seq = Sequence::from_seconds_floor(1000);
+        println!("{:?}", seq)
+    }
+
+    #[test]
+    fn outpoint_format() {
+        let outpoint = OutPoint::default();
+
+        let debug = "OutPoint { txid: 0000000000000000000000000000000000000000000000000000000000000000, vout: 4294967295 }";
+        assert_eq!(debug, format!("{:?}", &outpoint));
+
+        let display = "0000000000000000000000000000000000000000000000000000000000000000:4294967295";
+        assert_eq!(display, format!("{}", &outpoint));
+
+        let pretty_debug = "OutPoint {\n    txid: 0000000000000000000000000000000000000000000000000000000000000000,\n    vout: 4294967295,\n}";
+        assert_eq!(pretty_debug, format!("{:#?}", &outpoint));
+
+        let debug_txid = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(debug_txid, format!("{:?}", &outpoint.txid));
+
+        let display_txid = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(display_txid, format!("{}", &outpoint.txid));
+
+        let pretty_txid = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(pretty_txid, format!("{:#}", &outpoint.txid));
+    }
+}
+
+#[cfg(bench)]
+mod benches {
+    use hex_lit::hex;
+    use io::sink;
+    use test::{black_box, Bencher};
+
+    use super::Transaction;
+    use crate::consensus::{deserialize, Encodable};
+
+    const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
+
+    #[bench]
+    pub fn bench_transaction_size(bh: &mut Bencher) {
+        let raw_tx = hex!(SOME_TX);
+
+        let mut tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        bh.iter(|| {
+            black_box(black_box(&mut tx).total_size());
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_serialize(bh: &mut Bencher) {
+        let raw_tx = hex!(SOME_TX);
+        let tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        let mut data = Vec::with_capacity(raw_tx.len());
+
+        bh.iter(|| {
+            let result = tx.consensus_encode(&mut data);
+            black_box(&result);
+            data.clear();
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_serialize_logic(bh: &mut Bencher) {
+        let raw_tx = hex!(SOME_TX);
+        let tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        bh.iter(|| {
+            let size = tx.consensus_encode(&mut sink());
+            black_box(&size);
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_deserialize(bh: &mut Bencher) {
+        let raw_tx = hex!(SOME_TX);
+
+        bh.iter(|| {
+            let tx: Transaction = deserialize(&raw_tx).unwrap();
+            black_box(&tx);
+        });
+    }
+}

--- a/libs/bitcoin/src/blockdata/witness.rs
+++ b/libs/bitcoin/src/blockdata/witness.rs
@@ -1,0 +1,932 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Witness
+//!
+//! This module contains the [`Witness`] struct and related methods to operate on it
+//!
+
+use core::fmt;
+use core::ops::Index;
+
+use io::{Read, Write};
+
+use crate::consensus::encode::{Error, MAX_VEC_SIZE};
+use crate::consensus::{Decodable, Encodable, WriteExt};
+use crate::crypto::ecdsa;
+use crate::prelude::*;
+use crate::taproot::{self, TAPROOT_ANNEX_PREFIX};
+use crate::{Script, VarInt};
+
+/// The Witness is the data used to unlock bitcoin since the [segwit upgrade].
+///
+/// Can be logically seen as an array of bytestrings, i.e. `Vec<Vec<u8>>`, and it is serialized on the wire
+/// in that format. You can convert between this type and `Vec<Vec<u8>>` by using [`Witness::from_slice`]
+/// and [`Witness::to_vec`].
+///
+/// For serialization and deserialization performance it is stored internally as a single `Vec`,
+/// saving some allocations.
+///
+/// [segwit upgrade]: <https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki>
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Witness {
+    /// Contains the witness `Vec<Vec<u8>>` serialization without the initial varint indicating the
+    /// number of elements (which is stored in `witness_elements`).
+    content: Vec<u8>,
+
+    /// The number of elements in the witness.
+    ///
+    /// Stored separately (instead of as a VarInt in the initial part of content) so that methods
+    /// like [`Witness::push`] don't have to shift the entire array.
+    witness_elements: usize,
+
+    /// This is the valid index pointing to the beginning of the index area. This area is 4 *
+    /// stack_size bytes at the end of the content vector which stores the indices of each item.
+    indices_start: usize,
+}
+
+impl fmt::Debug for Witness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        if f.alternate() {
+            fmt_debug_pretty(self, f)
+        } else {
+            fmt_debug(self, f)
+        }
+    }
+}
+
+fn fmt_debug(w: &Witness, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    #[rustfmt::skip]
+    let comma_or_close = |current_index, last_index| {
+        if current_index == last_index { "]" } else { ", " }
+    };
+
+    f.write_str("Witness: { ")?;
+    write!(f, "indices: {}, ", w.witness_elements)?;
+    write!(f, "indices_start: {}, ", w.indices_start)?;
+    f.write_str("witnesses: [")?;
+
+    let instructions = w.iter();
+    match instructions.len().checked_sub(1) {
+        Some(last_instruction) => {
+            for (i, instruction) in instructions.enumerate() {
+                let bytes = instruction.iter();
+                match bytes.len().checked_sub(1) {
+                    Some(last_byte) => {
+                        f.write_str("[")?;
+                        for (j, byte) in bytes.enumerate() {
+                            write!(f, "{:#04x}", byte)?;
+                            f.write_str(comma_or_close(j, last_byte))?;
+                        }
+                    }
+                    None => {
+                        // This is possible because the varint is not part of the instruction (see Iter).
+                        write!(f, "[]")?;
+                    }
+                }
+                f.write_str(comma_or_close(i, last_instruction))?;
+            }
+        }
+        None => {
+            // Witnesses can be empty because the 0x00 var int is not stored in content.
+            write!(f, "]")?;
+        }
+    }
+
+    f.write_str(" }")
+}
+
+fn fmt_debug_pretty(w: &Witness, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    f.write_str("Witness: {\n")?;
+    writeln!(f, "    indices: {},", w.witness_elements)?;
+    writeln!(f, "    indices_start: {},", w.indices_start)?;
+    f.write_str("    witnesses: [\n")?;
+
+    for instruction in w.iter() {
+        f.write_str("        [")?;
+        for (j, byte) in instruction.iter().enumerate() {
+            if j > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{:#04x}", byte)?;
+        }
+        f.write_str("],\n")?;
+    }
+
+    writeln!(f, "    ],")?;
+    writeln!(f, "}}")
+}
+
+/// An iterator returning individual witness elements.
+pub struct Iter<'a> {
+    inner: &'a [u8],
+    indices_start: usize,
+    current_index: usize,
+}
+
+impl Decodable for Witness {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let witness_elements = VarInt::consensus_decode(r)?.0 as usize;
+        // Minimum size of witness element is 1 byte, so if the count is
+        // greater than MAX_VEC_SIZE we must return an error.
+        if witness_elements > MAX_VEC_SIZE {
+            return Err(self::Error::OversizedVectorAllocation {
+                requested: witness_elements,
+                max: MAX_VEC_SIZE,
+            });
+        }
+        if witness_elements == 0 {
+            Ok(Witness::default())
+        } else {
+            // Leave space at the head for element positions.
+            // We will rotate them to the end of the Vec later.
+            let witness_index_space = witness_elements * 4;
+            let mut cursor = witness_index_space;
+
+            // this number should be determined as high enough to cover most witness, and low enough
+            // to avoid wasting space without reallocating
+            let mut content = vec![0u8; cursor + 128];
+
+            for i in 0..witness_elements {
+                let element_size_varint = VarInt::consensus_decode(r)?;
+                let element_size_varint_len = element_size_varint.size();
+                let element_size = element_size_varint.0 as usize;
+                let required_len = cursor
+                    .checked_add(element_size)
+                    .ok_or(self::Error::OversizedVectorAllocation {
+                        requested: usize::MAX,
+                        max: MAX_VEC_SIZE,
+                    })?
+                    .checked_add(element_size_varint_len)
+                    .ok_or(self::Error::OversizedVectorAllocation {
+                        requested: usize::MAX,
+                        max: MAX_VEC_SIZE,
+                    })?;
+
+                if required_len > MAX_VEC_SIZE + witness_index_space {
+                    return Err(self::Error::OversizedVectorAllocation {
+                        requested: required_len,
+                        max: MAX_VEC_SIZE,
+                    });
+                }
+
+                // We will do content.rotate_left(witness_index_space) later.
+                // Encode the position's value AFTER we rotate left.
+                encode_cursor(&mut content, 0, i, cursor - witness_index_space);
+
+                resize_if_needed(&mut content, required_len);
+                element_size_varint.consensus_encode(
+                    &mut &mut content[cursor..cursor + element_size_varint_len],
+                )?;
+                cursor += element_size_varint_len;
+                r.read_exact(&mut content[cursor..cursor + element_size])?;
+                cursor += element_size;
+            }
+            content.truncate(cursor);
+            // Index space is now at the end of the Vec
+            content.rotate_left(witness_index_space);
+            Ok(Witness { content, witness_elements, indices_start: cursor - witness_index_space })
+        }
+    }
+}
+
+/// Correctness Requirements: value must always fit within u32
+#[inline]
+fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value: usize) {
+    let start = start_of_indices + index * 4;
+    let end = start + 4;
+    bytes[start..end]
+        .copy_from_slice(&u32::to_ne_bytes(value.try_into().expect("Larger than u32")));
+}
+
+#[inline]
+fn decode_cursor(bytes: &[u8], start_of_indices: usize, index: usize) -> Option<usize> {
+    let start = start_of_indices + index * 4;
+    let end = start + 4;
+    if end > bytes.len() {
+        None
+    } else {
+        Some(u32::from_ne_bytes(bytes[start..end].try_into().expect("is u32 size")) as usize)
+    }
+}
+
+fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
+    if required_len >= vec.len() {
+        let mut new_len = vec.len().max(1);
+        while new_len <= required_len {
+            new_len *= 2;
+        }
+        vec.resize(new_len, 0);
+    }
+}
+
+impl Encodable for Witness {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let len = VarInt::from(self.witness_elements);
+        len.consensus_encode(w)?;
+        let content_with_indices_len = self.content.len();
+        let indices_size = self.witness_elements * 4;
+        let content_len = content_with_indices_len - indices_size;
+        w.emit_slice(&self.content[..content_len])?;
+        Ok(content_len + len.size())
+    }
+}
+
+impl Witness {
+    /// Creates a new empty [`Witness`].
+    #[inline]
+    pub const fn new() -> Self {
+        Witness { content: Vec::new(), witness_elements: 0, indices_start: 0 }
+    }
+
+    /// Creates a witness required to spend a P2WPKH output.
+    ///
+    /// The witness will be made up of the DER encoded signature + sighash_type followed by the
+    /// serialized public key. Also useful for spending a P2SH-P2WPKH output.
+    ///
+    /// It is expected that `pubkey` is related to the secret key used to create `signature`.
+    pub fn p2wpkh(signature: &ecdsa::Signature, pubkey: &secp256k1::PublicKey) -> Witness {
+        let mut witness = Witness::new();
+        witness.push_slice(&signature.serialize());
+        witness.push_slice(&pubkey.serialize());
+        witness
+    }
+
+    /// Creates a witness required to do a key path spend of a P2TR output.
+    pub fn p2tr_key_spend(signature: &taproot::Signature) -> Witness {
+        let mut witness = Witness::new();
+        witness.push_slice(&signature.serialize());
+        witness
+    }
+
+    /// Creates a [`Witness`] object from a slice of bytes slices where each slice is a witness item.
+    pub fn from_slice<T: AsRef<[u8]>>(slice: &[T]) -> Self {
+        let witness_elements = slice.len();
+        let index_size = witness_elements * 4;
+        let content_size = slice
+            .iter()
+            .map(|elem| elem.as_ref().len() + VarInt::from(elem.as_ref().len()).size())
+            .sum();
+
+        let mut content = vec![0u8; content_size + index_size];
+        let mut cursor = 0usize;
+        for (i, elem) in slice.iter().enumerate() {
+            encode_cursor(&mut content, content_size, i, cursor);
+            let elem_len_varint = VarInt::from(elem.as_ref().len());
+            elem_len_varint
+                .consensus_encode(&mut &mut content[cursor..cursor + elem_len_varint.size()])
+                .expect("writers on vec don't errors, space granted by content_size");
+            cursor += elem_len_varint.size();
+            content[cursor..cursor + elem.as_ref().len()].copy_from_slice(elem.as_ref());
+            cursor += elem.as_ref().len();
+        }
+
+        Witness { witness_elements, content, indices_start: content_size }
+    }
+
+    /// Convenience method to create an array of byte-arrays from this witness.
+    pub fn to_vec(&self) -> Vec<Vec<u8>> { self.iter().map(|s| s.to_vec()).collect() }
+
+    /// Returns `true` if the witness contains no element.
+    pub fn is_empty(&self) -> bool { self.witness_elements == 0 }
+
+    /// Returns a struct implementing [`Iterator`].
+    pub fn iter(&self) -> Iter {
+        Iter { inner: self.content.as_slice(), indices_start: self.indices_start, current_index: 0 }
+    }
+
+    /// Returns the number of elements this witness holds.
+    pub fn len(&self) -> usize { self.witness_elements }
+
+    /// Returns the number of bytes this witness contributes to a transactions total size.
+    pub fn size(&self) -> usize {
+        let mut size: usize = 0;
+
+        size += VarInt::from(self.witness_elements).size();
+        size += self
+            .iter()
+            .map(|witness_element| {
+                VarInt::from(witness_element.len()).size() + witness_element.len()
+            })
+            .sum::<usize>();
+
+        size
+    }
+
+    /// Clear the witness.
+    pub fn clear(&mut self) {
+        self.content.clear();
+        self.witness_elements = 0;
+        self.indices_start = 0;
+    }
+
+    /// Push a new element on the witness, requires an allocation.
+    pub fn push<T: AsRef<[u8]>>(&mut self, new_element: T) {
+        self.push_slice(new_element.as_ref());
+    }
+
+    /// Push a new element slice onto the witness stack.
+    fn push_slice(&mut self, new_element: &[u8]) {
+        self.witness_elements += 1;
+        let previous_content_end = self.indices_start;
+        let element_len_varint = VarInt::from(new_element.len());
+        let current_content_len = self.content.len();
+        let new_item_total_len = element_len_varint.size() + new_element.len();
+        self.content.resize(current_content_len + new_item_total_len + 4, 0);
+
+        self.content[previous_content_end..].rotate_right(new_item_total_len);
+        self.indices_start += new_item_total_len;
+        encode_cursor(
+            &mut self.content,
+            self.indices_start,
+            self.witness_elements - 1,
+            previous_content_end,
+        );
+
+        let end_varint = previous_content_end + element_len_varint.size();
+        element_len_varint
+            .consensus_encode(&mut &mut self.content[previous_content_end..end_varint])
+            .expect("writers on vec don't error, space granted through previous resize");
+        self.content[end_varint..end_varint + new_element.len()].copy_from_slice(new_element);
+    }
+
+    /// Pushes, as a new element on the witness, an ECDSA signature.
+    ///
+    /// Pushes the DER encoded signature + sighash_type, requires an allocation.
+    pub fn push_ecdsa_signature(&mut self, signature: &ecdsa::Signature) {
+        self.push_slice(&signature.serialize())
+    }
+
+    fn element_at(&self, index: usize) -> Option<&[u8]> {
+        let varint = VarInt::consensus_decode(&mut &self.content[index..]).ok()?;
+        let start = index + varint.size();
+        Some(&self.content[start..start + varint.0 as usize])
+    }
+
+    /// Returns the last element in the witness, if any.
+    pub fn last(&self) -> Option<&[u8]> {
+        if self.witness_elements == 0 {
+            None
+        } else {
+            self.nth(self.witness_elements - 1)
+        }
+    }
+
+    /// Returns the second-to-last element in the witness, if any.
+    pub fn second_to_last(&self) -> Option<&[u8]> {
+        if self.witness_elements <= 1 {
+            None
+        } else {
+            self.nth(self.witness_elements - 2)
+        }
+    }
+
+    /// Returns the third-to-last element in the witness, if any.
+    pub fn third_to_last(&self) -> Option<&[u8]> {
+        if self.witness_elements <= 2 {
+            None
+        } else {
+            self.nth(self.witness_elements - 3)
+        }
+    }
+
+    /// Return the nth element in the witness, if any
+    pub fn nth(&self, index: usize) -> Option<&[u8]> {
+        let pos = decode_cursor(&self.content, self.indices_start, index)?;
+        self.element_at(pos)
+    }
+
+    /// Get Tapscript following BIP341 rules regarding accounting for an annex.
+    ///
+    /// This does not guarantee that this represents a P2TR [`Witness`]. It
+    /// merely gets the second to last or third to last element depending on
+    /// the first byte of the last element being equal to 0x50. See
+    /// [Script::is_p2tr](crate::blockdata::script::Script::is_p2tr) to
+    /// check whether this is actually a Taproot witness.
+    pub fn tapscript(&self) -> Option<&Script> {
+            if self.is_empty() {
+                return None;
+            }
+
+            if self.taproot_annex().is_some() {
+                self.third_to_last().map(Script::from_bytes)
+            } else {
+                self.second_to_last().map(Script::from_bytes)
+            }
+    }
+
+    /// Get the taproot control block following BIP341 rules.
+    ///
+    /// This does not guarantee that this represents a P2TR [`Witness`]. It
+    /// merely gets the last or second to last element depending on the first
+    /// byte of the last element being equal to 0x50. See
+    /// [Script::is_p2tr](crate::blockdata::script::Script::is_p2tr) to
+    /// check whether this is actually a Taproot witness.
+    pub fn taproot_control_block(&self) -> Option<&[u8]> {
+            if self.is_empty() {
+                return None;
+            }
+
+            if self.taproot_annex().is_some() {
+                self.second_to_last()
+            } else {
+                self.last()
+            }
+    }
+
+    /// Get the taproot annex following BIP341 rules.
+    ///
+    /// This does not guarantee that this represents a P2TR [`Witness`]. See
+    /// [Script::is_p2tr](crate::blockdata::script::Script::is_p2tr) to
+    /// check whether this is actually a Taproot witness.
+    pub fn taproot_annex(&self) -> Option<&[u8]> {
+        self.last().and_then(|last| {
+            // From BIP341:
+            // If there are at least two witness elements, and the first byte of
+            // the last element is 0x50, this last element is called annex a
+            // and is removed from the witness stack.
+            if self.len() >= 2 && last.first() == Some(&TAPROOT_ANNEX_PREFIX) {
+                Some(last)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get the p2wsh witness script following BIP141 rules.
+    ///
+    /// This does not guarantee that this represents a P2WS [`Witness`]. See
+    /// [Script::is_p2wsh](crate::blockdata::script::Script::is_p2wsh) to
+    /// check whether this is actually a P2WSH witness.
+    pub fn witness_script(&self) -> Option<&Script> {
+        self.last().map(Script::from_bytes)
+    }
+}
+
+impl Index<usize> for Witness {
+    type Output = [u8];
+
+    fn index(&self, index: usize) -> &Self::Output { self.nth(index).expect("Out of Bounds") }
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = decode_cursor(self.inner, self.indices_start, self.current_index)?;
+        let varint = VarInt::consensus_decode(&mut &self.inner[index..]).ok()?;
+        let start = index + varint.size();
+        let end = start + varint.0 as usize;
+        let slice = &self.inner[start..end];
+        self.current_index += 1;
+        Some(slice)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let total_count = (self.inner.len() - self.indices_start) / 4;
+        let remaining = total_count - self.current_index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {}
+
+impl<'a> IntoIterator for &'a Witness {
+    type IntoIter = Iter<'a>;
+    type Item = &'a [u8];
+
+    fn into_iter(self) -> Self::IntoIter { self.iter() }
+}
+
+// Serde keep backward compatibility with old Vec<Vec<u8>> format
+#[cfg(feature = "serde")]
+impl serde::Serialize for Witness {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let human_readable = serializer.is_human_readable();
+        let mut seq = serializer.serialize_seq(Some(self.witness_elements))?;
+
+        for elem in self.iter() {
+            if human_readable {
+                seq.serialize_element(&crate::serde_utils::SerializeBytesAsHex(elem))?;
+            } else {
+                seq.serialize_element(&elem)?;
+            }
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Witness {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor; // Human-readable visitor.
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Witness;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "a sequence of hex arrays")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut a: A,
+            ) -> Result<Self::Value, A::Error> {
+                use hex::FromHex;
+                use hex::HexToBytesError::*;
+                use serde::de::{self, Unexpected};
+
+                let mut ret = match a.size_hint() {
+                    Some(len) => Vec::with_capacity(len),
+                    None => Vec::new(),
+                };
+
+                while let Some(elem) = a.next_element::<String>()? {
+                    let vec = Vec::<u8>::from_hex(&elem).map_err(|e| match e {
+                        InvalidChar(ref e) => match core::char::from_u32(e.invalid_char().into()) {
+                            Some(c) => de::Error::invalid_value(
+                                Unexpected::Char(c),
+                                &"a valid hex character",
+                            ),
+                            None => de::Error::invalid_value(
+                                Unexpected::Unsigned(e.invalid_char().into()),
+                                &"a valid hex character",
+                            ),
+                        },
+                        OddLengthString(ref e) =>
+                            de::Error::invalid_length(e.length(), &"an even length string"),
+                    })?;
+                    ret.push(vec);
+                }
+                Ok(Witness::from_slice(&ret))
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_seq(Visitor)
+        } else {
+            let vec: Vec<Vec<u8>> = serde::Deserialize::deserialize(deserializer)?;
+            Ok(Witness::from_slice(&vec))
+        }
+    }
+}
+
+impl From<Vec<Vec<u8>>> for Witness {
+    fn from(vec: Vec<Vec<u8>>) -> Self { Witness::from_slice(&vec) }
+}
+
+impl From<&[&[u8]]> for Witness {
+    fn from(slice: &[&[u8]]) -> Self { Witness::from_slice(slice) }
+}
+
+impl From<&[Vec<u8>]> for Witness {
+    fn from(slice: &[Vec<u8>]) -> Self { Witness::from_slice(slice) }
+}
+
+impl From<Vec<&[u8]>> for Witness {
+    fn from(vec: Vec<&[u8]>) -> Self { Witness::from_slice(&vec) }
+}
+
+impl Default for Witness {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(test)]
+mod test {
+    use hex::test_hex_unwrap as hex;
+
+    use super::*;
+    use crate::consensus::{deserialize, serialize};
+    use crate::sighash::EcdsaSighashType;
+    use crate::Transaction;
+
+    fn append_u32_vec(mut v: Vec<u8>, n: &[u32]) -> Vec<u8> {
+        for &num in n {
+            v.extend_from_slice(&num.to_ne_bytes());
+        }
+        v
+    }
+
+    #[test]
+    fn witness_debug_can_display_empty_instruction() {
+        let witness = Witness {
+            witness_elements: 1,
+            content: append_u32_vec(vec![], &[0]),
+            indices_start: 2,
+        };
+        println!("{:?}", witness);
+    }
+
+    #[test]
+    fn test_push() {
+        let mut witness = Witness::default();
+        assert_eq!(witness.last(), None);
+        assert_eq!(witness.second_to_last(), None);
+        assert_eq!(witness.nth(0), None);
+        assert_eq!(witness.nth(1), None);
+        assert_eq!(witness.nth(2), None);
+        assert_eq!(witness.nth(3), None);
+        witness.push(&vec![0u8]);
+        let expected = Witness {
+            witness_elements: 1,
+            content: append_u32_vec(vec![1u8, 0], &[0]),
+            indices_start: 2,
+        };
+        assert_eq!(witness, expected);
+        assert_eq!(witness.last(), Some(&[0u8][..]));
+        assert_eq!(witness.second_to_last(), None);
+        assert_eq!(witness.nth(0), Some(&[0u8][..]));
+        assert_eq!(witness.nth(1), None);
+        assert_eq!(witness.nth(2), None);
+        assert_eq!(witness.nth(3), None);
+        assert_eq!(&witness[0], &[0u8][..]);
+        witness.push(&vec![2u8, 3u8]);
+        let expected = Witness {
+            witness_elements: 2,
+            content: append_u32_vec(vec![1u8, 0, 2, 2, 3], &[0, 2]),
+            indices_start: 5,
+        };
+        assert_eq!(witness, expected);
+        assert_eq!(witness.last(), Some(&[2u8, 3u8][..]));
+        assert_eq!(witness.second_to_last(), Some(&[0u8][..]));
+        assert_eq!(witness.nth(0), Some(&[0u8][..]));
+        assert_eq!(witness.nth(1), Some(&[2u8, 3u8][..]));
+        assert_eq!(witness.nth(2), None);
+        assert_eq!(witness.nth(3), None);
+        assert_eq!(&witness[0], &[0u8][..]);
+        assert_eq!(&witness[1], &[2u8, 3u8][..]);
+        witness.push(&vec![4u8, 5u8]);
+        let expected = Witness {
+            witness_elements: 3,
+            content: append_u32_vec(vec![1u8, 0, 2, 2, 3, 2, 4, 5], &[0, 2, 5]),
+            indices_start: 8,
+        };
+        assert_eq!(witness, expected);
+        assert_eq!(witness.last(), Some(&[4u8, 5u8][..]));
+        assert_eq!(witness.second_to_last(), Some(&[2u8, 3u8][..]));
+        assert_eq!(witness.nth(0), Some(&[0u8][..]));
+        assert_eq!(witness.nth(1), Some(&[2u8, 3u8][..]));
+        assert_eq!(witness.nth(2), Some(&[4u8, 5u8][..]));
+        assert_eq!(witness.nth(3), None);
+        assert_eq!(&witness[0], &[0u8][..]);
+        assert_eq!(&witness[1], &[2u8, 3u8][..]);
+        assert_eq!(&witness[2], &[4u8, 5u8][..]);
+    }
+
+    #[test]
+    fn test_iter_len() {
+        let mut witness = Witness::default();
+        for i in 0..5 {
+            assert_eq!(witness.iter().len(), i);
+            witness.push(&vec![0u8]);
+        }
+        let mut iter = witness.iter();
+        for i in (0..=5).rev() {
+            assert_eq!(iter.len(), i);
+            iter.next();
+        }
+    }
+
+    #[test]
+    fn test_push_ecdsa_sig() {
+        // The very first signature in block 734,958
+        let sig_bytes =
+            hex!("304402207c800d698f4b0298c5aac830b822f011bb02df41eb114ade9a6702f364d5e39c0220366900d2a60cab903e77ef7dd415d46509b1f78ac78906e3296f495aa1b1b541");
+        let signature = secp256k1::ecdsa::Signature::from_der(&sig_bytes).unwrap();
+        let mut witness = Witness::default();
+        let signature = crate::ecdsa::Signature { signature, sighash_type: EcdsaSighashType::All };
+        witness.push_ecdsa_signature(&signature);
+        let expected_witness = vec![hex!(
+            "304402207c800d698f4b0298c5aac830b822f011bb02df41eb114ade9a6702f364d5e39c0220366900d2a60cab903e77ef7dd415d46509b1f78ac78906e3296f495aa1b1b54101")
+            ];
+        assert_eq!(witness.to_vec(), expected_witness);
+    }
+
+    #[test]
+    fn test_witness() {
+        let w0 = hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105");
+        let w1 = hex!("000000");
+        let witness_vec = vec![w0.clone(), w1.clone()];
+        let witness_serialized: Vec<u8> = serialize(&witness_vec);
+        let witness = Witness {
+            content: append_u32_vec(witness_serialized[1..].to_vec(), &[0, 34]),
+            witness_elements: 2,
+            indices_start: 38,
+        };
+        for (i, el) in witness.iter().enumerate() {
+            assert_eq!(witness_vec[i], el);
+        }
+        assert_eq!(witness.last(), Some(&w1[..]));
+        assert_eq!(witness.second_to_last(), Some(&w0[..]));
+        assert_eq!(witness.nth(0), Some(&w0[..]));
+        assert_eq!(witness.nth(1), Some(&w1[..]));
+        assert_eq!(witness.nth(2), None);
+        assert_eq!(&witness[0], &w0[..]);
+        assert_eq!(&witness[1], &w1[..]);
+
+        let w_into = Witness::from_slice(&witness_vec);
+        assert_eq!(w_into, witness);
+
+        assert_eq!(witness_serialized, serialize(&witness));
+    }
+
+    #[test]
+    fn test_get_tapscript() {
+        let tapscript = hex!("deadbeef");
+        let control_block = hex!("02");
+        // annex starting with 0x50 causes the branching logic.
+        let annex = hex!("50");
+
+        let witness_vec = vec![tapscript.clone(), control_block.clone()];
+        let witness_vec_annex = vec![tapscript.clone(), control_block, annex];
+
+        let witness_serialized: Vec<u8> = serialize(&witness_vec);
+        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
+
+        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
+        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+
+        // With or without annex, the tapscript should be returned.
+        assert_eq!(witness.tapscript(), Some(Script::from_bytes(&tapscript[..])));
+        assert_eq!(witness_annex.tapscript(), Some(Script::from_bytes(&tapscript[..])));
+    }
+
+    #[test]
+    fn test_get_tapscript_from_keypath() {
+        let signature = hex!("deadbeef");
+        // annex starting with 0x50 causes the branching logic.
+        let annex = hex!("50");
+
+        let witness_vec = vec![signature.clone()];
+        let witness_vec_annex = vec![signature.clone(), annex];
+
+        let witness_serialized: Vec<u8> = serialize(&witness_vec);
+        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
+
+        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
+        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+
+        // With or without annex, no tapscript should be returned.
+        assert_eq!(witness.tapscript(), None);
+        assert_eq!(witness_annex.tapscript(), None);
+    }
+
+    #[test]
+    fn test_get_control_block() {
+        let tapscript = hex!("deadbeef");
+        let control_block = hex!("02");
+        // annex starting with 0x50 causes the branching logic.
+        let annex = hex!("50");
+
+        let witness_vec = vec![tapscript.clone(), control_block.clone()];
+        let witness_vec_annex = vec![tapscript.clone(), control_block.clone(), annex];
+
+        let witness_serialized: Vec<u8> = serialize(&witness_vec);
+        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
+
+        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
+        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+
+        // With or without annex, the tapscript should be returned.
+        assert_eq!(witness.taproot_control_block(), Some(&control_block[..]));
+        assert_eq!(witness_annex.taproot_control_block(), Some(&control_block[..]));
+    }
+
+    #[test]
+    fn test_get_annex() {
+        let tapscript = hex!("deadbeef");
+        let control_block = hex!("02");
+        // annex starting with 0x50 causes the branching logic.
+        let annex = hex!("50");
+
+        let witness_vec = vec![tapscript.clone(), control_block.clone()];
+        let witness_vec_annex = vec![tapscript.clone(), control_block.clone(), annex.clone()];
+
+        let witness_serialized: Vec<u8> = serialize(&witness_vec);
+        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
+
+        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
+        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+
+        // With or without annex, the tapscript should be returned.
+        assert_eq!(witness.taproot_annex(), None);
+        assert_eq!(witness_annex.taproot_annex(), Some(&annex[..]));
+
+        // Now for keyspend
+        let signature = hex!("deadbeef");
+        // annex starting with 0x50 causes the branching logic.
+        let annex = hex!("50");
+
+        let witness_vec = vec![signature.clone()];
+        let witness_vec_annex = vec![signature.clone(), annex.clone()];
+
+        let witness_serialized: Vec<u8> = serialize(&witness_vec);
+        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
+
+        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
+        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+
+        // With or without annex, the tapscript should be returned.
+        assert_eq!(witness.taproot_annex(), None);
+        assert_eq!(witness_annex.taproot_annex(), Some(&annex[..]));
+    }
+
+    #[test]
+    fn test_tx() {
+        const S: &str = "02000000000102b44f26b275b8ad7b81146ba3dbecd081f9c1ea0dc05b97516f56045cfcd3df030100000000ffffffff1cb4749ae827c0b75f3d0a31e63efc8c71b47b5e3634a4c698cd53661cab09170100000000ffffffff020b3a0500000000001976a9143ea74de92762212c96f4dd66c4d72a4deb20b75788ac630500000000000016001493a8dfd1f0b6a600ab01df52b138cda0b82bb7080248304502210084622878c94f4c356ce49c8e33a063ec90f6ee9c0208540888cfab056cd1fca9022014e8dbfdfa46d318c6887afd92dcfa54510e057565e091d64d2ee3a66488f82c0121026e181ffb98ebfe5a64c983073398ea4bcd1548e7b971b4c175346a25a1c12e950247304402203ef00489a0d549114977df2820fab02df75bebb374f5eee9e615107121658cfa02204751f2d1784f8e841bff6d3bcf2396af2f1a5537c0e4397224873fbd3bfbe9cf012102ae6aa498ce2dd204e9180e71b4fb1260fe3d1a95c8025b34e56a9adf5f278af200000000";
+        let tx_bytes = hex!(S);
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+
+        let expected_wit = ["304502210084622878c94f4c356ce49c8e33a063ec90f6ee9c0208540888cfab056cd1fca9022014e8dbfdfa46d318c6887afd92dcfa54510e057565e091d64d2ee3a66488f82c01", "026e181ffb98ebfe5a64c983073398ea4bcd1548e7b971b4c175346a25a1c12e95"];
+        for (i, wit_el) in tx.input[0].witness.iter().enumerate() {
+            assert_eq!(expected_wit[i], wit_el.to_lower_hex_string());
+        }
+        assert_eq!(expected_wit[1], tx.input[0].witness.last().unwrap().to_lower_hex_string());
+        assert_eq!(
+            expected_wit[0],
+            tx.input[0].witness.second_to_last().unwrap().to_lower_hex_string()
+        );
+        assert_eq!(expected_wit[0], tx.input[0].witness.nth(0).unwrap().to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.input[0].witness.nth(1).unwrap().to_lower_hex_string());
+        assert_eq!(None, tx.input[0].witness.nth(2));
+        assert_eq!(expected_wit[0], tx.input[0].witness[0].to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.input[0].witness[1].to_lower_hex_string());
+
+        let tx_bytes_back = serialize(&tx);
+        assert_eq!(tx_bytes_back, tx_bytes);
+    }
+
+    #[test]
+    fn fuzz_cases() {
+        let bytes = hex!("26ff0000000000c94ce592cf7a4cbb68eb00ce374300000057cd0000000000000026");
+        assert!(deserialize::<Witness>(&bytes).is_err()); // OversizedVectorAllocation
+
+        let bytes = hex!("24000000ffffffffffffffffffffffff");
+        assert!(deserialize::<Witness>(&bytes).is_err()); // OversizedVectorAllocation
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_bincode() {
+        use bincode;
+
+        let old_witness_format = vec![vec![0u8], vec![2]];
+        let new_witness_format = Witness::from_slice(&old_witness_format);
+
+        let old = bincode::serialize(&old_witness_format).unwrap();
+        let new = bincode::serialize(&new_witness_format).unwrap();
+
+        assert_eq!(old, new);
+
+        let back: Witness = bincode::deserialize(&new).unwrap();
+        assert_eq!(new_witness_format, back);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_human() {
+        use serde_json;
+
+        let witness = Witness::from_slice(&[vec![0u8, 123, 75], vec![2u8, 6, 3, 7, 8]]);
+
+        let json = serde_json::to_string(&witness).unwrap();
+
+        assert_eq!(json, r#"["007b4b","0206030708"]"#);
+
+        let back: Witness = serde_json::from_str(&json).unwrap();
+        assert_eq!(witness, back);
+    }
+}
+
+#[cfg(bench)]
+mod benches {
+    use test::{black_box, Bencher};
+
+    use super::Witness;
+
+    #[bench]
+    pub fn bench_big_witness_to_vec(bh: &mut Bencher) {
+        let raw_witness = [[1u8]; 5];
+        let witness = Witness::from_slice(&raw_witness);
+
+        bh.iter(|| {
+            black_box(witness.to_vec());
+        });
+    }
+
+    #[bench]
+    pub fn bench_witness_to_vec(bh: &mut Bencher) {
+        let raw_witness = vec![vec![1u8]; 3];
+        let witness = Witness::from_slice(&raw_witness);
+
+        bh.iter(|| {
+            black_box(witness.to_vec());
+        });
+    }
+}

--- a/libs/bitcoin/src/consensus/encode.rs
+++ b/libs/bitcoin/src/consensus/encode.rs
@@ -1,0 +1,1409 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin consensus-encodable types.
+//!
+//! This is basically a replacement of the `Encodable` trait which does
+//! normalization of endianness etc., to ensure that the encoding matches
+//! the network consensus encoding.
+//!
+//! Essentially, anything that must go on the _disk_ or _network_ must be
+//! encoded using the `Encodable` trait, since this data must be the same for
+//! all systems. Any data going to the _user_ e.g., over JSONRPC, should use the
+//! ordinary `Encodable` trait. (This should also be the same across systems, of
+//! course, but has some critical differences from the network format e.g.,
+//! scripts come with an opcode decode, hashes are big-endian, numbers are
+//! typically big-endian decimals, etc.)
+//!
+
+use core::{fmt, mem};
+
+use hashes::{sha256, sha256d, Hash};
+use hex::error::{InvalidCharError, OddLengthStringError};
+use internals::write_err;
+use io::{Cursor, Read, Write};
+
+use crate::bip152::{PrefilledTransaction, ShortId};
+use crate::bip158::{FilterHash, FilterHeader};
+use crate::blockdata::block::{self, BlockHash, TxMerkleNode};
+use crate::blockdata::transaction::{Transaction, TxIn, TxOut};
+use crate::consensus::{DecodeError, IterReader};
+#[cfg(feature = "std")]
+use crate::p2p::{
+    address::{AddrV2Message, Address},
+    message_blockdata::Inventory,
+};
+use crate::prelude::*;
+use crate::taproot::TapLeafHash;
+
+/// Encoding error.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// And I/O error.
+    Io(io::Error),
+    /// Tried to allocate an oversized vector.
+    OversizedVectorAllocation {
+        /// The capacity requested.
+        requested: usize,
+        /// The maximum capacity.
+        max: usize,
+    },
+    /// Checksum was invalid.
+    InvalidChecksum {
+        /// The expected checksum.
+        expected: [u8; 4],
+        /// The invalid checksum.
+        actual: [u8; 4],
+    },
+    /// VarInt was encoded in a non-minimal way.
+    NonMinimalVarInt,
+    /// Parsing error.
+    ParseFailed(&'static str),
+    /// Unsupported Segwit flag.
+    UnsupportedSegwitFlag(u8),
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            Io(ref e) => write_err!(f, "IO error"; e),
+            OversizedVectorAllocation {
+                requested: ref r,
+                max: ref m,
+            } => write!(
+                f,
+                "allocation of oversized vector: requested {}, maximum {}",
+                r, m
+            ),
+            InvalidChecksum {
+                expected: ref e,
+                actual: ref a,
+            } => write!(
+                f,
+                "invalid checksum: expected {:x}, actual {:x}",
+                e.as_hex(),
+                a.as_hex()
+            ),
+            NonMinimalVarInt => write!(f, "non-minimal varint"),
+            ParseFailed(ref s) => write!(f, "parse failed: {}", s),
+            UnsupportedSegwitFlag(ref swflag) => {
+                write!(f, "unsupported segwit version: {}", swflag)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match self {
+            Io(e) => Some(e),
+            OversizedVectorAllocation { .. }
+            | InvalidChecksum { .. }
+            | NonMinimalVarInt
+            | ParseFailed(_)
+            | UnsupportedSegwitFlag(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::Io(error)
+    }
+}
+
+/// Hex deserialization error.
+#[derive(Debug)]
+pub enum FromHexError {
+    /// Purported hex string had odd length.
+    OddLengthString(OddLengthStringError),
+    /// Decoding error.
+    Decode(DecodeError<InvalidCharError>),
+}
+
+impl fmt::Display for FromHexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FromHexError::*;
+
+        match *self {
+            OddLengthString(ref e) => {
+                write_err!(f, "odd length, failed to create bytes from hex"; e)
+            }
+            Decode(ref e) => write_err!(f, "decoding error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromHexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromHexError::*;
+
+        match *self {
+            OddLengthString(ref e) => Some(e),
+            Decode(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<OddLengthStringError> for FromHexError {
+    #[inline]
+    fn from(e: OddLengthStringError) -> Self {
+        Self::OddLengthString(e)
+    }
+}
+
+/// Encodes an object into a vector.
+pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
+    let mut encoder = Vec::new();
+    let len = data
+        .consensus_encode(&mut encoder)
+        .expect("in-memory writers don't error");
+    debug_assert_eq!(len, encoder.len());
+    encoder
+}
+
+/// Encodes an object into a hex-encoded string.
+pub fn serialize_hex<T: Encodable + ?Sized>(data: &T) -> String {
+    serialize(data).to_lower_hex_string()
+}
+
+/// Deserializes an object from a vector, will error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize<T: Decodable>(data: &[u8]) -> Result<T, Error> {
+    let (rv, consumed) = deserialize_partial(data)?;
+
+    // Fail if data are not consumed entirely.
+    if consumed == data.len() {
+        Ok(rv)
+    } else {
+        Err(Error::ParseFailed(
+            "data not consumed entirely when explicitly deserializing",
+        ))
+    }
+}
+
+/// Deserialize any decodable type from a hex string, will error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize_hex<T: Decodable>(hex: &str) -> Result<T, FromHexError> {
+    let iter = hex::HexSliceToBytesIter::new(hex)?;
+    let reader = IterReader::new(iter);
+    Ok(reader.decode().map_err(FromHexError::Decode)?)
+}
+
+/// Deserializes an object from a vector, but will not report an error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize_partial<T: Decodable>(data: &[u8]) -> Result<(T, usize), Error> {
+    let mut decoder = Cursor::new(data);
+    let rv = Decodable::consensus_decode_from_finite_reader(&mut decoder)?;
+    let consumed = decoder.position() as usize;
+
+    Ok((rv, consumed))
+}
+
+/// Extensions of `Write` to encode data as per Bitcoin consensus.
+pub trait WriteExt: Write {
+    /// Outputs a 64-bit unsigned integer.
+    fn emit_u64(&mut self, v: u64) -> Result<(), io::Error>;
+    /// Outputs a 32-bit unsigned integer.
+    fn emit_u32(&mut self, v: u32) -> Result<(), io::Error>;
+    /// Outputs a 16-bit unsigned integer.
+    fn emit_u16(&mut self, v: u16) -> Result<(), io::Error>;
+    /// Outputs an 8-bit unsigned integer.
+    fn emit_u8(&mut self, v: u8) -> Result<(), io::Error>;
+
+    /// Outputs a 64-bit signed integer.
+    fn emit_i64(&mut self, v: i64) -> Result<(), io::Error>;
+    /// Outputs a 32-bit signed integer.
+    fn emit_i32(&mut self, v: i32) -> Result<(), io::Error>;
+    /// Outputs a 16-bit signed integer.
+    fn emit_i16(&mut self, v: i16) -> Result<(), io::Error>;
+    /// Outputs an 8-bit signed integer.
+    fn emit_i8(&mut self, v: i8) -> Result<(), io::Error>;
+
+    /// Outputs a boolean.
+    fn emit_bool(&mut self, v: bool) -> Result<(), io::Error>;
+
+    /// Outputs a byte slice.
+    fn emit_slice(&mut self, v: &[u8]) -> Result<(), io::Error>;
+}
+
+/// Extensions of `Read` to decode data as per Bitcoin consensus.
+pub trait ReadExt: Read {
+    /// Reads a 64-bit unsigned integer.
+    fn read_u64(&mut self) -> Result<u64, Error>;
+    /// Reads a 32-bit unsigned integer.
+    fn read_u32(&mut self) -> Result<u32, Error>;
+    /// Reads a 16-bit unsigned integer.
+    fn read_u16(&mut self) -> Result<u16, Error>;
+    /// Reads an 8-bit unsigned integer.
+    fn read_u8(&mut self) -> Result<u8, Error>;
+
+    /// Reads a 64-bit signed integer.
+    fn read_i64(&mut self) -> Result<i64, Error>;
+    /// Reads a 32-bit signed integer.
+    fn read_i32(&mut self) -> Result<i32, Error>;
+    /// Reads a 16-bit signed integer.
+    fn read_i16(&mut self) -> Result<i16, Error>;
+    /// Reads an 8-bit signed integer.
+    fn read_i8(&mut self) -> Result<i8, Error>;
+
+    /// Reads a boolean.
+    fn read_bool(&mut self) -> Result<bool, Error>;
+
+    /// Reads a byte slice.
+    fn read_slice(&mut self, slice: &mut [u8]) -> Result<(), Error>;
+}
+
+macro_rules! encoder_fn {
+    ($name:ident, $val_type:ty) => {
+        #[inline]
+        fn $name(&mut self, v: $val_type) -> core::result::Result<(), io::Error> {
+            self.write_all(&v.to_le_bytes())
+        }
+    };
+}
+
+macro_rules! decoder_fn {
+    ($name:ident, $val_type:ty, $byte_len: expr) => {
+        #[inline]
+        fn $name(&mut self) -> core::result::Result<$val_type, Error> {
+            let mut val = [0; $byte_len];
+            self.read_exact(&mut val[..]).map_err(Error::Io)?;
+            Ok(<$val_type>::from_le_bytes(val))
+        }
+    };
+}
+
+impl<W: Write + ?Sized> WriteExt for W {
+    encoder_fn!(emit_u64, u64);
+    encoder_fn!(emit_u32, u32);
+    encoder_fn!(emit_u16, u16);
+    encoder_fn!(emit_i64, i64);
+    encoder_fn!(emit_i32, i32);
+    encoder_fn!(emit_i16, i16);
+
+    #[inline]
+    fn emit_i8(&mut self, v: i8) -> Result<(), io::Error> {
+        self.write_all(&[v as u8])
+    }
+    #[inline]
+    fn emit_u8(&mut self, v: u8) -> Result<(), io::Error> {
+        self.write_all(&[v])
+    }
+    #[inline]
+    fn emit_bool(&mut self, v: bool) -> Result<(), io::Error> {
+        self.write_all(&[v as u8])
+    }
+    #[inline]
+    fn emit_slice(&mut self, v: &[u8]) -> Result<(), io::Error> {
+        self.write_all(v)
+    }
+}
+
+impl<R: Read + ?Sized> ReadExt for R {
+    decoder_fn!(read_u64, u64, 8);
+    decoder_fn!(read_u32, u32, 4);
+    decoder_fn!(read_u16, u16, 2);
+    decoder_fn!(read_i64, i64, 8);
+    decoder_fn!(read_i32, i32, 4);
+    decoder_fn!(read_i16, i16, 2);
+
+    #[inline]
+    fn read_u8(&mut self) -> Result<u8, Error> {
+        let mut slice = [0u8; 1];
+        self.read_exact(&mut slice)?;
+        Ok(slice[0])
+    }
+    #[inline]
+    fn read_i8(&mut self) -> Result<i8, Error> {
+        let mut slice = [0u8; 1];
+        self.read_exact(&mut slice)?;
+        Ok(slice[0] as i8)
+    }
+    #[inline]
+    fn read_bool(&mut self) -> Result<bool, Error> {
+        ReadExt::read_i8(self).map(|bit| bit != 0)
+    }
+    #[inline]
+    fn read_slice(&mut self, slice: &mut [u8]) -> Result<(), Error> {
+        self.read_exact(slice).map_err(Error::Io)
+    }
+}
+
+/// Maximum size, in bytes, of a vector we are allowed to decode.
+pub const MAX_VEC_SIZE: usize = 4_000_000;
+
+/// Data which can be encoded in a consensus-consistent way.
+pub trait Encodable {
+    /// Encodes an object with a well-defined format.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written on success. The only errors returned are errors propagated from
+    /// the writer.
+    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error>;
+}
+
+/// Data which can be encoded in a consensus-consistent way.
+pub trait Decodable: Sized {
+    /// Decode `Self` from a size-limited reader.
+    ///
+    /// Like `consensus_decode` but relies on the reader being limited in the amount of data it
+    /// returns, e.g. by being wrapped in [`std::io::Take`].
+    ///
+    /// Failing to abide to this requirement might lead to memory exhaustion caused by malicious
+    /// inputs.
+    ///
+    /// Users should default to `consensus_decode`, but when data to be decoded is already in a byte
+    /// vector of a limited size, calling this function directly might be marginally faster (due to
+    /// avoiding extra checks).
+    ///
+    /// ### Rules for trait implementations
+    ///
+    /// * Simple types that that have a fixed size (own and member fields), don't have to overwrite
+    ///   this method, or be concern with it.
+    /// * Types that deserialize using externally provided length should implement it:
+    ///   * Make `consensus_decode` forward to `consensus_decode_bytes_from_finite_reader` with the
+    ///     reader wrapped by `Take`. Failure to do so, without other forms of memory exhaustion
+    ///     protection might lead to resource exhaustion vulnerability.
+    ///   * Put a max cap on things like `Vec::with_capacity` to avoid oversized allocations, and
+    ///     rely on the reader running out of data, and collections reallocating on a legitimately
+    ///     oversized input data, instead of trying to enforce arbitrary length limits.
+    /// * Types that contain other types that implement custom
+    ///   `consensus_decode_from_finite_reader`, should also implement it applying same rules, and
+    ///   in addition make sure to call `consensus_decode_from_finite_reader` on all members, to
+    ///   avoid creating redundant `Take` wrappers. Failure to do so might result only in a tiny
+    ///   performance hit.
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        reader: &mut R,
+    ) -> Result<Self, Error> {
+        // This method is always strictly less general than, `consensus_decode`, so it's safe and
+        // make sense to default to just calling it. This way most types, that don't care about
+        // protecting against resource exhaustion due to malicious input, can just ignore it.
+        Self::consensus_decode(reader)
+    }
+
+    /// Decode an object with a well-defined format.
+    ///
+    /// This is the method that should be implemented for a typical, fixed sized type
+    /// implementing this trait. Default implementation is wrapping the reader
+    /// in [`crate::io::Take`] to limit the input size to [`MAX_VEC_SIZE`], and forwards the call to
+    /// [`Self::consensus_decode_from_finite_reader`], which is convenient
+    /// for types that override [`Self::consensus_decode_from_finite_reader`]
+    /// instead.
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
+        Self::consensus_decode_from_finite_reader(&mut reader.take(MAX_VEC_SIZE as u64))
+    }
+}
+
+/// A variable-length unsigned integer.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+pub struct VarInt(pub u64);
+
+/// Data and a 4-byte checksum.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct CheckedData {
+    data: Vec<u8>,
+    checksum: [u8; 4],
+}
+
+impl CheckedData {
+    /// Creates a new `CheckedData` computing the checksum of given data.
+    pub fn new(data: Vec<u8>) -> Self {
+        let checksum = sha2_checksum(&data);
+        Self { data, checksum }
+    }
+
+    /// Returns a reference to the raw data without the checksum.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Returns the raw data without the checksum.
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
+    }
+
+    /// Returns the checksum of the data.
+    pub fn checksum(&self) -> [u8; 4] {
+        self.checksum
+    }
+}
+
+// Primitive types
+macro_rules! impl_int_encodable {
+    ($ty:ident, $meth_dec:ident, $meth_enc:ident) => {
+        impl Decodable for $ty {
+            #[inline]
+            fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> core::result::Result<Self, Error> {
+                ReadExt::$meth_dec(r)
+            }
+        }
+        impl Encodable for $ty {
+            #[inline]
+            fn consensus_encode<W: Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, io::Error> {
+                w.$meth_enc(*self)?;
+                Ok(mem::size_of::<$ty>())
+            }
+        }
+    };
+}
+
+impl_int_encodable!(u8, read_u8, emit_u8);
+impl_int_encodable!(u16, read_u16, emit_u16);
+impl_int_encodable!(u32, read_u32, emit_u32);
+impl_int_encodable!(u64, read_u64, emit_u64);
+impl_int_encodable!(i8, read_i8, emit_i8);
+impl_int_encodable!(i16, read_i16, emit_i16);
+impl_int_encodable!(i32, read_i32, emit_i32);
+impl_int_encodable!(i64, read_i64, emit_i64);
+
+#[allow(clippy::len_without_is_empty)] // VarInt has on concept of 'is_empty'.
+impl VarInt {
+    /// Returns the number of bytes this varint contributes to a transaction size.
+    ///
+    /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1), and 9 otherwise.
+    #[inline]
+    pub const fn size(&self) -> usize {
+        match self.0 {
+            0..=0xFC => 1,
+            0xFD..=0xFFFF => 3,
+            0x10000..=0xFFFFFFFF => 5,
+            _ => 9,
+        }
+    }
+}
+
+/// Implements `From<T> for VarInt`.
+///
+/// `VarInt`s are consensus encoded as `u64`s so we store them as such. Casting from any integer size smaller than or equal to `u64` is always safe and the cast value is correctly handled by `consensus_encode`.
+macro_rules! impl_var_int_from {
+    ($($ty:tt),*) => {
+        $(
+            /// Creates a `VarInt` from a `usize` by casting the to a `u64`.
+            impl From<$ty> for VarInt {
+                fn from(x: $ty) -> Self { VarInt(x as u64) }
+            }
+        )*
+    }
+}
+impl_var_int_from!(u8, u16, u32, u64, usize);
+
+impl Encodable for VarInt {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        match self.0 {
+            0..=0xFC => {
+                (self.0 as u8).consensus_encode(w)?;
+                Ok(1)
+            }
+            0xFD..=0xFFFF => {
+                w.emit_u8(0xFD)?;
+                (self.0 as u16).consensus_encode(w)?;
+                Ok(3)
+            }
+            0x10000..=0xFFFFFFFF => {
+                w.emit_u8(0xFE)?;
+                (self.0 as u32).consensus_encode(w)?;
+                Ok(5)
+            }
+            _ => {
+                w.emit_u8(0xFF)?;
+                self.0.consensus_encode(w)?;
+                Ok(9)
+            }
+        }
+    }
+}
+
+impl Decodable for VarInt {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let n = ReadExt::read_u8(r)?;
+        match n {
+            0xFF => {
+                let x = ReadExt::read_u64(r)?;
+                if x < 0x100000000 {
+                    Err(self::Error::NonMinimalVarInt)
+                } else {
+                    Ok(VarInt::from(x))
+                }
+            }
+            0xFE => {
+                let x = ReadExt::read_u32(r)?;
+                if x < 0x10000 {
+                    Err(self::Error::NonMinimalVarInt)
+                } else {
+                    Ok(VarInt::from(x))
+                }
+            }
+            0xFD => {
+                let x = ReadExt::read_u16(r)?;
+                if x < 0xFD {
+                    Err(self::Error::NonMinimalVarInt)
+                } else {
+                    Ok(VarInt::from(x))
+                }
+            }
+            n => Ok(VarInt::from(n)),
+        }
+    }
+}
+
+impl Encodable for bool {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        w.emit_bool(*self)?;
+        Ok(1)
+    }
+}
+
+impl Decodable for bool {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<bool, Error> {
+        ReadExt::read_bool(r)
+    }
+}
+
+impl Encodable for String {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let b = self.as_bytes();
+        let vi_len = VarInt(b.len() as u64).consensus_encode(w)?;
+        w.emit_slice(b)?;
+        Ok(vi_len + b.len())
+    }
+}
+
+impl Decodable for String {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<String, Error> {
+        String::from_utf8(Decodable::consensus_decode(r)?)
+            .map_err(|_| self::Error::ParseFailed("String was not valid UTF8"))
+    }
+}
+
+impl Encodable for Cow<'static, str> {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let b = self.as_bytes();
+        let vi_len = VarInt(b.len() as u64).consensus_encode(w)?;
+        w.emit_slice(b)?;
+        Ok(vi_len + b.len())
+    }
+}
+
+impl Decodable for Cow<'static, str> {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Cow<'static, str>, Error> {
+        String::from_utf8(Decodable::consensus_decode(r)?)
+            .map_err(|_| self::Error::ParseFailed("String was not valid UTF8"))
+            .map(Cow::Owned)
+    }
+}
+
+macro_rules! impl_array {
+    ( $size:literal ) => {
+        impl Encodable for [u8; $size] {
+            #[inline]
+            fn consensus_encode<W: WriteExt + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, io::Error> {
+                w.emit_slice(&self[..])?;
+                Ok(self.len())
+            }
+        }
+
+        impl Decodable for [u8; $size] {
+            #[inline]
+            fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> core::result::Result<Self, Error> {
+                let mut ret = [0; $size];
+                r.read_slice(&mut ret)?;
+                Ok(ret)
+            }
+        }
+    };
+}
+
+impl_array!(2);
+impl_array!(4);
+impl_array!(6);
+impl_array!(8);
+impl_array!(10);
+impl_array!(12);
+impl_array!(16);
+impl_array!(32);
+impl_array!(33);
+
+impl Decodable for [u16; 8] {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let mut res = [0; 8];
+        for item in &mut res {
+            *item = Decodable::consensus_decode(r)?;
+        }
+        Ok(res)
+    }
+}
+
+impl Encodable for [u16; 8] {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        for c in self.iter() {
+            c.consensus_encode(w)?;
+        }
+        Ok(16)
+    }
+}
+
+macro_rules! impl_vec {
+    ($type: ty) => {
+        impl Encodable for Vec<$type> {
+            #[inline]
+            fn consensus_encode<W: Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, io::Error> {
+                let mut len = 0;
+                len += VarInt(self.len() as u64).consensus_encode(w)?;
+                for c in self.iter() {
+                    len += c.consensus_encode(w)?;
+                }
+                Ok(len)
+            }
+        }
+
+        impl Decodable for Vec<$type> {
+            #[inline]
+            fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<Self, Error> {
+                let len = VarInt::consensus_decode_from_finite_reader(r)?.0;
+                // Do not allocate upfront more items than if the sequence of type
+                // occupied roughly quarter a block. This should never be the case
+                // for normal data, but even if that's not true - `push` will just
+                // reallocate.
+                // Note: OOM protection relies on reader eventually running out of
+                // data to feed us.
+                let max_capacity = MAX_VEC_SIZE / 4 / mem::size_of::<$type>();
+                let mut ret = Vec::with_capacity(core::cmp::min(len as usize, max_capacity));
+                for _ in 0..len {
+                    ret.push(Decodable::consensus_decode_from_finite_reader(r)?);
+                }
+                Ok(ret)
+            }
+        }
+    };
+}
+impl_vec!(BlockHash);
+impl_vec!(block::Header);
+impl_vec!(FilterHash);
+impl_vec!(FilterHeader);
+impl_vec!(TxMerkleNode);
+impl_vec!(Transaction);
+impl_vec!(TxOut);
+impl_vec!(TxIn);
+impl_vec!(Vec<u8>);
+impl_vec!(u64);
+impl_vec!(TapLeafHash);
+impl_vec!(VarInt);
+impl_vec!(ShortId);
+impl_vec!(PrefilledTransaction);
+
+#[cfg(feature = "std")]
+impl_vec!(Inventory);
+#[cfg(feature = "std")]
+impl_vec!((u32, Address));
+#[cfg(feature = "std")]
+impl_vec!(AddrV2Message);
+
+pub(crate) fn consensus_encode_with_size<W: Write + ?Sized>(
+    data: &[u8],
+    w: &mut W,
+) -> Result<usize, io::Error> {
+    let vi_len = VarInt(data.len() as u64).consensus_encode(w)?;
+    w.emit_slice(data)?;
+    Ok(vi_len + data.len())
+}
+
+struct ReadBytesFromFiniteReaderOpts {
+    len: usize,
+    chunk_size: usize,
+}
+
+/// Read `opts.len` bytes from reader, where `opts.len` could potentially be malicious.
+///
+/// This function relies on reader being bound in amount of data
+/// it returns for OOM protection. See [`Decodable::consensus_decode_from_finite_reader`].
+#[inline]
+fn read_bytes_from_finite_reader<D: Read + ?Sized>(
+    d: &mut D,
+    mut opts: ReadBytesFromFiniteReaderOpts,
+) -> Result<Vec<u8>, Error> {
+    let mut ret = vec![];
+
+    assert_ne!(opts.chunk_size, 0);
+
+    while opts.len > 0 {
+        let chunk_start = ret.len();
+        let chunk_size = core::cmp::min(opts.len, opts.chunk_size);
+        let chunk_end = chunk_start + chunk_size;
+        ret.resize(chunk_end, 0u8);
+        d.read_slice(&mut ret[chunk_start..chunk_end])?;
+        opts.len -= chunk_size;
+    }
+
+    Ok(ret)
+}
+
+impl Encodable for Vec<u8> {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        consensus_encode_with_size(self, w)
+    }
+}
+
+impl Decodable for Vec<u8> {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let len = VarInt::consensus_decode(r)?.0 as usize;
+        // most real-world vec of bytes data, wouldn't be larger than 128KiB
+        let opts = ReadBytesFromFiniteReaderOpts {
+            len,
+            chunk_size: 128 * 1024,
+        };
+        read_bytes_from_finite_reader(r, opts)
+    }
+}
+
+impl Encodable for Box<[u8]> {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        consensus_encode_with_size(self, w)
+    }
+}
+
+impl Decodable for Box<[u8]> {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        <Vec<u8>>::consensus_decode_from_finite_reader(r).map(From::from)
+    }
+}
+
+/// Does a double-SHA256 on `data` and returns the first 4 bytes.
+fn sha2_checksum(data: &[u8]) -> [u8; 4] {
+    let checksum = <sha256d::Hash as Hash>::hash(data);
+    [checksum[0], checksum[1], checksum[2], checksum[3]]
+}
+
+impl Encodable for CheckedData {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        u32::try_from(self.data.len())
+            .expect("network message use u32 as length")
+            .consensus_encode(w)?;
+        self.checksum().consensus_encode(w)?;
+        w.emit_slice(&self.data)?;
+        Ok(8 + self.data.len())
+    }
+}
+
+impl Decodable for CheckedData {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let len = u32::consensus_decode_from_finite_reader(r)? as usize;
+
+        let checksum = <[u8; 4]>::consensus_decode_from_finite_reader(r)?;
+        let opts = ReadBytesFromFiniteReaderOpts {
+            len,
+            chunk_size: MAX_VEC_SIZE,
+        };
+        let data = read_bytes_from_finite_reader(r, opts)?;
+        let expected_checksum = sha2_checksum(&data);
+        if expected_checksum != checksum {
+            Err(self::Error::InvalidChecksum {
+                expected: expected_checksum,
+                actual: checksum,
+            })
+        } else {
+            Ok(CheckedData { data, checksum })
+        }
+    }
+}
+
+impl<'a, T: Encodable> Encodable for &'a T {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        (**self).consensus_encode(w)
+    }
+}
+
+impl<'a, T: Encodable> Encodable for &'a mut T {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        (**self).consensus_encode(w)
+    }
+}
+
+impl<T: Encodable> Encodable for rc::Rc<T> {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        (**self).consensus_encode(w)
+    }
+}
+
+/// Note: This will fail to compile on old Rust for targets that don't support atomics
+#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+impl<T: Encodable> Encodable for sync::Arc<T> {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        (**self).consensus_encode(w)
+    }
+}
+
+macro_rules! tuple_encode {
+    ($($x:ident),*) => {
+        impl <$($x: Encodable),*> Encodable for ($($x),*) {
+            #[inline]
+            #[allow(non_snake_case)]
+            fn consensus_encode<W: Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, io::Error> {
+                let &($(ref $x),*) = self;
+                let mut len = 0;
+                $(len += $x.consensus_encode(w)?;)*
+                Ok(len)
+            }
+        }
+
+        impl<$($x: Decodable),*> Decodable for ($($x),*) {
+            #[inline]
+            #[allow(non_snake_case)]
+            fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> core::result::Result<Self, Error> {
+                Ok(($({let $x = Decodable::consensus_decode(r)?; $x }),*))
+            }
+        }
+    };
+}
+
+tuple_encode!(T0, T1);
+tuple_encode!(T0, T1, T2);
+tuple_encode!(T0, T1, T2, T3);
+tuple_encode!(T0, T1, T2, T3, T4);
+tuple_encode!(T0, T1, T2, T3, T4, T5);
+tuple_encode!(T0, T1, T2, T3, T4, T5, T6);
+tuple_encode!(T0, T1, T2, T3, T4, T5, T6, T7);
+
+impl Encodable for sha256d::Hash {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.as_byte_array().consensus_encode(w)
+    }
+}
+
+impl Decodable for sha256d::Hash {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        Ok(Self::from_byte_array(
+            <<Self as Hash>::Bytes>::consensus_decode(r)?,
+        ))
+    }
+}
+
+impl Encodable for sha256::Hash {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.as_byte_array().consensus_encode(w)
+    }
+}
+
+impl Decodable for sha256::Hash {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        Ok(Self::from_byte_array(
+            <<Self as Hash>::Bytes>::consensus_decode(r)?,
+        ))
+    }
+}
+
+impl Encodable for TapLeafHash {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.as_byte_array().consensus_encode(w)
+    }
+}
+
+impl Decodable for TapLeafHash {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        Ok(Self::from_byte_array(
+            <<Self as Hash>::Bytes>::consensus_decode(r)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem::discriminant;
+
+    use super::*;
+
+    #[test]
+    fn serialize_int_test() {
+        // bool
+        assert_eq!(serialize(&false), vec![0u8]);
+        assert_eq!(serialize(&true), vec![1u8]);
+        // u8
+        assert_eq!(serialize(&1u8), vec![1u8]);
+        assert_eq!(serialize(&0u8), vec![0u8]);
+        assert_eq!(serialize(&255u8), vec![255u8]);
+        // u16
+        assert_eq!(serialize(&1u16), vec![1u8, 0]);
+        assert_eq!(serialize(&256u16), vec![0u8, 1]);
+        assert_eq!(serialize(&5000u16), vec![136u8, 19]);
+        // u32
+        assert_eq!(serialize(&1u32), vec![1u8, 0, 0, 0]);
+        assert_eq!(serialize(&256u32), vec![0u8, 1, 0, 0]);
+        assert_eq!(serialize(&5000u32), vec![136u8, 19, 0, 0]);
+        assert_eq!(serialize(&500000u32), vec![32u8, 161, 7, 0]);
+        assert_eq!(serialize(&168430090u32), vec![10u8, 10, 10, 10]);
+        // i32
+        assert_eq!(serialize(&-1i32), vec![255u8, 255, 255, 255]);
+        assert_eq!(serialize(&-256i32), vec![0u8, 255, 255, 255]);
+        assert_eq!(serialize(&-5000i32), vec![120u8, 236, 255, 255]);
+        assert_eq!(serialize(&-500000i32), vec![224u8, 94, 248, 255]);
+        assert_eq!(serialize(&-168430090i32), vec![246u8, 245, 245, 245]);
+        assert_eq!(serialize(&1i32), vec![1u8, 0, 0, 0]);
+        assert_eq!(serialize(&256i32), vec![0u8, 1, 0, 0]);
+        assert_eq!(serialize(&5000i32), vec![136u8, 19, 0, 0]);
+        assert_eq!(serialize(&500000i32), vec![32u8, 161, 7, 0]);
+        assert_eq!(serialize(&168430090i32), vec![10u8, 10, 10, 10]);
+        // u64
+        assert_eq!(serialize(&1u64), vec![1u8, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(serialize(&256u64), vec![0u8, 1, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(serialize(&5000u64), vec![136u8, 19, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(serialize(&500000u64), vec![32u8, 161, 7, 0, 0, 0, 0, 0]);
+        assert_eq!(
+            serialize(&723401728380766730u64),
+            vec![10u8, 10, 10, 10, 10, 10, 10, 10]
+        );
+        // i64
+        assert_eq!(
+            serialize(&-1i64),
+            vec![255u8, 255, 255, 255, 255, 255, 255, 255]
+        );
+        assert_eq!(
+            serialize(&-256i64),
+            vec![0u8, 255, 255, 255, 255, 255, 255, 255]
+        );
+        assert_eq!(
+            serialize(&-5000i64),
+            vec![120u8, 236, 255, 255, 255, 255, 255, 255]
+        );
+        assert_eq!(
+            serialize(&-500000i64),
+            vec![224u8, 94, 248, 255, 255, 255, 255, 255]
+        );
+        assert_eq!(
+            serialize(&-723401728380766730i64),
+            vec![246u8, 245, 245, 245, 245, 245, 245, 245]
+        );
+        assert_eq!(serialize(&1i64), vec![1u8, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(serialize(&256i64), vec![0u8, 1, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(serialize(&5000i64), vec![136u8, 19, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(serialize(&500000i64), vec![32u8, 161, 7, 0, 0, 0, 0, 0]);
+        assert_eq!(
+            serialize(&723401728380766730i64),
+            vec![10u8, 10, 10, 10, 10, 10, 10, 10]
+        );
+    }
+
+    #[test]
+    fn serialize_varint_test() {
+        assert_eq!(serialize(&VarInt(10)), vec![10u8]);
+        assert_eq!(serialize(&VarInt(0xFC)), vec![0xFCu8]);
+        assert_eq!(serialize(&VarInt(0xFD)), vec![0xFDu8, 0xFD, 0]);
+        assert_eq!(serialize(&VarInt(0xFFF)), vec![0xFDu8, 0xFF, 0xF]);
+        assert_eq!(
+            serialize(&VarInt(0xF0F0F0F)),
+            vec![0xFEu8, 0xF, 0xF, 0xF, 0xF]
+        );
+        assert_eq!(
+            serialize(&VarInt(0xF0F0F0F0F0E0)),
+            vec![0xFFu8, 0xE0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0, 0]
+        );
+        assert_eq!(
+            test_varint_encode(0xFF, &0x100000000_u64.to_le_bytes()).unwrap(),
+            VarInt(0x100000000)
+        );
+        assert_eq!(
+            test_varint_encode(0xFE, &0x10000_u64.to_le_bytes()).unwrap(),
+            VarInt(0x10000)
+        );
+        assert_eq!(
+            test_varint_encode(0xFD, &0xFD_u64.to_le_bytes()).unwrap(),
+            VarInt(0xFD)
+        );
+
+        // Test that length calc is working correctly
+        test_varint_len(VarInt(0), 1);
+        test_varint_len(VarInt(0xFC), 1);
+        test_varint_len(VarInt(0xFD), 3);
+        test_varint_len(VarInt(0xFFFF), 3);
+        test_varint_len(VarInt(0x10000), 5);
+        test_varint_len(VarInt(0xFFFFFFFF), 5);
+        test_varint_len(VarInt(0xFFFFFFFF + 1), 9);
+        test_varint_len(VarInt(u64::MAX), 9);
+    }
+
+    fn test_varint_len(varint: VarInt, expected: usize) {
+        let mut encoder = vec![];
+        assert_eq!(varint.consensus_encode(&mut encoder).unwrap(), expected);
+        assert_eq!(varint.size(), expected);
+    }
+
+    fn test_varint_encode(n: u8, x: &[u8]) -> Result<VarInt, Error> {
+        let mut input = [0u8; 9];
+        input[0] = n;
+        input[1..x.len() + 1].copy_from_slice(x);
+        deserialize_partial::<VarInt>(&input).map(|t| t.0)
+    }
+
+    #[test]
+    fn deserialize_nonminimal_vec() {
+        // Check the edges for variant int
+        assert_eq!(
+            discriminant(
+                &test_varint_encode(0xFF, &(0x100000000_u64 - 1).to_le_bytes()).unwrap_err()
+            ),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(&test_varint_encode(0xFE, &(0x10000_u64 - 1).to_le_bytes()).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(&test_varint_encode(0xFD, &(0xFD_u64 - 1).to_le_bytes()).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+
+        assert_eq!(
+            discriminant(&deserialize::<Vec<u8>>(&[0xfd, 0x00, 0x00]).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(&deserialize::<Vec<u8>>(&[0xfd, 0xfc, 0x00]).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(&deserialize::<Vec<u8>>(&[0xfd, 0xfc, 0x00]).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(&deserialize::<Vec<u8>>(&[0xfe, 0xff, 0x00, 0x00, 0x00]).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(&deserialize::<Vec<u8>>(&[0xfe, 0xff, 0xff, 0x00, 0x00]).unwrap_err()),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(
+                &deserialize::<Vec<u8>>(&[0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+                    .unwrap_err()
+            ),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+        assert_eq!(
+            discriminant(
+                &deserialize::<Vec<u8>>(&[0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00])
+                    .unwrap_err()
+            ),
+            discriminant(&Error::NonMinimalVarInt)
+        );
+
+        let mut vec_256 = vec![0; 259];
+        vec_256[0] = 0xfd;
+        vec_256[1] = 0x00;
+        vec_256[2] = 0x01;
+        assert!(deserialize::<Vec<u8>>(&vec_256).is_ok());
+
+        let mut vec_253 = vec![0; 256];
+        vec_253[0] = 0xfd;
+        vec_253[1] = 0xfd;
+        vec_253[2] = 0x00;
+        assert!(deserialize::<Vec<u8>>(&vec_253).is_ok());
+    }
+
+    #[test]
+    fn serialize_checkeddata_test() {
+        let cd = CheckedData::new(vec![1u8, 2, 3, 4, 5]);
+        assert_eq!(
+            serialize(&cd),
+            vec![5, 0, 0, 0, 162, 107, 175, 90, 1, 2, 3, 4, 5]
+        );
+    }
+
+    #[test]
+    fn serialize_vector_test() {
+        assert_eq!(serialize(&vec![1u8, 2, 3]), vec![3u8, 1, 2, 3]);
+    }
+
+    #[test]
+    fn serialize_strbuf_test() {
+        assert_eq!(
+            serialize(&"Andrew".to_string()),
+            vec![6u8, 0x41, 0x6e, 0x64, 0x72, 0x65, 0x77]
+        );
+    }
+
+    #[test]
+    fn deserialize_int_test() {
+        // bool
+        assert!((deserialize(&[58u8, 0]) as Result<bool, _>).is_err());
+        assert_eq!(deserialize(&[58u8]).ok(), Some(true));
+        assert_eq!(deserialize(&[1u8]).ok(), Some(true));
+        assert_eq!(deserialize(&[0u8]).ok(), Some(false));
+        assert!((deserialize(&[0u8, 1]) as Result<bool, _>).is_err());
+
+        // u8
+        assert_eq!(deserialize(&[58u8]).ok(), Some(58u8));
+
+        // u16
+        assert_eq!(deserialize(&[0x01u8, 0x02]).ok(), Some(0x0201u16));
+        assert_eq!(deserialize(&[0xABu8, 0xCD]).ok(), Some(0xCDABu16));
+        assert_eq!(deserialize(&[0xA0u8, 0x0D]).ok(), Some(0xDA0u16));
+        let failure16: Result<u16, _> = deserialize(&[1u8]);
+        assert!(failure16.is_err());
+
+        // i16
+        assert_eq!(deserialize(&[0x32_u8, 0xF4]).ok(), Some(-0x0bce_i16));
+        assert_eq!(deserialize(&[0xFF_u8, 0xFE]).ok(), Some(-0x0101_i16));
+        assert_eq!(deserialize(&[0x00_u8, 0x00]).ok(), Some(-0_i16));
+        assert_eq!(deserialize(&[0xFF_u8, 0xFA]).ok(), Some(-0x0501_i16));
+
+        // u32
+        assert_eq!(deserialize(&[0xABu8, 0xCD, 0, 0]).ok(), Some(0xCDABu32));
+        assert_eq!(
+            deserialize(&[0xA0u8, 0x0D, 0xAB, 0xCD]).ok(),
+            Some(0xCDAB0DA0u32)
+        );
+
+        let failure32: Result<u32, _> = deserialize(&[1u8, 2, 3]);
+        assert!(failure32.is_err());
+
+        // i32
+        assert_eq!(deserialize(&[0xABu8, 0xCD, 0, 0]).ok(), Some(0xCDABi32));
+        assert_eq!(
+            deserialize(&[0xA0u8, 0x0D, 0xAB, 0x2D]).ok(),
+            Some(0x2DAB0DA0i32)
+        );
+
+        assert_eq!(deserialize(&[0, 0, 0, 0]).ok(), Some(-0_i32));
+        assert_eq!(deserialize(&[0, 0, 0, 0]).ok(), Some(0_i32));
+
+        assert_eq!(deserialize(&[0xFF, 0xFF, 0xFF, 0xFF]).ok(), Some(-1_i32));
+        assert_eq!(deserialize(&[0xFE, 0xFF, 0xFF, 0xFF]).ok(), Some(-2_i32));
+        assert_eq!(deserialize(&[0x01, 0xFF, 0xFF, 0xFF]).ok(), Some(-255_i32));
+        assert_eq!(deserialize(&[0x02, 0xFF, 0xFF, 0xFF]).ok(), Some(-254_i32));
+
+        let failurei32: Result<i32, _> = deserialize(&[1u8, 2, 3]);
+        assert!(failurei32.is_err());
+
+        // u64
+        assert_eq!(
+            deserialize(&[0xABu8, 0xCD, 0, 0, 0, 0, 0, 0]).ok(),
+            Some(0xCDABu64)
+        );
+        assert_eq!(
+            deserialize(&[0xA0u8, 0x0D, 0xAB, 0xCD, 0x99, 0, 0, 0x99]).ok(),
+            Some(0x99000099CDAB0DA0u64)
+        );
+        let failure64: Result<u64, _> = deserialize(&[1u8, 2, 3, 4, 5, 6, 7]);
+        assert!(failure64.is_err());
+
+        // i64
+        assert_eq!(
+            deserialize(&[0xABu8, 0xCD, 0, 0, 0, 0, 0, 0]).ok(),
+            Some(0xCDABi64)
+        );
+        assert_eq!(
+            deserialize(&[0xA0u8, 0x0D, 0xAB, 0xCD, 0x99, 0, 0, 0x99]).ok(),
+            Some(-0x66ffff663254f260i64)
+        );
+        assert_eq!(
+            deserialize(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).ok(),
+            Some(-1_i64)
+        );
+        assert_eq!(
+            deserialize(&[0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).ok(),
+            Some(-2_i64)
+        );
+        assert_eq!(
+            deserialize(&[0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).ok(),
+            Some(-255_i64)
+        );
+        assert_eq!(
+            deserialize(&[0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]).ok(),
+            Some(-254_i64)
+        );
+
+        let failurei64: Result<i64, _> = deserialize(&[1u8, 2, 3, 4, 5, 6, 7]);
+        assert!(failurei64.is_err());
+    }
+
+    #[test]
+    fn deserialize_vec_test() {
+        assert_eq!(deserialize(&[3u8, 2, 3, 4]).ok(), Some(vec![2u8, 3, 4]));
+        assert!((deserialize(&[4u8, 2, 3, 4, 5, 6]) as Result<Vec<u8>, _>).is_err());
+        // found by cargo fuzz
+        assert!(deserialize::<Vec<u64>>(&[
+            0xff, 0xff, 0xff, 0xff, 0x6b, 0x6b, 0x6b, 0x6b, 0x6b, 0x6b, 0x6b, 0x6b, 0x6b, 0x6b,
+            0x6b, 0x6b, 0xa, 0xa, 0x3a
+        ])
+        .is_err());
+
+        let rand_io_err = Error::Io(io::Error::new(io::ErrorKind::Other, ""));
+
+        // Check serialization that `if len > MAX_VEC_SIZE {return err}` isn't inclusive,
+        // by making sure it fails with IO Error and not an `OversizedVectorAllocation` Error.
+        let err =
+            deserialize::<CheckedData>(&serialize(&(super::MAX_VEC_SIZE as u32))).unwrap_err();
+        assert_eq!(discriminant(&err), discriminant(&rand_io_err));
+
+        test_len_is_max_vec::<u8>();
+        test_len_is_max_vec::<BlockHash>();
+        test_len_is_max_vec::<FilterHash>();
+        test_len_is_max_vec::<TxMerkleNode>();
+        test_len_is_max_vec::<Transaction>();
+        test_len_is_max_vec::<TxOut>();
+        test_len_is_max_vec::<TxIn>();
+        test_len_is_max_vec::<Vec<u8>>();
+        test_len_is_max_vec::<u64>();
+        #[cfg(feature = "std")]
+        test_len_is_max_vec::<(u32, Address)>();
+        #[cfg(feature = "std")]
+        test_len_is_max_vec::<Inventory>();
+    }
+
+    fn test_len_is_max_vec<T>()
+    where
+        Vec<T>: Decodable,
+        T: fmt::Debug,
+    {
+        let rand_io_err = Error::Io(io::Error::new(io::ErrorKind::Other, ""));
+        let varint = VarInt((super::MAX_VEC_SIZE / mem::size_of::<T>()) as u64);
+        let err = deserialize::<Vec<T>>(&serialize(&varint)).unwrap_err();
+        assert_eq!(discriminant(&err), discriminant(&rand_io_err));
+    }
+
+    #[test]
+    fn deserialize_strbuf_test() {
+        assert_eq!(
+            deserialize(&[6u8, 0x41, 0x6e, 0x64, 0x72, 0x65, 0x77]).ok(),
+            Some("Andrew".to_string())
+        );
+        assert_eq!(
+            deserialize(&[6u8, 0x41, 0x6e, 0x64, 0x72, 0x65, 0x77]).ok(),
+            Some(Cow::Borrowed("Andrew"))
+        );
+    }
+
+    #[test]
+    fn deserialize_checkeddata_test() {
+        let cd: Result<CheckedData, _> =
+            deserialize(&[5u8, 0, 0, 0, 162, 107, 175, 90, 1, 2, 3, 4, 5]);
+        assert_eq!(cd.ok(), Some(CheckedData::new(vec![1u8, 2, 3, 4, 5])));
+    }
+
+    #[test]
+    fn limit_read_test() {
+        let witness = vec![vec![0u8; 3_999_999]; 2];
+        let ser = serialize(&witness);
+        let mut reader = io::Cursor::new(ser);
+        let err = Vec::<Vec<u8>>::consensus_decode(&mut reader);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "rand-std")]
+    fn serialization_round_trips() {
+        use secp256k1::rand::{thread_rng, Rng};
+
+        macro_rules! round_trip {
+            ($($val_type:ty),*) => {
+                $(
+                    let r: $val_type = thread_rng().gen();
+                    assert_eq!(deserialize::<$val_type>(&serialize(&r)).unwrap(), r);
+                )*
+            };
+        }
+        macro_rules! round_trip_bytes {
+            ($(($val_type:ty, $data:expr)),*) => {
+                $(
+                    thread_rng().fill(&mut $data[..]);
+                    assert_eq!(deserialize::<$val_type>(&serialize(&$data)).unwrap()[..], $data[..]);
+                )*
+            };
+        }
+
+        let mut data = Vec::with_capacity(256);
+        let mut data64 = Vec::with_capacity(256);
+        for _ in 0..10 {
+            round_trip! {bool, i8, u8, i16, u16, i32, u32, i64, u64,
+            (bool, i8, u16, i32), (u64, i64, u32, i32, u16, i16), (i8, u8, i16, u16, i32, u32, i64, u64),
+            [u8; 2], [u8; 4], [u8; 8], [u8; 12], [u8; 16], [u8; 32]};
+
+            data.clear();
+            data64.clear();
+            let len = thread_rng().gen_range(1..256);
+            data.resize(len, 0u8);
+            data64.resize(len, 0u64);
+            let mut arr33 = [0u8; 33];
+            let mut arr16 = [0u16; 8];
+            round_trip_bytes! {(Vec<u8>, data), ([u8; 33], arr33), ([u16; 8], arr16), (Vec<u64>, data64)};
+        }
+    }
+
+    #[test]
+    fn test_read_bytes_from_finite_reader() {
+        let data: Vec<u8> = (0..10).collect();
+
+        for chunk_size in 1..20 {
+            assert_eq!(
+                read_bytes_from_finite_reader(
+                    &mut io::Cursor::new(&data),
+                    ReadBytesFromFiniteReaderOpts {
+                        len: data.len(),
+                        chunk_size
+                    }
+                )
+                .unwrap(),
+                data
+            );
+        }
+    }
+
+    // #[test]
+    // fn deserialize_tx_hex() {
+    //     let hex = include_str!("../../tests/data/previous_tx_0_hex"); // An arbitrary transaction.
+    //     assert!(deserialize_hex::<Transaction>(hex).is_ok())
+    // }
+
+    // #[test]
+    // fn deserialize_tx_hex_too_many_bytes() {
+    //     use crate::consensus::DecodeError;
+
+    //     let mut hex = include_str!("../../tests/data/previous_tx_0_hex").to_string(); // An arbitrary transaction.
+    //     hex.push_str("abcdef");
+    //     assert!(matches!(
+    //         deserialize_hex::<Transaction>(&hex).unwrap_err(),
+    //         FromHexError::Decode(DecodeError::TooManyBytes)
+    //     ));
+    // }
+}

--- a/libs/bitcoin/src/consensus/encode.rs
+++ b/libs/bitcoin/src/consensus/encode.rs
@@ -863,13 +863,13 @@ impl<T: Encodable> Encodable for rc::Rc<T> {
     }
 }
 
-/// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
-impl<T: Encodable> Encodable for sync::Arc<T> {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        (**self).consensus_encode(w)
-    }
-}
+// /// Note: This will fail to compile on old Rust for targets that don't support atomics
+// #[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+// impl<T: Encodable> Encodable for sync::Arc<T> {
+//     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+//         (**self).consensus_encode(w)
+//     }
+// }
 
 macro_rules! tuple_encode {
     ($($x:ident),*) => {

--- a/libs/bitcoin/src/consensus/mod.rs
+++ b/libs/bitcoin/src/consensus/mod.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin consensus.
+//!
+//! This module defines structures, functions, and traits that are needed to
+//! conform to Bitcoin consensus.
+//!
+
+pub mod encode;
+pub mod params;
+#[cfg(feature = "serde")]
+pub mod serde;
+#[cfg(feature = "bitcoinconsensus")]
+pub mod validation;
+
+use core::fmt;
+
+use internals::write_err;
+use io::{BufRead, Read};
+
+use crate::consensus;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    encode::{deserialize, deserialize_partial, serialize, Decodable, Encodable, ReadExt, WriteExt},
+    params::Params,
+};
+
+#[cfg(feature = "bitcoinconsensus")]
+#[doc(inline)]
+pub use self::validation::{
+    verify_script, verify_script_with_flags, verify_transaction, verify_transaction_with_flags,
+};
+
+struct IterReader<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> {
+    iterator: core::iter::Fuse<I>,
+    buf: Option<u8>,
+    error: Option<E>,
+}
+
+impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> IterReader<E, I> {
+    pub(crate) fn new(iterator: I) -> Self {
+        IterReader { iterator: iterator.fuse(), buf: None, error: None }
+    }
+
+    fn decode<T: Decodable>(mut self) -> Result<T, DecodeError<E>> {
+        let result = T::consensus_decode(&mut self);
+        match (result, self.error) {
+            (Ok(_), None) if self.iterator.next().is_some() => Err(DecodeError::TooManyBytes),
+            (Ok(value), None) => Ok(value),
+            (Ok(_), Some(error)) => panic!("{} silently ate the error: {:?}", core::any::type_name::<T>(), error),
+
+            (Err(consensus::encode::Error::Io(io_error)), Some(de_error)) if io_error.kind() == io::ErrorKind::Other && io_error.get_ref().is_none() => Err(DecodeError::Other(de_error)),
+            (Err(consensus_error), None) => Err(DecodeError::Consensus(consensus_error)),
+            (Err(consensus::encode::Error::Io(io_error)), de_error) => panic!("Unexpected IO error {:?} returned from {}::consensus_decode(), deserialization error: {:?}", io_error, core::any::type_name::<T>(), de_error),
+            (Err(consensus_error), Some(de_error)) => panic!("{} should've returned `Other` IO error because of deserialization error {:?} but it returned consensus error {:?} instead", core::any::type_name::<T>(), de_error, consensus_error),
+        }
+    }
+}
+
+impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> Read for IterReader<E, I> {
+    fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
+        let mut count = 0;
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        if let Some(first) = self.buf.take() {
+            buf[0] = first;
+            buf = &mut buf[1..];
+            count += 1;
+        }
+        for (dst, src) in buf.iter_mut().zip(&mut self.iterator) {
+            match src {
+                Ok(byte) => *dst = byte,
+                Err(error) => {
+                    self.error = Some(error);
+                    return Err(io::ErrorKind::Other.into());
+                }
+            }
+            // bounded by the length of buf
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> BufRead for IterReader<E, I> {
+    fn fill_buf(&mut self) -> Result<&[u8], io::Error> {
+        // matching on reference rather than using `ref` confuses borrow checker
+        if let Some(ref byte) = self.buf {
+            Ok(core::slice::from_ref(byte))
+        } else {
+            match self.iterator.next() {
+                Some(Ok(byte)) => {
+                    self.buf = Some(byte);
+                    Ok(core::slice::from_ref(self.buf.as_ref().expect("we've just filled it")))
+                }
+                Some(Err(error)) => {
+                    self.error = Some(error);
+                    Err(io::ErrorKind::Other.into())
+                }
+                None => Ok(&[]),
+            }
+        }
+    }
+
+    fn consume(&mut self, len: usize) {
+        debug_assert!(len <= 1);
+        if len > 0 {
+            self.buf = None;
+        }
+    }
+}
+
+/// Error when consensus decoding from an `[IterReader]`.
+#[derive(Debug)]
+pub enum DecodeError<E> {
+    /// Attempted to decode an object from an iterator that yielded too many bytes.
+    TooManyBytes,
+    /// Invalid consensus encoding.
+    Consensus(consensus::encode::Error),
+    /// Other decoding error.
+    Other(E),
+}
+
+internals::impl_from_infallible!(DecodeError<E>);
+
+impl<E: fmt::Debug> fmt::Display for DecodeError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use DecodeError::*;
+
+        match *self {
+            TooManyBytes =>
+                write!(f, "attempted to decode object from an iterator that yielded too many bytes"),
+            Consensus(ref e) => write_err!(f, "invalid consensus encoding"; e),
+            Other(ref other) => write!(f, "other decoding error: {:?}", other),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: fmt::Debug> std::error::Error for DecodeError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use DecodeError::*;
+
+        match *self {
+            TooManyBytes => None,
+            Consensus(ref e) => Some(e),
+            Other(_) => None, // TODO: Is this correct?
+        }
+    }
+}

--- a/libs/bitcoin/src/consensus/params.rs
+++ b/libs/bitcoin/src/consensus/params.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin consensus parameters.
+//!
+//! This module provides a predefined set of parameters for different Bitcoin
+//! chains (such as mainnet, testnet, testnet4).
+//!
+
+use crate::network::Network;
+#[cfg(doc)]
+use crate::pow::CompactTarget;
+use crate::pow::Target;
+
+/// Parameters that influence chain consensus.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Params {
+    /// Network for which parameters are valid.
+    pub network: Network,
+    /// Time when BIP16 becomes active.
+    pub bip16_time: u32,
+    /// Block height at which BIP34 becomes active.
+    pub bip34_height: u32,
+    /// Block height at which BIP65 becomes active.
+    pub bip65_height: u32,
+    /// Block height at which BIP66 becomes active.
+    pub bip66_height: u32,
+    /// Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
+    /// (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
+    /// Examples: 1916 for 95%, 1512 for testchains.
+    pub rule_change_activation_threshold: u32,
+    /// Number of blocks with the same set of rules.
+    pub miner_confirmation_window: u32,
+    /// Proof of work limit value. It contains the lowest possible difficulty.
+    #[deprecated(since = "0.32.0", note = "field renamed to max_attainable_target")]
+    pub pow_limit: Target,
+    /// The maximum **attainable** target value for these params.
+    ///
+    /// Not all target values are attainable because consensus code uses the compact format to
+    /// represent targets (see [`CompactTarget`]).
+    ///
+    /// Note that this value differs from Bitcoin Core's powLimit field in that this value is
+    /// attainable, but Bitcoin Core's is not. Specifically, because targets in Bitcoin are always
+    /// rounded to the nearest float expressible in "compact form", not all targets are attainable.
+    /// Still, this should not affect consensus as the only place where the non-compact form of
+    /// this is used in Bitcoin Core's consensus algorithm is in comparison and there are no
+    /// compact-expressible values between Bitcoin Core's and the limit expressed here.
+    pub max_attainable_target: Target,
+    /// Expected amount of time to mine one block.
+    pub pow_target_spacing: u64,
+    /// Difficulty recalculation interval.
+    pub pow_target_timespan: u64,
+    /// Determines whether minimal difficulty may be used for blocks or not.
+    pub allow_min_difficulty_blocks: bool,
+    /// Determines whether retargeting is disabled for this network or not.
+    pub no_pow_retargeting: bool,
+}
+
+/// The mainnet parameters.
+///
+/// Use this for a static reference e.g., `&params::MAINNET`.
+///
+/// For more on static vs const see The Rust Reference [using-statics-or-consts] section.
+///
+/// [using-statics-or-consts]: <https://doc.rust-lang.org/reference/items/static-items.html#using-statics-or-consts>
+pub static MAINNET: Params = Params::MAINNET;
+/// The testnet3 parameters.
+#[deprecated(since = "0.32.4", note = "Use TESTNET3 instead")]
+pub static TESTNET: Params = Params::TESTNET3;
+/// The testnet3 parameters.
+pub static TESTNET3: Params = Params::TESTNET3;
+/// The testnet4 parameters.
+pub static TESTNET4: Params = Params::TESTNET4;
+/// The signet parameters.
+pub static SIGNET: Params = Params::SIGNET;
+/// The regtest parameters.
+pub static REGTEST: Params = Params::REGTEST;
+
+#[allow(deprecated)]            // For `pow_limit`.
+impl Params {
+    /// The mainnet parameters (alias for `Params::MAINNET`).
+    pub const BITCOIN: Params = Params::MAINNET;
+
+    /// The mainnet parameters.
+    pub const MAINNET: Params = Params {
+        network: Network::Bitcoin,
+        bip16_time: 1333238400,                 // Apr 1 2012
+        bip34_height: 227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
+        bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+        bip66_height: 363725, // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        rule_change_activation_threshold: 1916, // 95%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_MAINNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_MAINNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: false,
+        no_pow_retargeting: false,
+    };
+
+    /// The testnet3 parameters.
+    #[deprecated(since = "0.32.4", note = "Use TESTNET3 instead")]
+    pub const TESTNET: Params = Params {
+        network: Network::Testnet,
+        bip16_time: 1333238400,                 // Apr 1 2012
+        bip34_height: 21111, // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+        bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        bip66_height: 330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        rule_change_activation_threshold: 1512, // 75%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_TESTNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_TESTNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: false,
+    };
+
+    /// The testnet3 parameters.
+    pub const TESTNET3: Params = Params {
+        network: Network::Testnet,
+        bip16_time: 1333238400,                 // Apr 1 2012
+        bip34_height: 21111, // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+        bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        bip66_height: 330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        rule_change_activation_threshold: 1512, // 75%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_TESTNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_TESTNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: false,
+    };
+
+    /// The testnet4 parameters.
+    pub const TESTNET4: Params = Params {
+        network: Network::Testnet4,
+        bip16_time: 1333238400, // Apr 1 2012
+        bip34_height: 1,
+        bip65_height: 1,
+        bip66_height: 1,
+        rule_change_activation_threshold: 1512, // 75%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_TESTNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_TESTNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: false,
+    };
+
+    /// The signet parameters.
+    pub const SIGNET: Params = Params {
+        network: Network::Signet,
+        bip16_time: 1333238400, // Apr 1 2012
+        bip34_height: 1,
+        bip65_height: 1,
+        bip66_height: 1,
+        rule_change_activation_threshold: 1916, // 95%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_SIGNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_SIGNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: false,
+        no_pow_retargeting: false,
+    };
+
+    /// The regtest parameters.
+    pub const REGTEST: Params = Params {
+        network: Network::Regtest,
+        bip16_time: 1333238400,  // Apr 1 2012
+        bip34_height: 100000000, // not activated on regtest
+        bip65_height: 1351,
+        bip66_height: 1251,                    // used only in rpc tests
+        rule_change_activation_threshold: 108, // 75%
+        miner_confirmation_window: 144,
+        pow_limit: Target::MAX_ATTAINABLE_REGTEST,
+        max_attainable_target: Target::MAX_ATTAINABLE_REGTEST,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: true,
+    };
+
+    /// Creates parameters set for the given network.
+    pub const fn new(network: Network) -> Self {
+        match network {
+            Network::Bitcoin => Params::MAINNET,
+            Network::Testnet => Params::TESTNET3,
+            Network::Testnet4 => Params::TESTNET4,
+            Network::Signet => Params::SIGNET,
+            Network::Regtest => Params::REGTEST,
+        }
+    }
+
+    /// Calculates the number of blocks between difficulty adjustments.
+    pub fn difficulty_adjustment_interval(&self) -> u64 {
+        self.pow_target_timespan / self.pow_target_spacing
+    }
+}
+
+impl From<Network> for Params {
+    fn from(value: Network) -> Self { Self::new(value) }
+}
+
+impl From<&Network> for Params {
+    fn from(value: &Network) -> Self { Self::new(*value) }
+}
+
+impl From<Network> for &'static Params {
+    fn from(value: Network) -> Self { value.params() }
+}
+
+impl From<&Network> for &'static Params {
+    fn from(value: &Network) -> Self { value.params() }
+}
+
+impl AsRef<Params> for Params {
+    fn as_ref(&self) -> &Params { self }
+}
+
+impl AsRef<Params> for Network {
+    fn as_ref(&self) -> &Params { Self::params(*self) }
+}

--- a/libs/bitcoin/src/consensus/serde.rs
+++ b/libs/bitcoin/src/consensus/serde.rs
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Serde serialization via consensus encoding
+//!
+//! This provides functions for (de)serializing any type as consensus-encoded bytes.
+//! For human-readable formats it serializes as a string with a consumer-supplied encoding, for
+//! binary formats it serializes as a sequence of bytes (not `serialize_bytes` to avoid allocations).
+//!
+//! The string encoding has to be specified using a marker type implementing the encoding strategy.
+//! This crate provides hex encoding via `Hex<Upper>` and `Hex<Lower>`
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use io::Write;
+use serde::de::{SeqAccess, Unexpected, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserializer, Serializer};
+
+use super::encode::Error as ConsensusError;
+use super::{Decodable, Encodable};
+use crate::consensus::{DecodeError, IterReader};
+
+/// Hex-encoding strategy
+pub struct Hex<Case = hex::Lower>(PhantomData<Case>)
+where
+    Case: hex::Case;
+
+impl<C: hex::Case> Default for Hex<C> {
+    fn default() -> Self { Hex(Default::default()) }
+}
+
+impl<C: hex::Case> ByteEncoder for Hex<C> {
+    type Encoder = hex::Encoder<C>;
+}
+
+/// Implements hex encoding.
+pub mod hex {
+    use core::fmt;
+    use core::marker::PhantomData;
+
+    use hex::buf_encoder::BufEncoder;
+
+    /// Marker for upper/lower case type-level flags ("type-level enum").
+    ///
+    /// You may use this trait in bounds only.
+    pub trait Case: sealed::Case {}
+    impl<T: sealed::Case> Case for T {}
+
+    /// Marker for using lower-case hex encoding.
+    pub enum Lower {}
+    /// Marker for using upper-case hex encoding.
+    pub enum Upper {}
+
+    mod sealed {
+        pub trait Case {
+            /// Internal detail, don't depend on it!!!
+            const INTERNAL_CASE: hex::Case;
+        }
+
+        impl Case for super::Lower {
+            const INTERNAL_CASE: hex::Case = hex::Case::Lower;
+        }
+
+        impl Case for super::Upper {
+            const INTERNAL_CASE: hex::Case = hex::Case::Upper;
+        }
+    }
+
+    // We just guessed at a reasonably sane value.
+    const HEX_BUF_SIZE: usize = 512;
+
+    /// Hex byte encoder.
+    // We wrap `BufEncoder` to not leak internal representation.
+    pub struct Encoder<C: Case>(BufEncoder<{ HEX_BUF_SIZE }>, PhantomData<C>);
+
+    impl<C: Case> From<super::Hex<C>> for Encoder<C> {
+        fn from(_: super::Hex<C>) -> Self { Encoder(BufEncoder::new(), Default::default()) }
+    }
+
+    impl<C: Case> super::EncodeBytes for Encoder<C> {
+        fn encode_chunk<W: fmt::Write>(&mut self, writer: &mut W, mut bytes: &[u8]) -> fmt::Result {
+            while !bytes.is_empty() {
+                if self.0.is_full() {
+                    self.flush(writer)?;
+                }
+                bytes = self.0.put_bytes_min(bytes, C::INTERNAL_CASE);
+            }
+            Ok(())
+        }
+
+        fn flush<W: fmt::Write>(&mut self, writer: &mut W) -> fmt::Result {
+            writer.write_str(self.0.as_str())?;
+            self.0.clear();
+            Ok(())
+        }
+    }
+
+    // Newtypes to hide internal details.
+
+    /// Error returned when a hex string decoder can't be created.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodeInitError(hex::OddLengthStringError);
+
+    /// Error returned when a hex string contains invalid characters.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodeError(hex::InvalidCharError);
+
+    /// Hex decoder state.
+    pub struct Decoder<'a>(hex::HexSliceToBytesIter<'a>);
+
+    impl<'a> Decoder<'a> {
+        fn new(s: &'a str) -> Result<Self, DecodeInitError> {
+            match hex::HexToBytesIter::new(s) {
+                Ok(iter) => Ok(Decoder(iter)),
+                Err(error) => Err(DecodeInitError(error)),
+            }
+        }
+    }
+
+    impl<'a> Iterator for Decoder<'a> {
+        type Item = Result<u8, DecodeError>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next().map(|result| result.map_err(DecodeError))
+        }
+    }
+
+    impl<'a, C: Case> super::ByteDecoder<'a> for super::Hex<C> {
+        type InitError = DecodeInitError;
+        type DecodeError = DecodeError;
+        type Decoder = Decoder<'a>;
+
+        fn from_str(s: &'a str) -> Result<Self::Decoder, Self::InitError> { Decoder::new(s) }
+    }
+
+    impl super::IntoDeError for DecodeInitError {
+        fn into_de_error<E: serde::de::Error>(self) -> E {
+            E::invalid_length(self.0.length(), &"an even number of ASCII-encoded hex digits")
+        }
+    }
+
+    impl super::IntoDeError for DecodeError {
+        fn into_de_error<E: serde::de::Error>(self) -> E {
+            use serde::de::Unexpected;
+
+            const EXPECTED_CHAR: &str = "an ASCII-encoded hex digit";
+
+            match self.0.invalid_char() {
+                c if c.is_ascii() => E::invalid_value(Unexpected::Char(c as _), &EXPECTED_CHAR),
+                c => E::invalid_value(Unexpected::Unsigned(c.into()), &EXPECTED_CHAR),
+            }
+        }
+    }
+}
+
+struct DisplayWrapper<'a, T: 'a + Encodable, E>(&'a T, PhantomData<E>);
+
+impl<'a, T: 'a + Encodable, E: ByteEncoder> fmt::Display for DisplayWrapper<'a, T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut writer = IoWrapper::<'_, _, E::Encoder>::new(f, E::default().into());
+        self.0.consensus_encode(&mut writer).map_err(|error| {
+            #[cfg(debug_assertions)]
+            {
+                if error.kind() != io::ErrorKind::Other
+                    || error.get_ref().is_some()
+                    || !writer.writer.was_error
+                {
+                    panic!(
+                        "{} returned an unexpected error: {:?}",
+                        core::any::type_name::<T>(),
+                        error
+                    );
+                }
+            }
+            fmt::Error
+        })?;
+        let result = writer.actually_flush();
+        if result.is_err() {
+            writer.writer.assert_was_error::<E>();
+        }
+        result
+    }
+}
+
+struct ErrorTrackingWriter<W: fmt::Write> {
+    writer: W,
+    #[cfg(debug_assertions)]
+    was_error: bool,
+}
+
+impl<W: fmt::Write> ErrorTrackingWriter<W> {
+    fn new(writer: W) -> Self {
+        ErrorTrackingWriter {
+            writer,
+            #[cfg(debug_assertions)]
+            was_error: false,
+        }
+    }
+
+    #[track_caller]
+    fn assert_no_error(&self, fun: &str) {
+        #[cfg(debug_assertions)]
+        {
+            if self.was_error {
+                panic!("`{}` called on errored writer", fun);
+            }
+        }
+    }
+
+    fn assert_was_error<Offender>(&self) {
+        #[cfg(debug_assertions)]
+        {
+            if !self.was_error {
+                panic!("{} returned an error unexpectedly", core::any::type_name::<Offender>());
+            }
+        }
+    }
+
+    fn set_error(&mut self, was: bool) {
+        #[cfg(debug_assertions)]
+        {
+            self.was_error |= was;
+        }
+    }
+
+    fn check_err<T, E>(&mut self, result: Result<T, E>) -> Result<T, E> {
+        self.set_error(result.is_err());
+        result
+    }
+}
+
+impl<W: fmt::Write> fmt::Write for ErrorTrackingWriter<W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.assert_no_error("write_str");
+        let result = self.writer.write_str(s);
+        self.check_err(result)
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.assert_no_error("write_char");
+        let result = self.writer.write_char(c);
+        self.check_err(result)
+    }
+}
+
+struct IoWrapper<'a, W: fmt::Write, E: EncodeBytes> {
+    writer: ErrorTrackingWriter<&'a mut W>,
+    encoder: E,
+}
+
+impl<'a, W: fmt::Write, E: EncodeBytes> IoWrapper<'a, W, E> {
+    fn new(writer: &'a mut W, encoder: E) -> Self {
+        IoWrapper { writer: ErrorTrackingWriter::new(writer), encoder }
+    }
+
+    fn actually_flush(&mut self) -> fmt::Result { self.encoder.flush(&mut self.writer) }
+}
+
+impl<'a, W: fmt::Write, E: EncodeBytes> Write for IoWrapper<'a, W, E> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        match self.encoder.encode_chunk(&mut self.writer, bytes) {
+            Ok(()) => Ok(bytes.len()),
+            Err(fmt::Error) => {
+                self.writer.assert_was_error::<E>();
+                Err(io::Error::from(io::ErrorKind::Other))
+            }
+        }
+    }
+    // we intentionally ignore flushes because we will do a single flush at the end.
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+/// Provides an instance of byte-to-string encoder.
+///
+/// This is basically a type constructor used in places where value arguments are not accepted.
+/// Such as the generic `serialize`.
+pub trait ByteEncoder: Default {
+    /// The encoder state.
+    type Encoder: EncodeBytes + From<Self>;
+}
+
+/// Transforms given bytes and writes to the writer.
+///
+/// The encoder is allowed to be buffered (and probably should be).
+/// The design passing writer each time bypasses the need for GAT.
+pub trait EncodeBytes {
+    /// Transform the provided slice and write to the writer.
+    ///
+    /// This is similar to the `write_all` method on `io::Write`.
+    fn encode_chunk<W: fmt::Write>(&mut self, writer: &mut W, bytes: &[u8]) -> fmt::Result;
+
+    /// Write data in buffer (if any) to the writer.
+    fn flush<W: fmt::Write>(&mut self, writer: &mut W) -> fmt::Result;
+}
+
+/// Provides an instance of string-to-byte decoder.
+///
+/// This is basically a type constructor used in places where value arguments are not accepted.
+/// Such as the generic `serialize`.
+pub trait ByteDecoder<'a> {
+    /// Error returned when decoder can't be created.
+    ///
+    /// This is typically returned when string length is invalid.
+    type InitError: IntoDeError + fmt::Debug;
+
+    /// Error returned when decoding fails.
+    ///
+    /// This is typically returned when the input string contains malformed chars.
+    type DecodeError: IntoDeError + fmt::Debug;
+
+    /// The decoder state.
+    type Decoder: Iterator<Item = Result<u8, Self::DecodeError>>;
+
+    /// Constructs the decoder from string.
+    fn from_str(s: &'a str) -> Result<Self::Decoder, Self::InitError>;
+}
+
+/// Converts error into a type implementing `serde::de::Error`
+pub trait IntoDeError {
+    /// Performs the conversion.
+    fn into_de_error<E: serde::de::Error>(self) -> E;
+}
+
+struct BinWriter<S: SerializeSeq> {
+    serializer: S,
+    error: Option<S::Error>,
+}
+
+impl<S: SerializeSeq> Write for BinWriter<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.write_all(buf).map(|_| buf.len()) }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        for byte in buf {
+            if let Err(error) = self.serializer.serialize_element(byte) {
+                self.error = Some(error);
+                return Err(io::ErrorKind::Other.into());
+            }
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+struct DisplayExpected<D: fmt::Display>(D);
+
+impl<D: fmt::Display> serde::de::Expected for DisplayExpected<D> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+// not a trait impl because we panic on some variants
+fn consensus_error_into_serde<E: serde::de::Error>(error: ConsensusError) -> E {
+    match error {
+        ConsensusError::Io(error) => panic!("unexpected IO error {:?}", error),
+        ConsensusError::OversizedVectorAllocation { requested, max } => E::custom(format_args!(
+            "the requested allocation of {} items exceeds maximum of {}",
+            requested, max
+        )),
+        ConsensusError::InvalidChecksum { expected, actual } => E::invalid_value(
+            Unexpected::Bytes(&actual),
+            &DisplayExpected(format_args!(
+                "checksum {:02x}{:02x}{:02x}{:02x}",
+                expected[0], expected[1], expected[2], expected[3]
+            )),
+        ),
+        ConsensusError::NonMinimalVarInt =>
+            E::custom(format_args!("compact size was not encoded minimally")),
+        ConsensusError::ParseFailed(msg) => E::custom(msg),
+        ConsensusError::UnsupportedSegwitFlag(flag) =>
+            E::invalid_value(Unexpected::Unsigned(flag.into()), &"segwit version 1 flag"),
+    }
+}
+
+impl<E> DecodeError<E>
+where
+    E: serde::de::Error,
+{
+    fn unify(self) -> E {
+        match self {
+            DecodeError::Other(error) => error,
+            DecodeError::TooManyBytes => E::custom(format_args!("got more bytes than expected")),
+            DecodeError::Consensus(error) => consensus_error_into_serde(error),
+        }
+    }
+}
+
+impl<E> IntoDeError for DecodeError<E>
+where
+    E: IntoDeError,
+{
+    fn into_de_error<DE: serde::de::Error>(self) -> DE {
+        match self {
+            DecodeError::Other(error) => error.into_de_error(),
+            DecodeError::TooManyBytes => DE::custom(format_args!("got more bytes than expected")),
+            DecodeError::Consensus(error) => consensus_error_into_serde(error),
+        }
+    }
+}
+
+/// Helper for `#[serde(with = "")]`.
+///
+/// To (de)serialize a field using consensus encoding you can write e.g.:
+///
+/// ```
+/// # use actual_serde::{Serialize, Deserialize};
+/// use bitcoin::Transaction;
+/// use bitcoin::consensus;
+///
+/// #[derive(Serialize, Deserialize)]
+/// # #[serde(crate = "actual_serde")]
+/// pub struct MyStruct {
+///     #[serde(with = "consensus::serde::With::<consensus::serde::Hex>")]
+///     tx: Transaction,
+/// }
+/// ```
+pub struct With<E>(PhantomData<E>);
+
+impl<E> With<E> {
+    /// Serializes the value as consensus-encoded
+    pub fn serialize<T: Encodable, S: Serializer>(
+        value: &T,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        E: ByteEncoder,
+    {
+        if serializer.is_human_readable() {
+            serializer.collect_str(&DisplayWrapper::<'_, _, E>(value, Default::default()))
+        } else {
+            let serializer = serializer.serialize_seq(None)?;
+            let mut writer = BinWriter { serializer, error: None };
+
+            let result = value.consensus_encode(&mut writer);
+            match (result, writer.error) {
+                (Ok(_), None) => writer.serializer.end(),
+                (Ok(_), Some(error)) =>
+                    panic!("{} silently ate an IO error: {:?}", core::any::type_name::<T>(), error),
+                (Err(io_error), Some(ser_error))
+                    if io_error.kind() == io::ErrorKind::Other && io_error.get_ref().is_none() =>
+                    Err(ser_error),
+                (Err(io_error), ser_error) => panic!(
+                    "{} returned an unexpected IO error: {:?} serialization error: {:?}",
+                    core::any::type_name::<T>(),
+                    io_error,
+                    ser_error
+                ),
+            }
+        }
+    }
+
+    /// Deserializes the value as consensus-encoded
+    pub fn deserialize<'d, T: Decodable, D: Deserializer<'d>>(
+        deserializer: D,
+    ) -> Result<T, D::Error>
+    where
+        for<'a> E: ByteDecoder<'a>,
+    {
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(HRVisitor::<_, E>(Default::default()))
+        } else {
+            deserializer.deserialize_seq(BinVisitor(Default::default()))
+        }
+    }
+}
+
+struct HRVisitor<T: Decodable, D: for<'a> ByteDecoder<'a>>(PhantomData<fn() -> (T, D)>);
+
+impl<'de, T: Decodable, D: for<'a> ByteDecoder<'a>> Visitor<'de> for HRVisitor<T, D> {
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("bytes encoded as a hex string")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, s: &str) -> Result<T, E> {
+        let decoder = D::from_str(s).map_err(IntoDeError::into_de_error)?;
+        IterReader::new(decoder).decode().map_err(IntoDeError::into_de_error)
+    }
+}
+
+struct BinVisitor<T: Decodable>(PhantomData<fn() -> T>);
+
+impl<'de, T: Decodable> Visitor<'de> for BinVisitor<T> {
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a sequence of bytes")
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, s: S) -> Result<T, S::Error> {
+        IterReader::new(SeqIterator(s, Default::default())).decode().map_err(DecodeError::unify)
+    }
+}
+
+struct SeqIterator<'a, S: serde::de::SeqAccess<'a>>(S, PhantomData<&'a ()>);
+
+impl<'a, S: serde::de::SeqAccess<'a>> Iterator for SeqIterator<'a, S> {
+    type Item = Result<u8, S::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> { self.0.next_element::<u8>().transpose() }
+}

--- a/libs/bitcoin/src/consensus/validation.rs
+++ b/libs/bitcoin/src/consensus/validation.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Transaction and script validation.
+//!
+//! Relies on the `bitcoinconsensus` crate that uses Bitcoin Core libconsensus to perform validation.
+
+use core::fmt;
+
+use internals::write_err;
+
+use crate::amount::Amount;
+use crate::blockdata::script::Script;
+use crate::blockdata::transaction::{OutPoint, Transaction, TxOut};
+#[cfg(doc)]
+use crate::consensus;
+use crate::consensus::encode;
+
+/// Verifies spend of an input script.
+///
+/// Shorthand for [`consensus::verify_script_with_flags`] with flag
+/// [`bitcoinconsensus::VERIFY_ALL`].
+///
+/// # Parameters
+///  * `index` - The input index in spending which is spending this transaction.
+///  * `amount` - The amount this script guards.
+///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
+///
+/// [`bitcoinconsensus::VERIFY_ALL`]: https://docs.rs/bitcoinconsensus/0.20.2-0.5.0/bitcoinconsensus/constant.VERIFY_ALL.html
+pub fn verify_script(
+    script: &Script,
+    index: usize,
+    amount: Amount,
+    spending_tx: &[u8],
+) -> Result<(), BitcoinconsensusError> {
+    verify_script_with_flags(script, index, amount, spending_tx, bitcoinconsensus::VERIFY_ALL)
+}
+
+/// Verifies spend of an input script.
+///
+/// # Parameters
+///  * `index` - The input index in spending which is spending this transaction.
+///  * `amount` - The amount this script guards.
+///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
+///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL`] and similar.
+///
+/// [`bitcoinconsensus::VERIFY_ALL`]: https://docs.rs/bitcoinconsensus/0.20.2-0.5.0/bitcoinconsensus/constant.VERIFY_ALL.html
+pub fn verify_script_with_flags<F: Into<u32>>(
+    script: &Script,
+    index: usize,
+    amount: Amount,
+    spending_tx: &[u8],
+    flags: F,
+) -> Result<(), BitcoinconsensusError> {
+    bitcoinconsensus::verify_with_flags(
+        script.as_bytes(),
+        amount.to_sat(),
+        spending_tx,
+        index,
+        flags.into(),
+    )
+    .map_err(BitcoinconsensusError)
+}
+
+/// Verifies that this transaction is able to spend its inputs.
+///
+/// Shorthand for [`consensus::verify_transaction_with_flags`] with flag
+/// [`bitcoinconsensus::VERIFY_ALL`].
+///
+/// The `spent` closure should not return the same [`TxOut`] twice!
+///
+/// [`bitcoinconsensus::VERIFY_ALL`]: https://docs.rs/bitcoinconsensus/0.20.2-0.5.0/bitcoinconsensus/constant.VERIFY_ALL.html
+pub fn verify_transaction<S>(tx: &Transaction, spent: S) -> Result<(), TxVerifyError>
+where
+    S: FnMut(&OutPoint) -> Option<TxOut>,
+{
+    verify_transaction_with_flags(tx, spent, bitcoinconsensus::VERIFY_ALL)
+}
+
+/// Verifies that this transaction is able to spend its inputs.
+///
+/// The `spent` closure should not return the same [`TxOut`] twice!
+pub fn verify_transaction_with_flags<S, F>(
+    tx: &Transaction,
+    mut spent: S,
+    flags: F,
+) -> Result<(), TxVerifyError>
+where
+    S: FnMut(&OutPoint) -> Option<TxOut>,
+    F: Into<u32>,
+{
+    let serialized_tx = encode::serialize(tx);
+    let flags: u32 = flags.into();
+    for (idx, input) in tx.input.iter().enumerate() {
+        if let Some(output) = spent(&input.previous_output) {
+            verify_script_with_flags(
+                &output.script_pubkey,
+                idx,
+                output.value,
+                serialized_tx.as_slice(),
+                flags,
+            )?;
+        } else {
+            return Err(TxVerifyError::UnknownSpentOutput(input.previous_output));
+        }
+    }
+    Ok(())
+}
+
+impl Script {
+    /// Verifies spend of an input script.
+    ///
+    /// Shorthand for [`Self::verify_with_flags`] with flag [`bitcoinconsensus::VERIFY_ALL`].
+    ///
+    /// # Parameters
+    ///  * `index` - The input index in spending which is spending this transaction.
+    ///  * `amount` - The amount this script guards.
+    ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
+    ///
+    /// [`bitcoinconsensus::VERIFY_ALL`]: https://docs.rs/bitcoinconsensus/0.20.2-0.5.0/bitcoinconsensus/constant.VERIFY_ALL.html
+    pub fn verify(
+        &self,
+        index: usize,
+        amount: crate::Amount,
+        spending_tx: &[u8],
+    ) -> Result<(), BitcoinconsensusError> {
+        verify_script(self, index, amount, spending_tx)
+    }
+
+    /// Verifies spend of an input script.
+    ///
+    /// # Parameters
+    ///  * `index` - The input index in spending which is spending this transaction.
+    ///  * `amount` - The amount this script guards.
+    ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
+    ///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL`] and similar.
+    ///
+    /// [`bitcoinconsensus::VERIFY_ALL`]: https://docs.rs/bitcoinconsensus/0.20.2-0.5.0/bitcoinconsensus/constant.VERIFY_ALL.html
+    pub fn verify_with_flags<F: Into<u32>>(
+        &self,
+        index: usize,
+        amount: crate::Amount,
+        spending_tx: &[u8],
+        flags: F,
+    ) -> Result<(), BitcoinconsensusError> {
+        verify_script_with_flags(self, index, amount, spending_tx, flags)
+    }
+}
+
+impl Transaction {
+    /// Verifies that this transaction is able to spend its inputs.
+    ///
+    /// Shorthand for [`Self::verify_with_flags`] with flag [`bitcoinconsensus::VERIFY_ALL`].
+    ///
+    /// The `spent` closure should not return the same [`TxOut`] twice!
+    ///
+    /// [`bitcoinconsensus::VERIFY_ALL`]: https://docs.rs/bitcoinconsensus/0.20.2-0.5.0/bitcoinconsensus/constant.VERIFY_ALL.html
+    pub fn verify<S>(&self, spent: S) -> Result<(), TxVerifyError>
+    where
+        S: FnMut(&OutPoint) -> Option<TxOut>,
+    {
+        verify_transaction(self, spent)
+    }
+
+    /// Verifies that this transaction is able to spend its inputs.
+    ///
+    /// The `spent` closure should not return the same [`TxOut`] twice!
+    pub fn verify_with_flags<S, F>(&self, spent: S, flags: F) -> Result<(), TxVerifyError>
+    where
+        S: FnMut(&OutPoint) -> Option<TxOut>,
+        F: Into<u32>,
+    {
+        verify_transaction_with_flags(self, spent, flags)
+    }
+}
+
+/// Wrapped error from `bitcoinconsensus`.
+// We do this for two reasons:
+// 1. We don't want the error to be part of the public API because we do not want to expose the
+//    unusual versioning used in `bitcoinconsensus` to users of `rust-bitcoin`.
+// 2. We want to implement `std::error::Error` if the "std" feature is enabled in `rust-bitcoin` but
+//    not in `bitcoinconsensus`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BitcoinconsensusError(bitcoinconsensus::Error);
+
+impl fmt::Display for BitcoinconsensusError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "bitcoinconsensus error"; &self.0)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "bitcoinconsensus-std"))]
+impl std::error::Error for BitcoinconsensusError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
+#[cfg(all(feature = "std", not(feature = "bitcoinconsensus-std")))]
+impl std::error::Error for BitcoinconsensusError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// An error during transaction validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TxVerifyError {
+    /// Error validating the script with bitcoinconsensus library.
+    ScriptVerification(BitcoinconsensusError),
+    /// Can not find the spent output.
+    UnknownSpentOutput(OutPoint),
+}
+
+internals::impl_from_infallible!(TxVerifyError);
+
+impl fmt::Display for TxVerifyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use TxVerifyError::*;
+
+        match *self {
+            ScriptVerification(ref e) => write_err!(f, "bitcoinconsensus verification failed"; e),
+            UnknownSpentOutput(ref p) => write!(f, "unknown spent output: {}", p),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TxVerifyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use TxVerifyError::*;
+
+        match *self {
+            ScriptVerification(ref e) => Some(e),
+            UnknownSpentOutput(_) => None,
+        }
+    }
+}
+
+impl From<BitcoinconsensusError> for TxVerifyError {
+    fn from(e: BitcoinconsensusError) -> Self { TxVerifyError::ScriptVerification(e) }
+}

--- a/libs/bitcoin/src/crypto/ecdsa.rs
+++ b/libs/bitcoin/src/crypto/ecdsa.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! ECDSA Bitcoin signatures.
+//!
+//! This module provides ECDSA signatures used by Bitcoin that can be roundtrip (de)serialized.
+
+use core::str::FromStr;
+use core::{fmt, iter};
+
+use hex::FromHex;
+use internals::write_err;
+use io::Write;
+
+use crate::prelude::*;
+use crate::script::PushBytes;
+use crate::sighash::{EcdsaSighashType, NonStandardSighashTypeError};
+
+const MAX_SIG_LEN: usize = 73;
+
+/// An ECDSA signature with the corresponding hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Signature {
+    /// The underlying ECDSA Signature.
+    pub signature: secp256k1::ecdsa::Signature,
+    /// The corresponding hash type.
+    pub sighash_type: EcdsaSighashType,
+}
+
+impl Signature {
+    /// Constructs an ECDSA Bitcoin signature for [`EcdsaSighashType::All`].
+    pub fn sighash_all(signature: secp256k1::ecdsa::Signature) -> Signature {
+        Signature { signature, sighash_type: EcdsaSighashType::All }
+    }
+
+    /// Deserializes from slice following the standardness rules for [`EcdsaSighashType`].
+    pub fn from_slice(sl: &[u8]) -> Result<Self, Error> {
+        let (sighash_type, sig) = sl.split_last().ok_or(Error::EmptySignature)?;
+        let sighash_type = EcdsaSighashType::from_standard(*sighash_type as u32)?;
+        let signature = secp256k1::ecdsa::Signature::from_der(sig).map_err(Error::Secp256k1)?;
+        Ok(Signature { signature, sighash_type })
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format).
+    ///
+    /// This does **not** perform extra heap allocation.
+    pub fn serialize(&self) -> SerializedSignature {
+        let mut buf = [0u8; MAX_SIG_LEN];
+        let signature = self.signature.serialize_der();
+        buf[..signature.len()].copy_from_slice(&signature);
+        buf[signature.len()] = self.sighash_type as u8;
+        SerializedSignature { data: buf, len: signature.len() + 1 }
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) into `Vec`.
+    ///
+    /// Note: this performs an extra heap allocation, you might prefer the
+    /// [`serialize`](Self::serialize) method instead.
+    pub fn to_vec(self) -> Vec<u8> {
+        self.signature
+            .serialize_der()
+            .iter()
+            .copied()
+            .chain(iter::once(self.sighash_type as u8))
+            .collect()
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) to a `writer`.
+    #[inline]
+    pub fn serialize_to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        let sig = self.serialize();
+        sig.write_to(writer)
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.signature.serialize_der().as_hex(), f)?;
+        fmt::LowerHex::fmt(&[self.sighash_type as u8].as_hex(), f)
+    }
+}
+
+impl FromStr for Signature {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = Vec::from_hex(s)?;
+        let (sighash_byte, signature) = bytes.split_last().ok_or(Error::EmptySignature)?;
+        Ok(Signature {
+            signature: secp256k1::ecdsa::Signature::from_der(signature)?,
+            sighash_type: EcdsaSighashType::from_standard(*sighash_byte as u32)?,
+        })
+    }
+}
+
+/// Holds signature serialized in-line (not in `Vec`).
+///
+/// This avoids allocation and allows proving maximum size of the signature (73 bytes).
+/// The type can be used largely as a byte slice. It implements all standard traits one would
+/// expect and has familiar methods.
+/// However, the usual use case is to push it into a script. This can be done directly passing it
+/// into [`push_slice`](crate::script::ScriptBuf::push_slice).
+#[derive(Copy, Clone)]
+pub struct SerializedSignature {
+    data: [u8; MAX_SIG_LEN],
+    len: usize,
+}
+
+impl SerializedSignature {
+    /// Returns an iterator over bytes of the signature.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, u8> { self.into_iter() }
+
+    /// Writes this serialized signature to a `writer`.
+    #[inline]
+    pub fn write_to<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(self)
+    }
+}
+
+impl core::ops::Deref for SerializedSignature {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target { &self.data[..self.len] }
+}
+
+impl core::ops::DerefMut for SerializedSignature {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.data[..self.len] }
+}
+
+impl AsRef<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &[u8] { self }
+}
+
+impl AsMut<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] { self }
+}
+
+impl AsRef<PushBytes> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &PushBytes { &<&PushBytes>::from(&self.data)[..self.len()] }
+}
+
+impl core::borrow::Borrow<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow(&self) -> &[u8] { self }
+}
+
+impl core::borrow::BorrowMut<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [u8] { self }
+}
+
+impl fmt::Debug for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
+}
+
+impl fmt::Display for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
+impl fmt::LowerHex for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&(**self).as_hex(), f)
+    }
+}
+
+impl fmt::UpperHex for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&(**self).as_hex(), f)
+    }
+}
+
+impl PartialEq for SerializedSignature {
+    #[inline]
+    fn eq(&self, other: &SerializedSignature) -> bool { **self == **other }
+}
+
+impl Eq for SerializedSignature {}
+
+impl core::hash::Hash for SerializedSignature {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) { core::hash::Hash::hash(&**self, state) }
+}
+
+impl<'a> IntoIterator for &'a SerializedSignature {
+    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = &'a u8;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { (*self).iter() }
+}
+
+/// An ECDSA signature-related error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Hex decoding error.
+    Hex(hex::HexToBytesError),
+    /// Non-standard sighash type.
+    SighashType(NonStandardSighashTypeError),
+    /// Signature was empty.
+    EmptySignature,
+    /// A secp256k1 error.
+    Secp256k1(secp256k1::Error),
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            Hex(ref e) => write_err!(f, "signature hex decoding error"; e),
+            SighashType(ref e) => write_err!(f, "non-standard signature hash type"; e),
+            EmptySignature => write!(f, "empty ECDSA signature"),
+            Secp256k1(ref e) => write_err!(f, "secp256k1"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            Hex(ref e) => Some(e),
+            Secp256k1(ref e) => Some(e),
+            SighashType(ref e) => Some(e),
+            EmptySignature => None,
+        }
+    }
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
+}
+
+impl From<NonStandardSighashTypeError> for Error {
+    fn from(e: NonStandardSighashTypeError) -> Self { Self::SighashType(e) }
+}
+
+impl From<hex::HexToBytesError> for Error {
+    fn from(e: hex::HexToBytesError) -> Self { Self::Hex(e) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_serialized_signature() {
+        let hex = "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45";
+        let sig = Signature {
+            signature: secp256k1::ecdsa::Signature::from_str(hex).unwrap(),
+            sighash_type: EcdsaSighashType::All,
+        };
+
+        let mut buf = vec![];
+        sig.serialize_to_writer(&mut buf).expect("write failed");
+
+        assert_eq!(sig.to_vec(), buf)
+    }
+}

--- a/libs/bitcoin/src/crypto/key.rs
+++ b/libs/bitcoin/src/crypto/key.rs
@@ -1,0 +1,1535 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin keys.
+//!
+//! This module provides keys used in Bitcoin that can be roundtrip
+//! (de)serialized.
+
+use core::fmt::{self, Write as _};
+use core::ops;
+use core::str::FromStr;
+
+use hashes::{hash160, Hash};
+use hex::{FromHex, HexToArrayError};
+use internals::array_vec::ArrayVec;
+use internals::write_err;
+use io::{Read, Write};
+
+use crate::blockdata::script::ScriptBuf;
+use crate::crypto::ecdsa;
+use crate::internal_macros::impl_asref_push_bytes;
+use crate::network::NetworkKind;
+use crate::prelude::*;
+use crate::taproot::{TapNodeHash, TapTweakHash};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+pub use secp256k1::{constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
+
+#[cfg(feature = "rand-std")]
+pub use secp256k1::rand;
+
+/// A Bitcoin ECDSA public key
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PublicKey {
+    /// Whether this public key should be serialized as compressed
+    pub compressed: bool,
+    /// The actual ECDSA key
+    pub inner: secp256k1::PublicKey,
+}
+
+impl PublicKey {
+    /// Constructs compressed ECDSA public key from the provided generic Secp256k1 public key
+    pub fn new(key: impl Into<secp256k1::PublicKey>) -> PublicKey {
+        PublicKey { compressed: true, inner: key.into() }
+    }
+
+    /// Constructs uncompressed (legacy) ECDSA public key from the provided generic Secp256k1
+    /// public key
+    pub fn new_uncompressed(key: impl Into<secp256k1::PublicKey>) -> PublicKey {
+        PublicKey { compressed: false, inner: key.into() }
+    }
+
+    fn with_serialized<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        if self.compressed {
+            f(&self.inner.serialize())
+        } else {
+            f(&self.inner.serialize_uncompressed())
+        }
+    }
+
+    /// Returns bitcoin 160-bit hash of the public key
+    pub fn pubkey_hash(&self) -> PubkeyHash { self.with_serialized(PubkeyHash::hash) }
+
+    /// Returns bitcoin 160-bit hash of the public key for witness program
+    pub fn wpubkey_hash(&self) -> Result<WPubkeyHash, UncompressedPublicKeyError> {
+        if self.compressed {
+            Ok(WPubkeyHash::from_byte_array(
+                hash160::Hash::hash(&self.inner.serialize()).to_byte_array(),
+            ))
+        } else {
+            Err(UncompressedPublicKeyError)
+        }
+    }
+
+    /// Returns the script code used to spend a P2WPKH input.
+    pub fn p2wpkh_script_code(&self) -> Result<ScriptBuf, UncompressedPublicKeyError> {
+        let key = CompressedPublicKey::try_from(*self)?;
+        Ok(key.p2wpkh_script_code())
+    }
+
+    /// Write the public key into a writer
+    pub fn write_into<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.with_serialized(|bytes| writer.write_all(bytes))
+    }
+
+    /// Read the public key from a reader
+    ///
+    /// This internally reads the first byte before reading the rest, so
+    /// use of a `BufReader` is recommended.
+    pub fn read_from<R: Read + ?Sized>(reader: &mut R) -> Result<Self, io::Error> {
+        let mut bytes = [0; 65];
+
+        reader.read_exact(&mut bytes[0..1])?;
+        let bytes = if bytes[0] < 4 { &mut bytes[..33] } else { &mut bytes[..65] };
+
+        reader.read_exact(&mut bytes[1..])?;
+        Self::from_slice(bytes).map_err(|e| {
+            // Need a static string for no-std io
+            #[cfg(feature = "std")]
+            let reason = e;
+            #[cfg(not(feature = "std"))]
+            let reason = match e {
+                FromSliceError::Secp256k1(_) => "secp256k1 error",
+                FromSliceError::InvalidKeyPrefix(_) => "invalid key prefix",
+                FromSliceError::InvalidLength(_) => "invalid length",
+            };
+            io::Error::new(io::ErrorKind::InvalidData, reason)
+        })
+    }
+
+    /// Serialize the public key to bytes
+    pub fn to_bytes(self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.write_into(&mut buf).expect("vecs don't error");
+        buf
+    }
+
+    /// Serialize the public key into a `SortKey`.
+    ///
+    /// `SortKey` is not too useful by itself, but it can be used to sort a
+    /// `[PublicKey]` slice using `sort_unstable_by_key`, `sort_by_cached_key`,
+    /// `sort_by_key`, or any of the other `*_by_key` methods on slice.
+    /// Pass the method into the sort method directly. (ie. `PublicKey::to_sort_key`)
+    ///
+    /// This method of sorting is in line with Bitcoin Core's implementation of
+    /// sorting keys for output descriptors such as `sortedmulti()`.
+    ///
+    /// If every `PublicKey` in the slice is `compressed == true` then this will sort
+    /// the keys in a
+    /// [BIP67](https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki)
+    /// compliant way.
+    ///
+    /// # Example: Using with `sort_unstable_by_key`
+    ///
+    /// ```rust
+    /// use std::str::FromStr;
+    /// use bitcoin::PublicKey;
+    ///
+    /// let pk = |s| PublicKey::from_str(s).unwrap();
+    ///
+    /// let mut unsorted = [
+    ///     pk("04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc38e98ac269ffe028345c31ac8d0a365f29c8f7e7cfccac72f84e1acd02bc554f35"),
+    ///     pk("038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354"),
+    ///     pk("028bde91b10013e08949a318018fedbd896534a549a278e220169ee2a36517c7aa"),
+    ///     pk("04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc3816753d96001fd7cba3ce5372f5c9a0d63708183033538d07b1e532fc43aaacfa"),
+    ///     pk("032b8324c93575034047a52e9bca05a46d8347046b91a032eff07d5de8d3f2730b"),
+    ///     pk("045d753414fa292ea5b8f56e39cfb6a0287b2546231a5cb05c4b14ab4b463d171f5128148985b23eccb1e2905374873b1f09b9487f47afa6b1f2b0083ac8b4f7e8"),
+    ///     pk("0234dd69c56c36a41230d573d68adeae0030c9bc0bf26f24d3e1b64c604d293c68"),
+    /// ];
+    /// let sorted = [
+    ///     // These first 4 keys are in a BIP67 compatible sorted order
+    ///     // (since they are compressed)
+    ///     pk("0234dd69c56c36a41230d573d68adeae0030c9bc0bf26f24d3e1b64c604d293c68"),
+    ///     pk("028bde91b10013e08949a318018fedbd896534a549a278e220169ee2a36517c7aa"),
+    ///     pk("032b8324c93575034047a52e9bca05a46d8347046b91a032eff07d5de8d3f2730b"),
+    ///     pk("038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354"),
+    ///     // Uncompressed keys are not BIP67 compliant, but are sorted
+    ///     // after compressed keys in Bitcoin Core using `sortedmulti()`
+    ///     pk("045d753414fa292ea5b8f56e39cfb6a0287b2546231a5cb05c4b14ab4b463d171f5128148985b23eccb1e2905374873b1f09b9487f47afa6b1f2b0083ac8b4f7e8"),
+    ///     pk("04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc3816753d96001fd7cba3ce5372f5c9a0d63708183033538d07b1e532fc43aaacfa"),
+    ///     pk("04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc38e98ac269ffe028345c31ac8d0a365f29c8f7e7cfccac72f84e1acd02bc554f35"),
+    /// ];
+    ///
+    /// unsorted.sort_unstable_by_key(|k| PublicKey::to_sort_key(*k));
+    ///
+    /// assert_eq!(unsorted, sorted);
+    /// ```
+    pub fn to_sort_key(self) -> SortKey {
+        if self.compressed {
+            let buf = ArrayVec::from_slice(&self.inner.serialize());
+            SortKey(buf)
+        } else {
+            let buf = ArrayVec::from_slice(&self.inner.serialize_uncompressed());
+            SortKey(buf)
+        }
+    }
+
+    /// Deserialize a public key from a slice
+    pub fn from_slice(data: &[u8]) -> Result<PublicKey, FromSliceError> {
+        let compressed = match data.len() {
+            33 => true,
+            65 => false,
+            len => {
+                return Err(FromSliceError::InvalidLength(len));
+            }
+        };
+
+        if !compressed && data[0] != 0x04 {
+            return Err(FromSliceError::InvalidKeyPrefix(data[0]));
+        }
+
+        Ok(PublicKey { compressed, inner: secp256k1::PublicKey::from_slice(data)? })
+    }
+
+    /// Computes the public key as supposed to be used with this secret
+    pub fn from_private_key<C: secp256k1::Signing>(
+        secp: &Secp256k1<C>,
+        sk: &PrivateKey,
+    ) -> PublicKey {
+        sk.public_key(secp)
+    }
+
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
+    pub fn verify<C: secp256k1::Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        msg: &secp256k1::Message,
+        sig: &ecdsa::Signature,
+    ) -> Result<(), secp256k1::Error> {
+        secp.verify_ecdsa(msg, &sig.signature, &self.inner)
+    }
+}
+
+impl From<secp256k1::PublicKey> for PublicKey {
+    fn from(pk: secp256k1::PublicKey) -> PublicKey { PublicKey::new(pk) }
+}
+
+impl From<PublicKey> for XOnlyPublicKey {
+    fn from(pk: PublicKey) -> XOnlyPublicKey { pk.inner.into() }
+}
+
+/// An opaque return type for PublicKey::to_sort_key
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct SortKey(ArrayVec<u8, 65>);
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.with_serialized(|bytes| fmt::Display::fmt(&bytes.as_hex(), f))
+    }
+}
+
+impl FromStr for PublicKey {
+    type Err = ParsePublicKeyError;
+    fn from_str(s: &str) -> Result<PublicKey, ParsePublicKeyError> {
+        use HexToArrayError::*;
+
+        match s.len() {
+            66 => {
+                let bytes = <[u8; 33]>::from_hex(s).map_err(|e| match e {
+                    InvalidChar(e) => ParsePublicKeyError::InvalidChar(e.invalid_char()),
+                    InvalidLength(_) => unreachable!("length checked already"),
+                })?;
+                Ok(PublicKey::from_slice(&bytes)?)
+            }
+            130 => {
+                let bytes = <[u8; 65]>::from_hex(s).map_err(|e| match e {
+                    InvalidChar(e) => ParsePublicKeyError::InvalidChar(e.invalid_char()),
+                    InvalidLength(_) => unreachable!("length checked already"),
+                })?;
+                Ok(PublicKey::from_slice(&bytes)?)
+            }
+            len => Err(ParsePublicKeyError::InvalidHexLength(len)),
+        }
+    }
+}
+
+hashes::hash_newtype! {
+    /// A hash of a public key.
+    pub struct PubkeyHash(hash160::Hash);
+    /// SegWit version of a public key hash.
+    pub struct WPubkeyHash(hash160::Hash);
+}
+impl_asref_push_bytes!(PubkeyHash, WPubkeyHash);
+
+impl From<PublicKey> for PubkeyHash {
+    fn from(key: PublicKey) -> PubkeyHash { key.pubkey_hash() }
+}
+
+impl From<&PublicKey> for PubkeyHash {
+    fn from(key: &PublicKey) -> PubkeyHash { key.pubkey_hash() }
+}
+
+/// An always-compressed Bitcoin ECDSA public key
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CompressedPublicKey(pub secp256k1::PublicKey);
+
+impl CompressedPublicKey {
+    /// Returns bitcoin 160-bit hash of the public key
+    pub fn pubkey_hash(&self) -> PubkeyHash { PubkeyHash::hash(&self.to_bytes()) }
+
+    /// Returns bitcoin 160-bit hash of the public key for witness program
+    pub fn wpubkey_hash(&self) -> WPubkeyHash {
+        WPubkeyHash::from_byte_array(hash160::Hash::hash(&self.to_bytes()).to_byte_array())
+    }
+
+    /// Returns the script code used to spend a P2WPKH input.
+    pub fn p2wpkh_script_code(&self) -> ScriptBuf {
+        ScriptBuf::p2wpkh_script_code(self.wpubkey_hash())
+    }
+
+    /// Write the public key into a writer
+    pub fn write_into<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(&self.to_bytes())
+    }
+
+    /// Read the public key from a reader
+    ///
+    /// This internally reads the first byte before reading the rest, so
+    /// use of a `BufReader` is recommended.
+    pub fn read_from<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, io::Error> {
+        let mut bytes = [0; 33];
+
+        reader.read_exact(&mut bytes)?;
+        #[allow(unused_variables)] // e when std not enabled
+        Self::from_slice(&bytes).map_err(|e| {
+            // Need a static string for no-std io
+            #[cfg(feature = "std")]
+            let reason = e;
+            #[cfg(not(feature = "std"))]
+            let reason = "secp256k1 error";
+            io::Error::new(io::ErrorKind::InvalidData, reason)
+        })
+    }
+
+    /// Serializes the public key.
+    ///
+    /// As the type name suggests, the key is serialzied in compressed format.
+    ///
+    /// Note that this can be used as a sort key to get BIP67-compliant sorting.
+    /// That's why this type doesn't have the `to_sort_key` method - it would duplicate this one.
+    pub fn to_bytes(&self) -> [u8; 33] { self.0.serialize() }
+
+    /// Deserialize a public key from a slice
+    pub fn from_slice(data: &[u8]) -> Result<Self, secp256k1::Error> {
+        secp256k1::PublicKey::from_slice(data).map(CompressedPublicKey)
+    }
+
+    /// Computes the public key as supposed to be used with this secret
+    pub fn from_private_key<C: secp256k1::Signing>(
+        secp: &Secp256k1<C>,
+        sk: &PrivateKey,
+    ) -> Result<Self, UncompressedPublicKeyError> {
+        sk.public_key(secp).try_into()
+    }
+
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
+    pub fn verify<C: secp256k1::Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        msg: &secp256k1::Message,
+        sig: &ecdsa::Signature,
+    ) -> Result<(), secp256k1::Error> {
+        Ok(secp.verify_ecdsa(msg, &sig.signature, &self.0)?)
+    }
+}
+
+impl fmt::Display for CompressedPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_bytes().as_hex(), f)
+    }
+}
+
+impl FromStr for CompressedPublicKey {
+    type Err = ParseCompressedPublicKeyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        CompressedPublicKey::from_slice(&<[u8; 33]>::from_hex(s)?).map_err(Into::into)
+    }
+}
+
+impl TryFrom<PublicKey> for CompressedPublicKey {
+    type Error = UncompressedPublicKeyError;
+
+    fn try_from(value: PublicKey) -> Result<Self, Self::Error> {
+        if value.compressed {
+            Ok(CompressedPublicKey(value.inner))
+        } else {
+            Err(UncompressedPublicKeyError)
+        }
+    }
+}
+
+impl From<CompressedPublicKey> for PublicKey {
+    fn from(value: CompressedPublicKey) -> Self { PublicKey::new(value.0) }
+}
+
+impl From<CompressedPublicKey> for XOnlyPublicKey {
+    fn from(pk: CompressedPublicKey) -> Self { pk.0.into() }
+}
+
+impl From<CompressedPublicKey> for PubkeyHash {
+    fn from(key: CompressedPublicKey) -> Self { key.pubkey_hash() }
+}
+
+impl From<&CompressedPublicKey> for PubkeyHash {
+    fn from(key: &CompressedPublicKey) -> Self { key.pubkey_hash() }
+}
+
+impl From<CompressedPublicKey> for WPubkeyHash {
+    fn from(key: CompressedPublicKey) -> Self { key.wpubkey_hash() }
+}
+
+impl From<&CompressedPublicKey> for WPubkeyHash {
+    fn from(key: &CompressedPublicKey) -> Self { key.wpubkey_hash() }
+}
+
+/// A Bitcoin ECDSA private key
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PrivateKey {
+    /// Whether this private key should be serialized as compressed
+    pub compressed: bool,
+    /// The network kind on which this key should be used
+    pub network: NetworkKind,
+    /// The actual ECDSA key
+    pub inner: secp256k1::SecretKey,
+}
+
+impl PrivateKey {
+    /// Constructs new compressed ECDSA private key using the secp256k1 algorithm and
+    /// a secure random number generator.
+    #[cfg(feature = "rand-std")]
+    pub fn generate(network: impl Into<NetworkKind>) -> PrivateKey {
+        let secret_key = secp256k1::SecretKey::new(&mut rand::thread_rng());
+        PrivateKey::new(secret_key, network.into())
+    }
+    /// Constructs compressed ECDSA private key from the provided generic Secp256k1 private key
+    /// and the specified network
+    pub fn new(key: secp256k1::SecretKey, network: impl Into<NetworkKind>) -> PrivateKey {
+        PrivateKey { compressed: true, network: network.into(), inner: key }
+    }
+
+    /// Constructs uncompressed (legacy) ECDSA private key from the provided generic Secp256k1
+    /// private key and the specified network
+    pub fn new_uncompressed(
+        key: secp256k1::SecretKey,
+        network: impl Into<NetworkKind>,
+    ) -> PrivateKey {
+        PrivateKey { compressed: false, network: network.into(), inner: key }
+    }
+
+    /// Creates a public key from this private key
+    pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> PublicKey {
+        PublicKey {
+            compressed: self.compressed,
+            inner: secp256k1::PublicKey::from_secret_key(secp, &self.inner),
+        }
+    }
+
+    /// Serialize the private key to bytes
+    pub fn to_bytes(self) -> Vec<u8> { self.inner[..].to_vec() }
+
+    /// Deserialize a private key from a slice
+    pub fn from_slice(
+        data: &[u8],
+        network: impl Into<NetworkKind>,
+    ) -> Result<PrivateKey, secp256k1::Error> {
+        Ok(PrivateKey::new(secp256k1::SecretKey::from_slice(data)?, network))
+    }
+
+    /// Format the private key to WIF format.
+    #[rustfmt::skip]
+    pub fn fmt_wif(&self, fmt: &mut dyn fmt::Write) -> fmt::Result {
+        let mut ret = [0; 34];
+        ret[0] = if self.network.is_mainnet() { 128 } else { 239 };
+
+        ret[1..33].copy_from_slice(&self.inner[..]);
+        let privkey = if self.compressed {
+            ret[33] = 1;
+            base58::encode_check(&ret[..])
+        } else {
+            base58::encode_check(&ret[..33])
+        };
+        fmt.write_str(&privkey)
+    }
+
+    /// Get WIF encoding of this private key.
+    pub fn to_wif(self) -> String {
+        let mut buf = String::new();
+        buf.write_fmt(format_args!("{}", self)).unwrap();
+        buf.shrink_to_fit();
+        buf
+    }
+
+    /// Parse WIF encoded private key.
+    pub fn from_wif(wif: &str) -> Result<PrivateKey, FromWifError> {
+        let data = base58::decode_check(wif)?;
+
+        let compressed = match data.len() {
+            33 => false,
+            34 => true,
+            length => {
+                return Err(InvalidBase58PayloadLengthError { length }.into());
+            }
+        };
+
+        let network = match data[0] {
+            128 => NetworkKind::Main,
+            239 => NetworkKind::Test,
+            invalid => {
+                return Err(InvalidAddressVersionError { invalid }.into());
+            }
+        };
+
+        Ok(PrivateKey {
+            compressed,
+            network,
+            inner: secp256k1::SecretKey::from_slice(&data[1..33])?,
+        })
+    }
+}
+
+impl fmt::Display for PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_wif(f) }
+}
+
+impl FromStr for PrivateKey {
+    type Err = FromWifError;
+    fn from_str(s: &str) -> Result<PrivateKey, FromWifError> { PrivateKey::from_wif(s) }
+}
+
+impl ops::Index<ops::RangeFull> for PrivateKey {
+    type Output = [u8];
+    fn index(&self, _: ops::RangeFull) -> &[u8] { &self.inner[..] }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for PrivateKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PrivateKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<PrivateKey, D::Error> {
+        struct WifVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for WifVisitor {
+            type Value = PrivateKey;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("an ASCII WIF string")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if let Ok(s) = core::str::from_utf8(v) {
+                    PrivateKey::from_str(s).map_err(E::custom)
+                } else {
+                    Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
+                }
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                PrivateKey::from_str(v).map_err(E::custom)
+            }
+        }
+
+        d.deserialize_str(WifVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[allow(clippy::collapsible_else_if)] // Aids readability.
+impl serde::Serialize for PublicKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if s.is_human_readable() {
+            s.collect_str(self)
+        } else {
+            self.with_serialized(|bytes| s.serialize_bytes(bytes))
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PublicKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<PublicKey, D::Error> {
+        if d.is_human_readable() {
+            struct HexVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for HexVisitor {
+                type Value = PublicKey;
+
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("an ASCII hex string")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    if let Ok(hex) = core::str::from_utf8(v) {
+                        PublicKey::from_str(hex).map_err(E::custom)
+                    } else {
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
+                    }
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    PublicKey::from_str(v).map_err(E::custom)
+                }
+            }
+            d.deserialize_str(HexVisitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = PublicKey;
+
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("a bytestring")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    PublicKey::from_slice(v).map_err(E::custom)
+                }
+            }
+
+            d.deserialize_bytes(BytesVisitor)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for CompressedPublicKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if s.is_human_readable() {
+            s.collect_str(self)
+        } else {
+            s.serialize_bytes(&self.to_bytes())
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for CompressedPublicKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        if d.is_human_readable() {
+            struct HexVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for HexVisitor {
+                type Value = CompressedPublicKey;
+
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("a 66 digits long ASCII hex string")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    if let Ok(hex) = core::str::from_utf8(v) {
+                        CompressedPublicKey::from_str(hex).map_err(E::custom)
+                    } else {
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
+                    }
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    CompressedPublicKey::from_str(v).map_err(E::custom)
+                }
+            }
+            d.deserialize_str(HexVisitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = CompressedPublicKey;
+
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("a bytestring")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    CompressedPublicKey::from_slice(v).map_err(E::custom)
+                }
+            }
+
+            d.deserialize_bytes(BytesVisitor)
+        }
+    }
+}
+/// Untweaked BIP-340 X-coord-only public key
+pub type UntweakedPublicKey = XOnlyPublicKey;
+
+/// Tweaked BIP-340 X-coord-only public key
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct TweakedPublicKey(XOnlyPublicKey);
+
+impl fmt::LowerHex for TweakedPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
+}
+
+impl fmt::Display for TweakedPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+/// Untweaked BIP-340 key pair
+pub type UntweakedKeypair = Keypair;
+
+/// Tweaked BIP-340 key pair
+///
+/// # Examples
+/// ```
+/// # #[cfg(feature = "rand-std")] {
+/// # use bitcoin::key::{Keypair, TweakedKeypair, TweakedPublicKey};
+/// # use bitcoin::secp256k1::{rand, Secp256k1};
+/// # let secp = Secp256k1::new();
+/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(Keypair::new(&secp, &mut rand::thread_rng()));
+/// // There are various conversion methods available to get a tweaked pubkey from a tweaked keypair.
+/// let (_pk, _parity) = keypair.public_parts();
+/// let _pk  = TweakedPublicKey::from_keypair(keypair);
+/// let _pk = TweakedPublicKey::from(keypair);
+/// # }
+/// ```
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct TweakedKeypair(Keypair);
+
+/// A trait for tweaking BIP340 key types (x-only public keys and key pairs).
+pub trait TapTweak {
+    /// Tweaked key type with optional auxiliary information
+    type TweakedAux;
+    /// Tweaked key type
+    type TweakedKey;
+
+    /// Tweaks an untweaked key with corresponding public key value and optional script tree merkle
+    /// root. For the [`Keypair`] type this also tweaks the private key in the pair.
+    ///
+    /// This is done by using the equation Q = P + H(P|c)G, where
+    ///  * Q is the tweaked public key
+    ///  * P is the internal public key
+    ///  * H is the hash function
+    ///  * c is the commitment data
+    ///  * G is the generator point
+    ///
+    /// # Returns
+    /// The tweaked key and its parity.
+    fn tap_tweak<C: Verification>(
+        self,
+        secp: &Secp256k1<C>,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self::TweakedAux;
+
+    /// Directly converts an [`UntweakedPublicKey`] to a [`TweakedPublicKey`]
+    ///
+    /// This method is dangerous and can lead to loss of funds if used incorrectly.
+    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
+    fn dangerous_assume_tweaked(self) -> Self::TweakedKey;
+}
+
+impl TapTweak for UntweakedPublicKey {
+    type TweakedAux = (TweakedPublicKey, Parity);
+    type TweakedKey = TweakedPublicKey;
+
+    /// Tweaks an untweaked public key with corresponding public key value and optional script tree
+    /// merkle root.
+    ///
+    /// This is done by using the equation Q = P + H(P|c)G, where
+    ///  * Q is the tweaked public key
+    ///  * P is the internal public key
+    ///  * H is the hash function
+    ///  * c is the commitment data
+    ///  * G is the generator point
+    ///
+    /// # Returns
+    /// The tweaked key and its parity.
+    fn tap_tweak<C: Verification>(
+        self,
+        secp: &Secp256k1<C>,
+        merkle_root: Option<TapNodeHash>,
+    ) -> (TweakedPublicKey, Parity) {
+        let tweak = TapTweakHash::from_key_and_tweak(self, merkle_root).to_scalar();
+        let (output_key, parity) = self.add_tweak(secp, &tweak).expect("Tap tweak failed");
+
+        debug_assert!(self.tweak_add_check(secp, &output_key, parity, tweak));
+        (TweakedPublicKey(output_key), parity)
+    }
+
+    fn dangerous_assume_tweaked(self) -> TweakedPublicKey { TweakedPublicKey(self) }
+}
+
+impl TapTweak for UntweakedKeypair {
+    type TweakedAux = TweakedKeypair;
+    type TweakedKey = TweakedKeypair;
+
+    /// Tweaks private and public keys within an untweaked [`Keypair`] with corresponding public key
+    /// value and optional script tree merkle root.
+    ///
+    /// This is done by tweaking private key within the pair using the equation q = p + H(P|c), where
+    ///  * q is the tweaked private key
+    ///  * p is the internal private key
+    ///  * H is the hash function
+    ///  * c is the commitment data
+    ///
+    /// The public key is generated from a private key by multiplying with generator point, Q = qG.
+    ///
+    /// # Returns
+    ///
+    /// The tweaked key and its parity.
+    fn tap_tweak<C: Verification>(
+        self,
+        secp: &Secp256k1<C>,
+        merkle_root: Option<TapNodeHash>,
+    ) -> TweakedKeypair {
+        let (pubkey, _parity) = XOnlyPublicKey::from_keypair(&self);
+        let tweak = TapTweakHash::from_key_and_tweak(pubkey, merkle_root).to_scalar();
+        let tweaked = self.add_xonly_tweak(secp, &tweak).expect("Tap tweak failed");
+        TweakedKeypair(tweaked)
+    }
+
+    fn dangerous_assume_tweaked(self) -> TweakedKeypair { TweakedKeypair(self) }
+}
+
+impl TweakedPublicKey {
+    /// Returns the [`TweakedPublicKey`] for `keypair`.
+    #[inline]
+    pub fn from_keypair(keypair: TweakedKeypair) -> Self {
+        let (xonly, _parity) = keypair.0.x_only_public_key();
+        TweakedPublicKey(xonly)
+    }
+
+    /// Creates a new [`TweakedPublicKey`] from a [`XOnlyPublicKey`]. No tweak is applied, consider
+    /// calling `tap_tweak` on an [`UntweakedPublicKey`] instead of using this constructor.
+    ///
+    /// This method is dangerous and can lead to loss of funds if used incorrectly.
+    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
+    #[inline]
+    pub fn dangerous_assume_tweaked(key: XOnlyPublicKey) -> TweakedPublicKey {
+        TweakedPublicKey(key)
+    }
+
+    /// Returns the underlying public key.
+    pub fn to_inner(self) -> XOnlyPublicKey { self.0 }
+
+    /// Serialize the key as a byte-encoded pair of values. In compressed form
+    /// the y-coordinate is represented by only a single bit, as x determines
+    /// it up to one bit.
+    #[inline]
+    pub fn serialize(&self) -> [u8; constants::SCHNORR_PUBLIC_KEY_SIZE] { self.0.serialize() }
+}
+
+impl TweakedKeypair {
+    /// Creates a new [`TweakedKeypair`] from a [`Keypair`]. No tweak is applied, consider
+    /// calling `tap_tweak` on an [`UntweakedKeypair`] instead of using this constructor.
+    ///
+    /// This method is dangerous and can lead to loss of funds if used incorrectly.
+    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
+    #[inline]
+    pub fn dangerous_assume_tweaked(pair: Keypair) -> TweakedKeypair { TweakedKeypair(pair) }
+
+    /// Returns the underlying key pair.
+    #[inline]
+    pub fn to_inner(self) -> Keypair { self.0 }
+
+    /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeypair`].
+    #[inline]
+    pub fn public_parts(&self) -> (TweakedPublicKey, Parity) {
+        let (xonly, parity) = self.0.x_only_public_key();
+        (TweakedPublicKey(xonly), parity)
+    }
+}
+
+impl From<TweakedPublicKey> for XOnlyPublicKey {
+    #[inline]
+    fn from(pair: TweakedPublicKey) -> Self { pair.0 }
+}
+
+impl From<TweakedKeypair> for Keypair {
+    #[inline]
+    fn from(pair: TweakedKeypair) -> Self { pair.0 }
+}
+
+impl From<TweakedKeypair> for TweakedPublicKey {
+    #[inline]
+    fn from(pair: TweakedKeypair) -> Self { TweakedPublicKey::from_keypair(pair) }
+}
+
+/// Error returned while generating key from slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FromSliceError {
+    /// Invalid key prefix error.
+    InvalidKeyPrefix(u8),
+    /// A Secp256k1 error.
+    Secp256k1(secp256k1::Error),
+    /// Invalid Length of the slice.
+    InvalidLength(usize),
+}
+
+internals::impl_from_infallible!(FromSliceError);
+
+impl fmt::Display for FromSliceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FromSliceError::*;
+
+        match self {
+            Secp256k1(e) => write_err!(f, "secp256k1"; e),
+            InvalidKeyPrefix(b) => write!(f, "key prefix invalid: {}", b),
+            InvalidLength(got) => write!(f, "slice length should be 33 or 65 bytes, got: {}", got),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromSliceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromSliceError::*;
+
+        match *self {
+            Secp256k1(ref e) => Some(e),
+            InvalidKeyPrefix(_) | InvalidLength(_) => None,
+        }
+    }
+}
+
+impl From<secp256k1::Error> for FromSliceError {
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
+}
+
+/// Error generated from WIF key format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FromWifError {
+    /// A base58 decoding error.
+    Base58(base58::Error),
+    /// Base58 decoded data was an invalid length.
+    InvalidBase58PayloadLength(InvalidBase58PayloadLengthError),
+    /// Base58 decoded data contained an invalid address version byte.
+    InvalidAddressVersion(InvalidAddressVersionError),
+    /// A secp256k1 error.
+    Secp256k1(secp256k1::Error),
+}
+
+internals::impl_from_infallible!(FromWifError);
+
+impl fmt::Display for FromWifError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FromWifError::*;
+
+        match *self {
+            Base58(ref e) => write_err!(f, "invalid base58"; e),
+            InvalidBase58PayloadLength(ref e) =>
+                write_err!(f, "decoded base58 data was an invalid length"; e),
+            InvalidAddressVersion(ref e) =>
+                write_err!(f, "decoded base58 data contained an invalid address version btye"; e),
+            Secp256k1(ref e) => write_err!(f, "private key validation failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromWifError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromWifError::*;
+
+        match *self {
+            Base58(ref e) => Some(e),
+            InvalidBase58PayloadLength(ref e) => Some(e),
+            InvalidAddressVersion(ref e) => Some(e),
+            Secp256k1(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<base58::Error> for FromWifError {
+    fn from(e: base58::Error) -> Self { Self::Base58(e) }
+}
+
+impl From<secp256k1::Error> for FromWifError {
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
+}
+
+impl From<InvalidBase58PayloadLengthError> for FromWifError {
+    fn from(e: InvalidBase58PayloadLengthError) -> FromWifError {
+        Self::InvalidBase58PayloadLength(e)
+    }
+}
+
+impl From<InvalidAddressVersionError> for FromWifError {
+    fn from(e: InvalidAddressVersionError) -> FromWifError { Self::InvalidAddressVersion(e) }
+}
+
+/// Error returned while constructing public key from string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsePublicKeyError {
+    /// Error originated while parsing string.
+    Encoding(FromSliceError),
+    /// Hex decoding error.
+    InvalidChar(u8),
+    /// `PublicKey` hex should be 66 or 130 digits long.
+    InvalidHexLength(usize),
+}
+
+internals::impl_from_infallible!(ParsePublicKeyError);
+
+impl fmt::Display for ParsePublicKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParsePublicKeyError::*;
+        match self {
+            Encoding(e) => write_err!(f, "string error"; e),
+            InvalidChar(char) => write!(f, "hex error {}", char),
+            InvalidHexLength(got) =>
+                write!(f, "pubkey string should be 66 or 130 digits long, got: {}", got),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParsePublicKeyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ParsePublicKeyError::*;
+
+        match self {
+            Encoding(e) => Some(e),
+            InvalidChar(_) | InvalidHexLength(_) => None,
+        }
+    }
+}
+
+impl From<FromSliceError> for ParsePublicKeyError {
+    fn from(e: FromSliceError) -> Self { Self::Encoding(e) }
+}
+
+/// Error returned when parsing a [`CompressedPublicKey`] from a string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseCompressedPublicKeyError {
+    /// Secp256k1 Error.
+    Secp256k1(secp256k1::Error),
+    /// hex to array conversion error.
+    Hex(hex::HexToArrayError),
+}
+
+internals::impl_from_infallible!(ParseCompressedPublicKeyError);
+
+impl fmt::Display for ParseCompressedPublicKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParseCompressedPublicKeyError::*;
+        match self {
+            Secp256k1(e) => write_err!(f, "secp256k1 error"; e),
+            Hex(e) => write_err!(f, "invalid hex"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseCompressedPublicKeyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ParseCompressedPublicKeyError::*;
+
+        match self {
+            Secp256k1(e) => Some(e),
+            Hex(e) => Some(e),
+        }
+    }
+}
+
+impl From<secp256k1::Error> for ParseCompressedPublicKeyError {
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
+}
+
+impl From<hex::HexToArrayError> for ParseCompressedPublicKeyError {
+    fn from(e: hex::HexToArrayError) -> Self { Self::Hex(e) }
+}
+
+/// Segwit public keys must always be compressed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UncompressedPublicKeyError;
+
+impl fmt::Display for UncompressedPublicKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("segwit public keys must always be compressed")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UncompressedPublicKeyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// Decoded base58 data was an invalid length.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidBase58PayloadLengthError {
+    /// The base58 payload length we got after decoding WIF string.
+    pub(crate) length: usize,
+}
+
+impl InvalidBase58PayloadLengthError {
+    /// Returns the invalid payload length.
+    pub fn invalid_base58_payload_length(&self) -> usize { self.length }
+}
+
+impl fmt::Display for InvalidBase58PayloadLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "decoded base58 data was an invalid length: {} (expected 33 or 34)", self.length)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidBase58PayloadLengthError {}
+
+/// Invalid address version in decoded base58 data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidAddressVersionError {
+    /// The invalid version.
+    pub(crate) invalid: u8,
+}
+
+impl InvalidAddressVersionError {
+    /// Returns the invalid version.
+    pub fn invalid_address_version(&self) -> u8 { self.invalid }
+}
+
+impl fmt::Display for InvalidAddressVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid address version in decoded base58 data {}", self.invalid)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidAddressVersionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::address::Address;
+
+    #[test]
+    fn test_key_derivation() {
+        // testnet compressed
+        let sk =
+            PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        assert_eq!(sk.network, NetworkKind::Test);
+        assert!(sk.compressed);
+        assert_eq!(&sk.to_wif(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
+
+        let secp = Secp256k1::new();
+        let pk = Address::p2pkh(sk.public_key(&secp), sk.network);
+        assert_eq!(&pk.to_string(), "mqwpxxvfv3QbM8PU8uBx2jaNt9btQqvQNx");
+
+        // test string conversion
+        assert_eq!(&sk.to_string(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
+        let sk_str =
+            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        assert_eq!(&sk.to_wif(), &sk_str.to_wif());
+
+        // mainnet uncompressed
+        let sk =
+            PrivateKey::from_wif("5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3").unwrap();
+        assert_eq!(sk.network, NetworkKind::Main);
+        assert!(!sk.compressed);
+        assert_eq!(&sk.to_wif(), "5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3");
+
+        let secp = Secp256k1::new();
+        let mut pk = sk.public_key(&secp);
+        assert!(!pk.compressed);
+        assert_eq!(&pk.to_string(), "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133");
+        assert_eq!(pk, PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap());
+        let addr = Address::p2pkh(pk, sk.network);
+        assert_eq!(&addr.to_string(), "1GhQvF6dL8xa6wBxLnWmHcQsurx9RxiMc8");
+        pk.compressed = true;
+        assert_eq!(
+            &pk.to_string(),
+            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+        );
+        assert_eq!(
+            pk,
+            PublicKey::from_str(
+                "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_pubkey_hash() {
+        let pk = PublicKey::from_str(
+            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
+        )
+        .unwrap();
+        let upk = PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap();
+        assert_eq!(pk.pubkey_hash().to_string(), "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4");
+        assert_eq!(upk.pubkey_hash().to_string(), "ac2e7daf42d2c97418fd9f78af2de552bb9c6a7a");
+    }
+
+    #[test]
+    fn test_wpubkey_hash() {
+        let pk = PublicKey::from_str(
+            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
+        )
+        .unwrap();
+        let upk = PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap();
+        assert_eq!(
+            pk.wpubkey_hash().unwrap().to_string(),
+            "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4"
+        );
+        assert!(upk.wpubkey_hash().is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_key_serde() {
+        use serde_test::{assert_tokens, Configure, Token};
+
+        static KEY_WIF: &str = "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy";
+        static PK_STR: &str = "039b6347398505f5ec93826dc61c19f47c66c0283ee9be980e29ce325a0f4679ef";
+        static PK_STR_U: &str = "\
+            04\
+            9b6347398505f5ec93826dc61c19f47c66c0283ee9be980e29ce325a0f4679ef\
+            87288ed73ce47fc4f5c79d19ebfa57da7cff3aff6e819e4ee971d86b5e61875d\
+        ";
+        #[rustfmt::skip]
+        static PK_BYTES: [u8; 33] = [
+            0x03,
+            0x9b, 0x63, 0x47, 0x39, 0x85, 0x05, 0xf5, 0xec,
+            0x93, 0x82, 0x6d, 0xc6, 0x1c, 0x19, 0xf4, 0x7c,
+            0x66, 0xc0, 0x28, 0x3e, 0xe9, 0xbe, 0x98, 0x0e,
+            0x29, 0xce, 0x32, 0x5a, 0x0f, 0x46, 0x79, 0xef,
+        ];
+        #[rustfmt::skip]
+        static PK_BYTES_U: [u8; 65] = [
+            0x04,
+            0x9b, 0x63, 0x47, 0x39, 0x85, 0x05, 0xf5, 0xec,
+            0x93, 0x82, 0x6d, 0xc6, 0x1c, 0x19, 0xf4, 0x7c,
+            0x66, 0xc0, 0x28, 0x3e, 0xe9, 0xbe, 0x98, 0x0e,
+            0x29, 0xce, 0x32, 0x5a, 0x0f, 0x46, 0x79, 0xef,
+            0x87, 0x28, 0x8e, 0xd7, 0x3c, 0xe4, 0x7f, 0xc4,
+            0xf5, 0xc7, 0x9d, 0x19, 0xeb, 0xfa, 0x57, 0xda,
+            0x7c, 0xff, 0x3a, 0xff, 0x6e, 0x81, 0x9e, 0x4e,
+            0xe9, 0x71, 0xd8, 0x6b, 0x5e, 0x61, 0x87, 0x5d,
+        ];
+
+        let s = Secp256k1::new();
+        let sk = PrivateKey::from_str(KEY_WIF).unwrap();
+        let pk = PublicKey::from_private_key(&s, &sk);
+        let pk_u = PublicKey { inner: pk.inner, compressed: false };
+
+        assert_tokens(&sk, &[Token::BorrowedStr(KEY_WIF)]);
+        assert_tokens(&pk.compact(), &[Token::BorrowedBytes(&PK_BYTES[..])]);
+        assert_tokens(&pk.readable(), &[Token::BorrowedStr(PK_STR)]);
+        assert_tokens(&pk_u.compact(), &[Token::BorrowedBytes(&PK_BYTES_U[..])]);
+        assert_tokens(&pk_u.readable(), &[Token::BorrowedStr(PK_STR_U)]);
+    }
+
+    fn random_key(mut seed: u8) -> PublicKey {
+        loop {
+            let mut data = [0; 65];
+            for byte in &mut data[..] {
+                *byte = seed;
+                // totally a rng
+                seed = seed.wrapping_mul(41).wrapping_add(43);
+            }
+            if data[0] % 2 == 0 {
+                data[0] = 4;
+                if let Ok(key) = PublicKey::from_slice(&data[..]) {
+                    return key;
+                }
+            } else {
+                data[0] = 2 + (data[0] >> 7);
+                if let Ok(key) = PublicKey::from_slice(&data[..33]) {
+                    return key;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pubkey_read_write() {
+        const N_KEYS: usize = 20;
+        let keys: Vec<_> = (0..N_KEYS).map(|i| random_key(i as u8)).collect();
+
+        let mut v = vec![];
+        for k in &keys {
+            k.write_into(&mut v).expect("writing into vec");
+        }
+
+        let mut reader = v.as_slice();
+        let mut dec_keys = vec![];
+        for _ in 0..N_KEYS {
+            dec_keys.push(PublicKey::read_from(&mut reader).expect("reading from vec"));
+        }
+        assert_eq!(keys, dec_keys);
+        assert!(PublicKey::read_from(&mut reader).is_err());
+
+        // sanity checks
+        let mut empty: &[u8] = &[];
+        assert!(PublicKey::read_from(&mut empty).is_err());
+        assert!(PublicKey::read_from(&mut &[0; 33][..]).is_err());
+        assert!(PublicKey::read_from(&mut &[2; 32][..]).is_err());
+        assert!(PublicKey::read_from(&mut &[0; 65][..]).is_err());
+        assert!(PublicKey::read_from(&mut &[4; 64][..]).is_err());
+    }
+
+    #[test]
+    fn pubkey_to_sort_key() {
+        let key1 = PublicKey::from_str(
+            "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8",
+        )
+        .unwrap();
+        let key2 = PublicKey { inner: key1.inner, compressed: false };
+        let arrayvec1 = ArrayVec::from_slice(
+            &<[u8; 33]>::from_hex(
+                "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8",
+            )
+            .unwrap(),
+        );
+        let expected1 = SortKey(arrayvec1);
+        let arrayvec2 = ArrayVec::from_slice(&<[u8; 65]>::from_hex(
+            "04ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f81794e7f3d5e420641a3bc690067df5541470c966cbca8c694bf39aa16d836918",
+        ).unwrap());
+        let expected2 = SortKey(arrayvec2);
+        assert_eq!(key1.to_sort_key(), expected1);
+        assert_eq!(key2.to_sort_key(), expected2);
+    }
+
+    #[test]
+    fn pubkey_sort() {
+        struct Vector {
+            input: Vec<PublicKey>,
+            expect: Vec<PublicKey>,
+        }
+        let fmt =
+            |v: Vec<_>| v.into_iter().map(|s| PublicKey::from_str(s).unwrap()).collect::<Vec<_>>();
+        let vectors = vec![
+            // Start BIP67 vectors
+            // Vector 1
+            Vector {
+                input: fmt(vec![
+                    "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8",
+                    "02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f",
+                ]),
+                expect: fmt(vec![
+                    "02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f",
+                    "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8",
+                ]),
+            },
+            // Vector 2 (Already sorted, no action required)
+            Vector {
+                input: fmt(vec![
+                    "02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0",
+                    "027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77",
+                    "02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404",
+                ]),
+                expect: fmt(vec![
+                    "02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0",
+                    "027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77",
+                    "02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404",
+                ]),
+            },
+            // Vector 3
+            Vector {
+                input: fmt(vec![
+                    "030000000000000000000000000000000000004141414141414141414141414141",
+                    "020000000000000000000000000000000000004141414141414141414141414141",
+                    "020000000000000000000000000000000000004141414141414141414141414140",
+                    "030000000000000000000000000000000000004141414141414141414141414140",
+                ]),
+                expect: fmt(vec![
+                    "020000000000000000000000000000000000004141414141414141414141414140",
+                    "020000000000000000000000000000000000004141414141414141414141414141",
+                    "030000000000000000000000000000000000004141414141414141414141414140",
+                    "030000000000000000000000000000000000004141414141414141414141414141",
+                ]),
+            },
+            // Vector 4: (from bitcore)
+            Vector {
+                input: fmt(vec![
+                    "022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da",
+                    "03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9",
+                    "021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18",
+                ]),
+                expect: fmt(vec![
+                    "021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18",
+                    "022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da",
+                    "03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9",
+                ]),
+            },
+            // Non-BIP67 vectors
+            Vector {
+                input: fmt(vec![
+                    "02c690d642c1310f3a1ababad94e3930e4023c930ea472e7f37f660fe485263b88",
+                    "0234dd69c56c36a41230d573d68adeae0030c9bc0bf26f24d3e1b64c604d293c68",
+                    "041a181bd0e79974bd7ca552e09fc42ba9c3d5dbb3753741d6f0ab3015dbfd9a22d6b001a32f5f51ac6f2c0f35e73a6a62f59e848fa854d3d21f3f231594eeaa46",
+                    "032b8324c93575034047a52e9bca05a46d8347046b91a032eff07d5de8d3f2730b",
+                    "04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc3816753d96001fd7cba3ce5372f5c9a0d63708183033538d07b1e532fc43aaacfa",
+                    "028e1c947c8c0b8ed021088b8e981491ac7af2b8fabebea1abdb448424c8ed75b7",
+                    "045d753414fa292ea5b8f56e39cfb6a0287b2546231a5cb05c4b14ab4b463d171f5128148985b23eccb1e2905374873b1f09b9487f47afa6b1f2b0083ac8b4f7e8",
+                    "03004a8a3d242d7957c0b60fb7208d386fa6a0193aabd1f3f095ffd0ac097e447b",
+                    "04eb0db2d71ccbb0edd8fb35092cbcae2f7fa1f06d4c170804bf52007924b569a8d2d6f6bc8fd2b3caa3253fa1bb674443743bf7fb9f94f9c0b0831a252894cfa8",
+                    "04516cde23e14f2319423b7a4a7ae48b1dadceb5e9c123198d417d10895684c42eb05e210f90ccbc72448803a22312e3f122ff2939956ccef4f7316f836295ddd5",
+                    "038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354",
+                    "04c6bec3b07586a4b085a78cbb97e9bab6f1d3c9ebf299b65dec85213c5eacd44487de86017183120bb7ea3b6c6660c5037615fe1add2a73f800cbeeae22c60438",
+                    "03e1a1cfa9eaff604ae237b7af31ffe4c01be22eb96f3da0e62c5850dd4b4386c1",
+                    "028d3a2d9f1b1c5c75845944f93bc183ba23aecde53f1978b8aa1b77661be6114f",
+                    "028bde91b10013e08949a318018fedbd896534a549a278e220169ee2a36517c7aa",
+                    "04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc38e98ac269ffe028345c31ac8d0a365f29c8f7e7cfccac72f84e1acd02bc554f35",
+                ]),
+                expect: fmt(vec![
+                    "0234dd69c56c36a41230d573d68adeae0030c9bc0bf26f24d3e1b64c604d293c68",
+                    "028bde91b10013e08949a318018fedbd896534a549a278e220169ee2a36517c7aa",
+                    "028d3a2d9f1b1c5c75845944f93bc183ba23aecde53f1978b8aa1b77661be6114f",
+                    "028e1c947c8c0b8ed021088b8e981491ac7af2b8fabebea1abdb448424c8ed75b7",
+                    "02c690d642c1310f3a1ababad94e3930e4023c930ea472e7f37f660fe485263b88",
+                    "03004a8a3d242d7957c0b60fb7208d386fa6a0193aabd1f3f095ffd0ac097e447b",
+                    "032b8324c93575034047a52e9bca05a46d8347046b91a032eff07d5de8d3f2730b",
+                    "038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354",
+                    "03e1a1cfa9eaff604ae237b7af31ffe4c01be22eb96f3da0e62c5850dd4b4386c1",
+                    "041a181bd0e79974bd7ca552e09fc42ba9c3d5dbb3753741d6f0ab3015dbfd9a22d6b001a32f5f51ac6f2c0f35e73a6a62f59e848fa854d3d21f3f231594eeaa46",
+                    "04516cde23e14f2319423b7a4a7ae48b1dadceb5e9c123198d417d10895684c42eb05e210f90ccbc72448803a22312e3f122ff2939956ccef4f7316f836295ddd5",
+                    "045d753414fa292ea5b8f56e39cfb6a0287b2546231a5cb05c4b14ab4b463d171f5128148985b23eccb1e2905374873b1f09b9487f47afa6b1f2b0083ac8b4f7e8",
+                    // These two pubkeys are mirrored. This helps verify the sort past the x value.
+                    "04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc3816753d96001fd7cba3ce5372f5c9a0d63708183033538d07b1e532fc43aaacfa",
+                    "04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc38e98ac269ffe028345c31ac8d0a365f29c8f7e7cfccac72f84e1acd02bc554f35",
+                    "04c6bec3b07586a4b085a78cbb97e9bab6f1d3c9ebf299b65dec85213c5eacd44487de86017183120bb7ea3b6c6660c5037615fe1add2a73f800cbeeae22c60438",
+                    "04eb0db2d71ccbb0edd8fb35092cbcae2f7fa1f06d4c170804bf52007924b569a8d2d6f6bc8fd2b3caa3253fa1bb674443743bf7fb9f94f9c0b0831a252894cfa8",
+                ]),
+            },
+        ];
+        for mut vector in vectors {
+            vector.input.sort_by_cached_key(|k| PublicKey::to_sort_key(*k));
+            assert_eq!(vector.input, vector.expect);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "rand-std")]
+    fn public_key_constructors() {
+        use secp256k1::rand;
+
+        let secp = Secp256k1::new();
+        let kp = Keypair::new(&secp, &mut rand::thread_rng());
+
+        let _ = PublicKey::new(kp);
+        let _ = PublicKey::new_uncompressed(kp);
+    }
+
+    #[test]
+    fn public_key_from_str_wrong_length() {
+        // Sanity checks, we accept string length 130 digits.
+        let s = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
+        assert_eq!(s.len(), 130);
+        assert!(PublicKey::from_str(s).is_ok());
+        // And 66 digits.
+        let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
+        assert_eq!(s.len(), 66);
+        assert!(PublicKey::from_str(s).is_ok());
+
+        let s = "aoeusthb";
+        assert_eq!(s.len(), 8);
+        let res = PublicKey::from_str(s);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), ParsePublicKeyError::InvalidHexLength(8));
+    }
+
+    #[test]
+    fn public_key_from_str_invalid_str() {
+        // Ensuring test cases fail when PublicKey::from_str is used on invalid keys
+        let s = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b142";
+        assert_eq!(s.len(), 130);
+        let res = PublicKey::from_str(s);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err(),
+            ParsePublicKeyError::Encoding(FromSliceError::Secp256k1(
+                secp256k1::Error::InvalidPublicKey
+            ))
+        );
+
+        let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd169";
+        assert_eq!(s.len(), 66);
+        let res = PublicKey::from_str(s);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err(),
+            ParsePublicKeyError::Encoding(FromSliceError::Secp256k1(
+                secp256k1::Error::InvalidPublicKey
+            ))
+        );
+
+        let s = "062e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
+        assert_eq!(s.len(), 130);
+        let res = PublicKey::from_str(s);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err(),
+            ParsePublicKeyError::Encoding(FromSliceError::InvalidKeyPrefix(6))
+        );
+
+        let s = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b13g";
+        assert_eq!(s.len(), 130);
+        let res = PublicKey::from_str(s);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), ParsePublicKeyError::InvalidChar(103));
+
+        let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1ag";
+        assert_eq!(s.len(), 66);
+        let res = PublicKey::from_str(s);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), ParsePublicKeyError::InvalidChar(103));
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn private_key_debug_is_obfuscated() {
+        let sk =
+            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        let want =
+            "PrivateKey { compressed: true, network: Test, inner: SecretKey(#32014e414fdce702) }";
+        let got = format!("{:?}", sk);
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    #[cfg(not(feature = "std"))]
+    fn private_key_debug_is_obfuscated() {
+        let sk =
+            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        // Why is this not shortened? In rust-secp256k1/src/secret it is printed with "#{:016x}"?
+        let want = "PrivateKey { compressed: true, network: Test, inner: SecretKey(#7217ac58fbad8880a91032107b82cb6c5422544b426c350ee005cf509f3dbf7b) }";
+        let got = format!("{:?}", sk);
+        assert_eq!(got, want)
+    }
+}

--- a/libs/bitcoin/src/crypto/mod.rs
+++ b/libs/bitcoin/src/crypto/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Cryptography
+//!
+//! Cryptography related functionality: keys and signatures.
+//!
+
+pub mod ecdsa;
+pub mod key;
+pub mod sighash;
+// Contents re-exported in `bitcoin::taproot`.
+pub(crate) mod taproot;

--- a/libs/bitcoin/src/crypto/sighash.rs
+++ b/libs/bitcoin/src/crypto/sighash.rs
@@ -1,0 +1,2163 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Signature hash implementation (used in transaction signing).
+//!
+//! Efficient implementation of the algorithm to compute the message to be signed according to
+//! [Bip341](https://github.com/bitcoin/bips/blob/150ab6f5c3aca9da05fccc5b435e9667853407f4/bip-0341.mediawiki),
+//! [Bip143](https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki)
+//! and legacy (before Bip143).
+//!
+//! Computing signature hashes is required to sign a transaction and this module is designed to
+//! handle its complexity efficiently. Computing these hashes is as simple as creating
+//! [`SighashCache`] and calling its methods.
+
+use core::{fmt, str};
+
+use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
+use internals::write_err;
+use io::Write;
+
+use crate::blockdata::witness::Witness;
+use crate::consensus::{encode, Encodable};
+use crate::prelude::*;
+use crate::taproot::{LeafVersion, TapLeafHash, TAPROOT_ANNEX_PREFIX};
+use crate::{transaction, Amount, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
+
+/// Used for signature hash for invalid use of SIGHASH_SINGLE.
+#[rustfmt::skip]
+pub(crate) const UINT256_ONE: [u8; 32] = [
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+];
+
+macro_rules! impl_message_from_hash {
+    ($ty:ident) => {
+        impl From<$ty> for secp256k1::Message {
+            fn from(hash: $ty) -> secp256k1::Message {
+                secp256k1::Message::from_digest(hash.to_byte_array())
+            }
+        }
+    };
+}
+
+hash_newtype! {
+    /// Hash of a transaction according to the legacy signature algorithm.
+    #[hash_newtype(forward)]
+    pub struct LegacySighash(sha256d::Hash);
+
+    /// Hash of a transaction according to the segwit version 0 signature algorithm.
+    #[hash_newtype(forward)]
+    pub struct SegwitV0Sighash(sha256d::Hash);
+}
+
+impl_message_from_hash!(LegacySighash);
+impl_message_from_hash!(SegwitV0Sighash);
+
+sha256t_hash_newtype! {
+    pub struct TapSighashTag = hash_str("TapSighash");
+
+    /// Taproot-tagged hash with tag \"TapSighash\".
+    ///
+    /// This hash type is used for computing taproot signature hash."
+    #[hash_newtype(forward)]
+    pub struct TapSighash(_);
+}
+
+impl_message_from_hash!(TapSighash);
+
+/// Efficiently calculates signature hash message for legacy, segwit and taproot inputs.
+#[derive(Debug)]
+pub struct SighashCache<T: Borrow<Transaction>> {
+    /// Access to transaction required for transaction introspection. Moreover, type
+    /// `T: Borrow<Transaction>` allows us to use borrowed and mutable borrowed types,
+    /// the latter in particular is necessary for [`SighashCache::witness_mut`].
+    tx: T,
+
+    /// Common cache for taproot and segwit inputs, `None` for legacy inputs.
+    common_cache: Option<CommonCache>,
+
+    /// Cache for segwit v0 inputs (the result of another round of sha256 on `common_cache`).
+    segwit_cache: Option<SegwitCache>,
+
+    /// Cache for taproot v1 inputs.
+    taproot_cache: Option<TaprootCache>,
+}
+
+/// Common values cached between segwit and taproot inputs.
+#[derive(Debug)]
+struct CommonCache {
+    prevouts: sha256::Hash,
+    sequences: sha256::Hash,
+
+    /// In theory `outputs` could be an `Option` since `SIGHASH_NONE` and `SIGHASH_SINGLE` do not
+    /// need it, but since `SIGHASH_ALL` is by far the most used variant we don't bother.
+    outputs: sha256::Hash,
+}
+
+/// Values cached for segwit inputs, equivalent to [`CommonCache`] plus another round of `sha256`.
+#[derive(Debug)]
+struct SegwitCache {
+    prevouts: sha256d::Hash,
+    sequences: sha256d::Hash,
+    outputs: sha256d::Hash,
+}
+
+/// Values cached for taproot inputs.
+#[derive(Debug)]
+struct TaprootCache {
+    amounts: sha256::Hash,
+    script_pubkeys: sha256::Hash,
+}
+
+/// Contains outputs of previous transactions. In the case [`TapSighashType`] variant is
+/// `SIGHASH_ANYONECANPAY`, [`Prevouts::One`] may be used.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum Prevouts<'u, T>
+where
+    T: 'u + Borrow<TxOut>,
+{
+    /// `One` variant allows provision of the single prevout needed. It's useful, for example, when
+    /// modifier `SIGHASH_ANYONECANPAY` is provided, only prevout of the current input is needed.
+    /// The first `usize` argument is the input index this [`TxOut`] is referring to.
+    One(usize, T),
+    /// When `SIGHASH_ANYONECANPAY` is not provided, or when the caller is giving all prevouts so
+    /// the same variable can be used for multiple inputs.
+    All(&'u [T]),
+}
+
+const KEY_VERSION_0: u8 = 0u8;
+
+/// Information related to the script path spending.
+///
+/// This can be hashed into a [`TapLeafHash`].
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct ScriptPath<'s> {
+    script: &'s Script,
+    leaf_version: LeafVersion,
+}
+
+/// Hashtype of an input's signature, encoded in the last byte of the signature.
+/// Fixed values so they can be cast as integer types for encoding.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum TapSighashType {
+    /// 0x0: Used when not explicitly specified, defaults to [`TapSighashType::All`]
+    Default = 0x00,
+    /// 0x1: Sign all outputs.
+    All = 0x01,
+    /// 0x2: Sign no outputs --- anyone can choose the destination.
+    None = 0x02,
+    /// 0x3: Sign the output whose index matches this input's index. If none exists,
+    /// sign the hash `0000000000000000000000000000000000000000000000000000000000000001`.
+    /// (This rule is probably an unintentional C++ism, but it's consensus so we have
+    /// to follow it.)
+    Single = 0x03,
+    /// 0x81: Sign all outputs but only this input.
+    AllPlusAnyoneCanPay = 0x81,
+    /// 0x82: Sign no outputs and only this input.
+    NonePlusAnyoneCanPay = 0x82,
+    /// 0x83: Sign one output and only this input (see `Single` for what "one output" means).
+    SinglePlusAnyoneCanPay = 0x83,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(TapSighashType, "a TapSighashType data");
+
+impl fmt::Display for TapSighashType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use TapSighashType::*;
+
+        let s = match self {
+            Default => "SIGHASH_DEFAULT",
+            All => "SIGHASH_ALL",
+            None => "SIGHASH_NONE",
+            Single => "SIGHASH_SINGLE",
+            AllPlusAnyoneCanPay => "SIGHASH_ALL|SIGHASH_ANYONECANPAY",
+            NonePlusAnyoneCanPay => "SIGHASH_NONE|SIGHASH_ANYONECANPAY",
+            SinglePlusAnyoneCanPay => "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY",
+        };
+        f.write_str(s)
+    }
+}
+
+impl str::FromStr for TapSighashType {
+    type Err = SighashTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use TapSighashType::*;
+
+        match s {
+            "SIGHASH_DEFAULT" => Ok(Default),
+            "SIGHASH_ALL" => Ok(All),
+            "SIGHASH_NONE" => Ok(None),
+            "SIGHASH_SINGLE" => Ok(Single),
+            "SIGHASH_ALL|SIGHASH_ANYONECANPAY" => Ok(AllPlusAnyoneCanPay),
+            "SIGHASH_NONE|SIGHASH_ANYONECANPAY" => Ok(NonePlusAnyoneCanPay),
+            "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY" => Ok(SinglePlusAnyoneCanPay),
+            _ => Err(SighashTypeParseError { unrecognized: s.to_owned() }),
+        }
+    }
+}
+
+impl<'u, T> Prevouts<'u, T>
+where
+    T: Borrow<TxOut>,
+{
+    fn check_all(&self, tx: &Transaction) -> Result<(), PrevoutsSizeError> {
+        if let Prevouts::All(prevouts) = self {
+            if prevouts.len() != tx.input.len() {
+                return Err(PrevoutsSizeError);
+            }
+        }
+        Ok(())
+    }
+
+    fn get_all(&self) -> Result<&[T], PrevoutsKindError> {
+        match self {
+            Prevouts::All(prevouts) => Ok(*prevouts),
+            _ => Err(PrevoutsKindError),
+        }
+    }
+
+    fn get(&self, input_index: usize) -> Result<&TxOut, PrevoutsIndexError> {
+        match self {
+            Prevouts::One(index, prevout) =>
+                if input_index == *index {
+                    Ok(prevout.borrow())
+                } else {
+                    Err(PrevoutsIndexError::InvalidOneIndex)
+                },
+            Prevouts::All(prevouts) => prevouts
+                .get(input_index)
+                .map(|x| x.borrow())
+                .ok_or(PrevoutsIndexError::InvalidAllIndex),
+        }
+    }
+}
+
+/// The number of supplied prevouts differs from the number of inputs in the transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PrevoutsSizeError;
+
+impl fmt::Display for PrevoutsSizeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "number of supplied prevouts differs from the number of inputs in transaction")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PrevoutsSizeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// A single prevout was been provided but all prevouts are needed without `ANYONECANPAY`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PrevoutsKindError;
+
+impl fmt::Display for PrevoutsKindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "single prevout provided but all prevouts are needed without `ANYONECANPAY`")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PrevoutsKindError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// [`Prevouts`] index related errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrevoutsIndexError {
+    /// Invalid index when accessing a [`Prevouts::One`] kind.
+    InvalidOneIndex,
+    /// Invalid index when accessing a [`Prevouts::All`] kind.
+    InvalidAllIndex,
+}
+
+internals::impl_from_infallible!(PrevoutsIndexError);
+
+impl fmt::Display for PrevoutsIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use PrevoutsIndexError::*;
+
+        match *self {
+            InvalidOneIndex => write!(f, "invalid index when accessing a Prevouts::One kind"),
+            InvalidAllIndex => write!(f, "invalid index when accessing a Prevouts::All kind"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PrevoutsIndexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use PrevoutsIndexError::*;
+
+        match *self {
+            InvalidOneIndex | InvalidAllIndex => None,
+        }
+    }
+}
+
+impl<'s> ScriptPath<'s> {
+    /// Creates a new `ScriptPath` structure.
+    pub fn new(script: &'s Script, leaf_version: LeafVersion) -> Self {
+        ScriptPath { script, leaf_version }
+    }
+    /// Creates a new `ScriptPath` structure using default leaf version value.
+    pub fn with_defaults(script: &'s Script) -> Self { Self::new(script, LeafVersion::TapScript) }
+    /// Computes the leaf hash for this `ScriptPath`.
+    pub fn leaf_hash(&self) -> TapLeafHash {
+        let mut enc = TapLeafHash::engine();
+
+        self.leaf_version
+            .to_consensus()
+            .consensus_encode(&mut enc)
+            .expect("writing to hash enging should never fail");
+        self.script.consensus_encode(&mut enc).expect("writing to hash enging should never fail");
+
+        TapLeafHash::from_engine(enc)
+    }
+}
+
+impl<'s> From<ScriptPath<'s>> for TapLeafHash {
+    fn from(script_path: ScriptPath<'s>) -> TapLeafHash { script_path.leaf_hash() }
+}
+
+/// Hashtype of an input's signature, encoded in the last byte of the signature.
+///
+/// Fixed values so they can be cast as integer types for encoding (see also
+/// [`TapSighashType`]).
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
+pub enum EcdsaSighashType {
+    /// 0x1: Sign all outputs.
+    All = 0x01,
+    /// 0x2: Sign no outputs --- anyone can choose the destination.
+    None = 0x02,
+    /// 0x3: Sign the output whose index matches this input's index. If none exists,
+    /// sign the hash `0000000000000000000000000000000000000000000000000000000000000001`.
+    /// (This rule is probably an unintentional C++ism, but it's consensus so we have
+    /// to follow it.)
+    Single = 0x03,
+    /// 0x81: Sign all outputs but only this input.
+    AllPlusAnyoneCanPay = 0x81,
+    /// 0x82: Sign no outputs and only this input.
+    NonePlusAnyoneCanPay = 0x82,
+    /// 0x83: Sign one output and only this input (see `Single` for what "one output" means).
+    SinglePlusAnyoneCanPay = 0x83,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(EcdsaSighashType, "a EcdsaSighashType data");
+
+impl fmt::Display for EcdsaSighashType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use EcdsaSighashType::*;
+
+        let s = match self {
+            All => "SIGHASH_ALL",
+            None => "SIGHASH_NONE",
+            Single => "SIGHASH_SINGLE",
+            AllPlusAnyoneCanPay => "SIGHASH_ALL|SIGHASH_ANYONECANPAY",
+            NonePlusAnyoneCanPay => "SIGHASH_NONE|SIGHASH_ANYONECANPAY",
+            SinglePlusAnyoneCanPay => "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY",
+        };
+        f.write_str(s)
+    }
+}
+
+impl str::FromStr for EcdsaSighashType {
+    type Err = SighashTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use EcdsaSighashType::*;
+
+        match s {
+            "SIGHASH_ALL" => Ok(All),
+            "SIGHASH_NONE" => Ok(None),
+            "SIGHASH_SINGLE" => Ok(Single),
+            "SIGHASH_ALL|SIGHASH_ANYONECANPAY" => Ok(AllPlusAnyoneCanPay),
+            "SIGHASH_NONE|SIGHASH_ANYONECANPAY" => Ok(NonePlusAnyoneCanPay),
+            "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY" => Ok(SinglePlusAnyoneCanPay),
+            _ => Err(SighashTypeParseError { unrecognized: s.to_owned() }),
+        }
+    }
+}
+
+impl EcdsaSighashType {
+    /// Splits the sighash flag into the "real" sighash flag and the ANYONECANPAY boolean.
+    pub(crate) fn split_anyonecanpay_flag(self) -> (EcdsaSighashType, bool) {
+        use EcdsaSighashType::*;
+
+        match self {
+            All => (All, false),
+            None => (None, false),
+            Single => (Single, false),
+            AllPlusAnyoneCanPay => (All, true),
+            NonePlusAnyoneCanPay => (None, true),
+            SinglePlusAnyoneCanPay => (Single, true),
+        }
+    }
+
+    /// Creates a [`EcdsaSighashType`] from a raw `u32`.
+    ///
+    /// **Note**: this replicates consensus behaviour, for current standardness rules correctness
+    /// you probably want [`Self::from_standard`].
+    ///
+    /// This might cause unexpected behavior because it does not roundtrip. That is,
+    /// `EcdsaSighashType::from_consensus(n) as u32 != n` for non-standard values of `n`. While
+    /// verifying signatures, the user should retain the `n` and use it compute the signature hash
+    /// message.
+    pub fn from_consensus(n: u32) -> EcdsaSighashType {
+        use EcdsaSighashType::*;
+
+        // In Bitcoin Core, the SignatureHash function will mask the (int32) value with
+        // 0x1f to (apparently) deactivate ACP when checking for SINGLE and NONE bits.
+        // We however want to be matching also against on ACP-masked ALL, SINGLE, and NONE.
+        // So here we re-activate ACP.
+        let mask = 0x1f | 0x80;
+        match n & mask {
+            // "real" sighashes
+            0x01 => All,
+            0x02 => None,
+            0x03 => Single,
+            0x81 => AllPlusAnyoneCanPay,
+            0x82 => NonePlusAnyoneCanPay,
+            0x83 => SinglePlusAnyoneCanPay,
+            // catchalls
+            x if x & 0x80 == 0x80 => AllPlusAnyoneCanPay,
+            _ => All,
+        }
+    }
+
+    /// Creates a [`EcdsaSighashType`] from a raw `u32`.
+    ///
+    /// # Errors
+    ///
+    /// If `n` is a non-standard sighash value.
+    pub fn from_standard(n: u32) -> Result<EcdsaSighashType, NonStandardSighashTypeError> {
+        use EcdsaSighashType::*;
+
+        match n {
+            // Standard sighashes, see https://github.com/bitcoin/bitcoin/blob/b805dbb0b9c90dadef0424e5b3bf86ac308e103e/src/script/interpreter.cpp#L189-L198
+            0x01 => Ok(All),
+            0x02 => Ok(None),
+            0x03 => Ok(Single),
+            0x81 => Ok(AllPlusAnyoneCanPay),
+            0x82 => Ok(NonePlusAnyoneCanPay),
+            0x83 => Ok(SinglePlusAnyoneCanPay),
+            non_standard => Err(NonStandardSighashTypeError(non_standard)),
+        }
+    }
+
+    /// Converts [`EcdsaSighashType`] to a `u32` sighash flag.
+    ///
+    /// The returned value is guaranteed to be a valid according to standardness rules.
+    pub fn to_u32(self) -> u32 { self as u32 }
+}
+
+impl From<EcdsaSighashType> for TapSighashType {
+    fn from(s: EcdsaSighashType) -> Self {
+        use TapSighashType::*;
+
+        match s {
+            EcdsaSighashType::All => All,
+            EcdsaSighashType::None => None,
+            EcdsaSighashType::Single => Single,
+            EcdsaSighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            EcdsaSighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            EcdsaSighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+impl TapSighashType {
+    /// Breaks the sighash flag into the "real" sighash flag and the `SIGHASH_ANYONECANPAY` boolean.
+    pub(crate) fn split_anyonecanpay_flag(self) -> (TapSighashType, bool) {
+        use TapSighashType::*;
+
+        match self {
+            Default => (Default, false),
+            All => (All, false),
+            None => (None, false),
+            Single => (Single, false),
+            AllPlusAnyoneCanPay => (All, true),
+            NonePlusAnyoneCanPay => (None, true),
+            SinglePlusAnyoneCanPay => (Single, true),
+        }
+    }
+
+    /// Constructs a [`TapSighashType`] from a raw `u8`.
+    pub fn from_consensus_u8(sighash_type: u8) -> Result<Self, InvalidSighashTypeError> {
+        use TapSighashType::*;
+
+        Ok(match sighash_type {
+            0x00 => Default,
+            0x01 => All,
+            0x02 => None,
+            0x03 => Single,
+            0x81 => AllPlusAnyoneCanPay,
+            0x82 => NonePlusAnyoneCanPay,
+            0x83 => SinglePlusAnyoneCanPay,
+            x => return Err(InvalidSighashTypeError(x.into())),
+        })
+    }
+}
+
+/// Integer is not a consensus valid sighash type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSighashTypeError(pub u32);
+
+impl fmt::Display for InvalidSighashTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid sighash type {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidSighashTypeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// This type is consensus valid but an input including it would prevent the transaction from
+/// being relayed on today's Bitcoin network.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonStandardSighashTypeError(pub u32);
+
+impl fmt::Display for NonStandardSighashTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "non-standard sighash type {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NonStandardSighashTypeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// Error returned for failure during parsing one of the sighash types.
+///
+/// This is currently returned for unrecognized sighash strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SighashTypeParseError {
+    /// The unrecognized string we attempted to parse.
+    pub unrecognized: String,
+}
+
+impl fmt::Display for SighashTypeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "unrecognized SIGHASH string '{}'", self.unrecognized)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SighashTypeParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+impl<R: Borrow<Transaction>> SighashCache<R> {
+    /// Constructs a new `SighashCache` from an unsigned transaction.
+    ///
+    /// The sighash components are computed in a lazy manner when required. For the generated
+    /// sighashes to be valid, no fields in the transaction may change except for script_sig and
+    /// witness.
+    pub fn new(tx: R) -> Self {
+        SighashCache { tx, common_cache: None, taproot_cache: None, segwit_cache: None }
+    }
+
+    /// Returns the reference to the cached transaction.
+    pub fn transaction(&self) -> &Transaction { self.tx.borrow() }
+
+    /// Destroys the cache and recovers the stored transaction.
+    pub fn into_transaction(self) -> R { self.tx }
+
+    /// Encodes the BIP341 signing data for any flag type into a given object implementing the
+    /// [`io::Write`] trait.
+    pub fn taproot_encode_signing_data_to<W: Write + ?Sized, T: Borrow<TxOut>>(
+        &mut self,
+        writer: &mut W,
+        input_index: usize,
+        prevouts: &Prevouts<T>,
+        annex: Option<Annex>,
+        leaf_hash_code_separator: Option<(TapLeafHash, u32)>,
+        sighash_type: TapSighashType,
+    ) -> Result<(), SigningDataError<TaprootError>> {
+        prevouts.check_all(self.tx.borrow()).map_err(SigningDataError::sighash)?;
+
+        let (sighash, anyone_can_pay) = sighash_type.split_anyonecanpay_flag();
+
+        // epoch
+        0u8.consensus_encode(writer)?;
+
+        // * Control:
+        // hash_type (1).
+        (sighash_type as u8).consensus_encode(writer)?;
+
+        // * Transaction Data:
+        // nVersion (4): the nVersion of the transaction.
+        self.tx.borrow().version.consensus_encode(writer)?;
+
+        // nLockTime (4): the nLockTime of the transaction.
+        self.tx.borrow().lock_time.consensus_encode(writer)?;
+
+        // If the hash_type & 0x80 does not equal SIGHASH_ANYONECANPAY:
+        //     sha_prevouts (32): the SHA256 of the serialization of all input outpoints.
+        //     sha_amounts (32): the SHA256 of the serialization of all spent output amounts.
+        //     sha_scriptpubkeys (32): the SHA256 of the serialization of all spent output scriptPubKeys.
+        //     sha_sequences (32): the SHA256 of the serialization of all input nSequence.
+        if !anyone_can_pay {
+            self.common_cache().prevouts.consensus_encode(writer)?;
+            self.taproot_cache(prevouts.get_all().map_err(SigningDataError::sighash)?)
+                .amounts
+                .consensus_encode(writer)?;
+            self.taproot_cache(prevouts.get_all().map_err(SigningDataError::sighash)?)
+                .script_pubkeys
+                .consensus_encode(writer)?;
+            self.common_cache().sequences.consensus_encode(writer)?;
+        }
+
+        // If hash_type & 3 does not equal SIGHASH_NONE or SIGHASH_SINGLE:
+        //     sha_outputs (32): the SHA256 of the serialization of all outputs in CTxOut format.
+        if sighash != TapSighashType::None && sighash != TapSighashType::Single {
+            self.common_cache().outputs.consensus_encode(writer)?;
+        }
+
+        // * Data about this input:
+        // spend_type (1): equal to (ext_flag * 2) + annex_present, where annex_present is 0
+        // if no annex is present, or 1 otherwise
+        let mut spend_type = 0u8;
+        if annex.is_some() {
+            spend_type |= 1u8;
+        }
+        if leaf_hash_code_separator.is_some() {
+            spend_type |= 2u8;
+        }
+        spend_type.consensus_encode(writer)?;
+
+        // If hash_type & 0x80 equals SIGHASH_ANYONECANPAY:
+        //      outpoint (36): the COutPoint of this input (32-byte hash + 4-byte little-endian).
+        //      amount (8): value of the previous output spent by this input.
+        //      scriptPubKey (35): scriptPubKey of the previous output spent by this input, serialized as script inside CTxOut. Its size is always 35 bytes.
+        //      nSequence (4): nSequence of this input.
+        if anyone_can_pay {
+            let txin = &self.tx.borrow().tx_in(input_index).map_err(SigningDataError::sighash)?;
+            let previous_output = prevouts.get(input_index).map_err(SigningDataError::sighash)?;
+            txin.previous_output.consensus_encode(writer)?;
+            previous_output.value.consensus_encode(writer)?;
+            previous_output.script_pubkey.consensus_encode(writer)?;
+            txin.sequence.consensus_encode(writer)?;
+        } else {
+            (input_index as u32).consensus_encode(writer)?;
+        }
+
+        // If an annex is present (the lowest bit of spend_type is set):
+        //      sha_annex (32): the SHA256 of (compact_size(size of annex) || annex), where annex
+        //      includes the mandatory 0x50 prefix.
+        if let Some(annex) = annex {
+            let mut enc = sha256::Hash::engine();
+            annex.consensus_encode(&mut enc)?;
+            let hash = sha256::Hash::from_engine(enc);
+            hash.consensus_encode(writer)?;
+        }
+
+        // * Data about this output:
+        // If hash_type & 3 equals SIGHASH_SINGLE:
+        //      sha_single_output (32): the SHA256 of the corresponding output in CTxOut format.
+        if sighash == TapSighashType::Single {
+            let mut enc = sha256::Hash::engine();
+            self.tx
+                .borrow()
+                .output
+                .get(input_index)
+                .ok_or(TaprootError::SingleMissingOutput(SingleMissingOutputError {
+                    input_index,
+                    outputs_length: self.tx.borrow().output.len(),
+                }))
+                .map_err(SigningDataError::Sighash)?
+                .consensus_encode(&mut enc)?;
+            let hash = sha256::Hash::from_engine(enc);
+            hash.consensus_encode(writer)?;
+        }
+
+        //     if (scriptpath):
+        //         ss += TaggedHash("TapLeaf", bytes([leaf_ver]) + ser_string(script))
+        //         ss += bytes([0])
+        //         ss += struct.pack("<i", codeseparator_pos)
+        if let Some((hash, code_separator_pos)) = leaf_hash_code_separator {
+            hash.as_byte_array().consensus_encode(writer)?;
+            KEY_VERSION_0.consensus_encode(writer)?;
+            code_separator_pos.consensus_encode(writer)?;
+        }
+
+        Ok(())
+    }
+
+    /// Computes the BIP341 sighash for any flag type.
+    pub fn taproot_signature_hash<T: Borrow<TxOut>>(
+        &mut self,
+        input_index: usize,
+        prevouts: &Prevouts<T>,
+        annex: Option<Annex>,
+        leaf_hash_code_separator: Option<(TapLeafHash, u32)>,
+        sighash_type: TapSighashType,
+    ) -> Result<TapSighash, TaprootError> {
+        let mut enc = TapSighash::engine();
+        self.taproot_encode_signing_data_to(
+            &mut enc,
+            input_index,
+            prevouts,
+            annex,
+            leaf_hash_code_separator,
+            sighash_type,
+        )
+        .map_err(SigningDataError::unwrap_sighash)?;
+        Ok(TapSighash::from_engine(enc))
+    }
+
+    /// Computes the BIP341 sighash for a key spend.
+    pub fn taproot_key_spend_signature_hash<T: Borrow<TxOut>>(
+        &mut self,
+        input_index: usize,
+        prevouts: &Prevouts<T>,
+        sighash_type: TapSighashType,
+    ) -> Result<TapSighash, TaprootError> {
+        let mut enc = TapSighash::engine();
+        self.taproot_encode_signing_data_to(
+            &mut enc,
+            input_index,
+            prevouts,
+            None,
+            None,
+            sighash_type,
+        )
+        .map_err(SigningDataError::unwrap_sighash)?;
+        Ok(TapSighash::from_engine(enc))
+    }
+
+    /// Computes the BIP341 sighash for a script spend.
+    ///
+    /// Assumes the default `OP_CODESEPARATOR` position of `0xFFFFFFFF`. Custom values can be
+    /// provided through the more fine-grained API of [`SighashCache::taproot_encode_signing_data_to`].
+    pub fn taproot_script_spend_signature_hash<S: Into<TapLeafHash>, T: Borrow<TxOut>>(
+        &mut self,
+        input_index: usize,
+        prevouts: &Prevouts<T>,
+        leaf_hash: S,
+        sighash_type: TapSighashType,
+    ) -> Result<TapSighash, TaprootError> {
+        let mut enc = TapSighash::engine();
+        self.taproot_encode_signing_data_to(
+            &mut enc,
+            input_index,
+            prevouts,
+            None,
+            Some((leaf_hash.into(), 0xFFFFFFFF)),
+            sighash_type,
+        )
+        .map_err(SigningDataError::unwrap_sighash)?;
+        Ok(TapSighash::from_engine(enc))
+    }
+
+    /// Encodes the BIP143 signing data for any flag type into a given object implementing the
+    /// [`std::io::Write`] trait.
+    ///
+    /// `script_code` is dependent on the type of the spend transaction. For p2wpkh use
+    /// [`Script::p2wpkh_script_code`], for p2wsh just pass in the witness script. (Also see
+    /// [`Self::p2wpkh_signature_hash`] and [`SighashCache::p2wsh_signature_hash`].)
+    pub fn segwit_v0_encode_signing_data_to<W: Write + ?Sized>(
+        &mut self,
+        writer: &mut W,
+        input_index: usize,
+        script_code: &Script,
+        value: Amount,
+        sighash_type: EcdsaSighashType,
+    ) -> Result<(), SigningDataError<transaction::InputsIndexError>> {
+        let zero_hash = sha256d::Hash::all_zeros();
+
+        let (sighash, anyone_can_pay) = sighash_type.split_anyonecanpay_flag();
+
+        self.tx.borrow().version.consensus_encode(writer)?;
+
+        if !anyone_can_pay {
+            self.segwit_cache().prevouts.consensus_encode(writer)?;
+        } else {
+            zero_hash.consensus_encode(writer)?;
+        }
+
+        if !anyone_can_pay
+            && sighash != EcdsaSighashType::Single
+            && sighash != EcdsaSighashType::None
+        {
+            self.segwit_cache().sequences.consensus_encode(writer)?;
+        } else {
+            zero_hash.consensus_encode(writer)?;
+        }
+
+        {
+            let txin = &self.tx.borrow().tx_in(input_index).map_err(SigningDataError::sighash)?;
+            txin.previous_output.consensus_encode(writer)?;
+            script_code.consensus_encode(writer)?;
+            value.consensus_encode(writer)?;
+            txin.sequence.consensus_encode(writer)?;
+        }
+
+        if sighash != EcdsaSighashType::Single && sighash != EcdsaSighashType::None {
+            self.segwit_cache().outputs.consensus_encode(writer)?;
+        } else if sighash == EcdsaSighashType::Single && input_index < self.tx.borrow().output.len()
+        {
+            let mut single_enc = LegacySighash::engine();
+            self.tx.borrow().output[input_index].consensus_encode(&mut single_enc)?;
+            let hash = LegacySighash::from_engine(single_enc);
+            writer.write_all(&hash[..])?;
+        } else {
+            writer.write_all(&zero_hash[..])?;
+        }
+
+        self.tx.borrow().lock_time.consensus_encode(writer)?;
+        sighash_type.to_u32().consensus_encode(writer)?;
+        Ok(())
+    }
+
+    /// Computes the BIP143 sighash to spend a p2wpkh transaction for any flag type.
+    ///
+    /// `script_pubkey` is the `scriptPubkey` (native segwit) of the spend transaction
+    /// ([`TxOut::script_pubkey`]) or the `redeemScript` (wrapped segwit).
+    pub fn p2wpkh_signature_hash(
+        &mut self,
+        input_index: usize,
+        script_pubkey: &Script,
+        value: Amount,
+        sighash_type: EcdsaSighashType,
+    ) -> Result<SegwitV0Sighash, P2wpkhError> {
+        let script_code = script_pubkey.p2wpkh_script_code().ok_or(P2wpkhError::NotP2wpkhScript)?;
+
+        let mut enc = SegwitV0Sighash::engine();
+        self.segwit_v0_encode_signing_data_to(
+            &mut enc,
+            input_index,
+            &script_code,
+            value,
+            sighash_type,
+        )
+        .map_err(SigningDataError::unwrap_sighash)?;
+        Ok(SegwitV0Sighash::from_engine(enc))
+    }
+
+    /// Computes the BIP143 sighash to spend a p2wsh transaction for any flag type.
+    pub fn p2wsh_signature_hash(
+        &mut self,
+        input_index: usize,
+        witness_script: &Script,
+        value: Amount,
+        sighash_type: EcdsaSighashType,
+    ) -> Result<SegwitV0Sighash, transaction::InputsIndexError> {
+        let mut enc = SegwitV0Sighash::engine();
+        self.segwit_v0_encode_signing_data_to(
+            &mut enc,
+            input_index,
+            witness_script,
+            value,
+            sighash_type,
+        )
+        .map_err(SigningDataError::unwrap_sighash)?;
+        Ok(SegwitV0Sighash::from_engine(enc))
+    }
+
+    /// Encodes the legacy signing data from which a signature hash for a given input index with a
+    /// given sighash flag can be computed.
+    ///
+    /// To actually produce a scriptSig, this hash needs to be run through an ECDSA signer, the
+    /// [`EcdsaSighashType`] appended to the resulting sig, and a script written around this, but
+    /// this is the general (and hard) part.
+    ///
+    /// The `sighash_type` supports an arbitrary `u32` value, instead of just [`EcdsaSighashType`],
+    /// because internally 4 bytes are being hashed, even though only the lowest byte is appended to
+    /// signature in a transaction.
+    ///
+    /// # Warning
+    ///
+    /// - Does NOT attempt to support OP_CODESEPARATOR. In general this would require evaluating
+    ///   `script_pubkey` to determine which separators get evaluated and which don't, which we don't
+    ///   have the information to determine.
+    /// - Does NOT handle the sighash single bug (see "Return type" section)
+    ///
+    /// # Returns
+    ///
+    /// This function can't handle the SIGHASH_SINGLE bug internally, so it returns [`EncodeSigningDataResult`]
+    /// that must be handled by the caller (see [`EncodeSigningDataResult::is_sighash_single_bug`]).
+    pub fn legacy_encode_signing_data_to<W: Write + ?Sized, U: Into<u32>>(
+        &self,
+        writer: &mut W,
+        input_index: usize,
+        script_pubkey: &Script,
+        sighash_type: U,
+    ) -> EncodeSigningDataResult<SigningDataError<transaction::InputsIndexError>> {
+        // Validate input_index.
+        if let Err(e) = self.tx.borrow().tx_in(input_index) {
+            return EncodeSigningDataResult::WriteResult(Err(SigningDataError::Sighash(e)));
+        }
+        let sighash_type: u32 = sighash_type.into();
+
+        if is_invalid_use_of_sighash_single(
+            sighash_type,
+            input_index,
+            self.tx.borrow().output.len(),
+        ) {
+            // We cannot correctly handle the SIGHASH_SINGLE bug here because usage of this function
+            // will result in the data written to the writer being hashed, however the correct
+            // handling of the SIGHASH_SINGLE bug is to return the 'one array' - either implement
+            // this behaviour manually or use `signature_hash()`.
+            return EncodeSigningDataResult::SighashSingleBug;
+        }
+
+        fn encode_signing_data_to_inner<W: Write + ?Sized>(
+            self_: &Transaction,
+            writer: &mut W,
+            input_index: usize,
+            script_pubkey: &Script,
+            sighash_type: u32,
+        ) -> Result<(), io::Error> {
+            let (sighash, anyone_can_pay) =
+                EcdsaSighashType::from_consensus(sighash_type).split_anyonecanpay_flag();
+
+            // Build tx to sign
+            let mut tx = Transaction {
+                version: self_.version,
+                lock_time: self_.lock_time,
+                input: vec![],
+                output: vec![],
+            };
+            // Add all inputs necessary..
+            if anyone_can_pay {
+                tx.input = vec![TxIn {
+                    previous_output: self_.input[input_index].previous_output,
+                    script_sig: script_pubkey.to_owned(),
+                    sequence: self_.input[input_index].sequence,
+                    witness: Witness::default(),
+                }];
+            } else {
+                tx.input = Vec::with_capacity(self_.input.len());
+                for (n, input) in self_.input.iter().enumerate() {
+                    tx.input.push(TxIn {
+                        previous_output: input.previous_output,
+                        script_sig: if n == input_index {
+                            script_pubkey.to_owned()
+                        } else {
+                            ScriptBuf::new()
+                        },
+                        sequence: if n != input_index
+                            && (sighash == EcdsaSighashType::Single
+                                || sighash == EcdsaSighashType::None)
+                        {
+                            Sequence::ZERO
+                        } else {
+                            input.sequence
+                        },
+                        witness: Witness::default(),
+                    });
+                }
+            }
+            // ..then all outputs
+            tx.output = match sighash {
+                EcdsaSighashType::All => self_.output.clone(),
+                EcdsaSighashType::Single => {
+                    let output_iter = self_
+                        .output
+                        .iter()
+                        .take(input_index + 1) // sign all outputs up to and including this one, but erase
+                        .enumerate() // all of them except for this one
+                        .map(|(n, out)| if n == input_index { out.clone() } else { TxOut::NULL });
+                    output_iter.collect()
+                }
+                EcdsaSighashType::None => vec![],
+                _ => unreachable!(),
+            };
+            // hash the result
+            tx.consensus_encode(writer)?;
+            sighash_type.to_le_bytes().consensus_encode(writer)?;
+            Ok(())
+        }
+
+        EncodeSigningDataResult::WriteResult(
+            encode_signing_data_to_inner(
+                self.tx.borrow(),
+                writer,
+                input_index,
+                script_pubkey,
+                sighash_type,
+            )
+            .map_err(Into::into),
+        )
+    }
+
+    /// Computes a legacy signature hash for a given input index with a given sighash flag.
+    ///
+    /// To actually produce a scriptSig, this hash needs to be run through an ECDSA signer, the
+    /// [`EcdsaSighashType`] appended to the resulting sig, and a script written around this, but
+    /// this is the general (and hard) part.
+    ///
+    /// The `sighash_type` supports an arbitrary `u32` value, instead of just [`EcdsaSighashType`],
+    /// because internally 4 bytes are being hashed, even though only the lowest byte is appended to
+    /// signature in a transaction.
+    ///
+    /// This function correctly handles the sighash single bug by returning the 'one array'. The
+    /// sighash single bug becomes exploitable when one tries to sign a transaction with
+    /// `SIGHASH_SINGLE` and there is not a corresponding output with the same index as the input.
+    ///
+    /// # Warning
+    ///
+    /// Does NOT attempt to support OP_CODESEPARATOR. In general this would require evaluating
+    /// `script_pubkey` to determine which separators get evaluated and which don't, which we don't
+    /// have the information to determine.
+    pub fn legacy_signature_hash(
+        &self,
+        input_index: usize,
+        script_pubkey: &Script,
+        sighash_type: u32,
+    ) -> Result<LegacySighash, transaction::InputsIndexError> {
+        let mut engine = LegacySighash::engine();
+        match self
+            .legacy_encode_signing_data_to(&mut engine, input_index, script_pubkey, sighash_type)
+            .is_sighash_single_bug()
+        {
+            Ok(true) => Ok(LegacySighash::from_byte_array(UINT256_ONE)),
+            Ok(false) => Ok(LegacySighash::from_engine(engine)),
+            Err(e) => Err(e.unwrap_sighash()),
+        }
+    }
+
+    #[inline]
+    fn common_cache(&mut self) -> &CommonCache {
+        Self::common_cache_minimal_borrow(&mut self.common_cache, self.tx.borrow())
+    }
+
+    fn common_cache_minimal_borrow<'a>(
+        common_cache: &'a mut Option<CommonCache>,
+        tx: &Transaction,
+    ) -> &'a CommonCache {
+        common_cache.get_or_insert_with(|| {
+            let mut enc_prevouts = sha256::Hash::engine();
+            let mut enc_sequences = sha256::Hash::engine();
+            for txin in tx.input.iter() {
+                txin.previous_output.consensus_encode(&mut enc_prevouts).unwrap();
+                txin.sequence.consensus_encode(&mut enc_sequences).unwrap();
+            }
+            CommonCache {
+                prevouts: sha256::Hash::from_engine(enc_prevouts),
+                sequences: sha256::Hash::from_engine(enc_sequences),
+                outputs: {
+                    let mut enc = sha256::Hash::engine();
+                    for txout in tx.output.iter() {
+                        txout.consensus_encode(&mut enc).unwrap();
+                    }
+                    sha256::Hash::from_engine(enc)
+                },
+            }
+        })
+    }
+
+    fn segwit_cache(&mut self) -> &SegwitCache {
+        let common_cache = &mut self.common_cache;
+        let tx = self.tx.borrow();
+        self.segwit_cache.get_or_insert_with(|| {
+            let common_cache = Self::common_cache_minimal_borrow(common_cache, tx);
+            SegwitCache {
+                prevouts: common_cache.prevouts.hash_again(),
+                sequences: common_cache.sequences.hash_again(),
+                outputs: common_cache.outputs.hash_again(),
+            }
+        })
+    }
+
+    fn taproot_cache<T: Borrow<TxOut>>(&mut self, prevouts: &[T]) -> &TaprootCache {
+        self.taproot_cache.get_or_insert_with(|| {
+            let mut enc_amounts = sha256::Hash::engine();
+            let mut enc_script_pubkeys = sha256::Hash::engine();
+            for prevout in prevouts {
+                prevout.borrow().value.consensus_encode(&mut enc_amounts).unwrap();
+                prevout.borrow().script_pubkey.consensus_encode(&mut enc_script_pubkeys).unwrap();
+            }
+            TaprootCache {
+                amounts: sha256::Hash::from_engine(enc_amounts),
+                script_pubkeys: sha256::Hash::from_engine(enc_script_pubkeys),
+            }
+        })
+    }
+}
+
+impl<R: BorrowMut<Transaction>> SighashCache<R> {
+    /// Allows modification of witnesses.
+    ///
+    /// As a lint against accidental changes to the transaction that would invalidate the cache and
+    /// signatures, `SighashCache` borrows the Transaction so that modifying it is not possible
+    /// without hacks with `UnsafeCell` (which is hopefully a strong indication that something is
+    /// wrong). However modifying witnesses never invalidates the cache and is actually useful - one
+    /// usually wants to put the signature generated for an input into the witness of that input.
+    ///
+    /// This method allows doing exactly that if the transaction is owned by the `SighashCache` or
+    /// borrowed mutably.
+    ///
+    /// # Examples
+    ///
+    /// ```compile_fail
+    /// let mut sighasher = SighashCache::new(&mut tx_to_sign);
+    /// let sighash = sighasher.p2wpkh_signature_hash(input_index, &utxo.script_pubkey, amount, sighash_type)?;
+    ///
+    /// let signature = {
+    ///     // Sign the sighash using secp256k1
+    /// };
+    ///
+    /// *sighasher.witness_mut(input_index).unwrap() = Witness::p2wpkh(&signature, &pk);
+    /// ```
+    ///
+    /// For full signing code see the [`segwit v0`] and [`taproot`] signing examples.
+    ///
+    /// [`segwit v0`]: <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/sign-tx-segwit-v0.rs>
+    /// [`taproot`]: <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/sign-tx-taproot.rs>
+    pub fn witness_mut(&mut self, input_index: usize) -> Option<&mut Witness> {
+        self.tx.borrow_mut().input.get_mut(input_index).map(|i| &mut i.witness)
+    }
+}
+
+/// The `Annex` struct is a slice wrapper enforcing first byte is `0x50`.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Annex<'a>(&'a [u8]);
+
+impl<'a> Annex<'a> {
+    /// Creates a new `Annex` struct checking the first byte is `0x50`.
+    pub fn new(annex_bytes: &'a [u8]) -> Result<Self, AnnexError> {
+        use AnnexError::*;
+
+        match annex_bytes.first() {
+            Some(&TAPROOT_ANNEX_PREFIX) => Ok(Annex(annex_bytes)),
+            Some(other) => Err(IncorrectPrefix(*other)),
+            None => Err(Empty),
+        }
+    }
+
+    /// Returns the Annex bytes data (including first byte `0x50`).
+    pub fn as_bytes(&self) -> &[u8] { self.0 }
+}
+
+impl<'a> Encodable for Annex<'a> {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        encode::consensus_encode_with_size(self.0, w)
+    }
+}
+
+/// Error computing a taproot sighash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TaprootError {
+    /// Index out of bounds when accessing transaction input vector.
+    InputsIndex(transaction::InputsIndexError),
+    /// Using `SIGHASH_SINGLE` requires an output at the same index is the input.
+    SingleMissingOutput(SingleMissingOutputError),
+    /// Prevouts size error.
+    PrevoutsSize(PrevoutsSizeError),
+    /// Prevouts index error.
+    PrevoutsIndex(PrevoutsIndexError),
+    /// Prevouts kind error.
+    PrevoutsKind(PrevoutsKindError),
+    /// Invalid Sighash type.
+    InvalidSighashType(u32),
+}
+
+internals::impl_from_infallible!(TaprootError);
+
+impl fmt::Display for TaprootError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use TaprootError::*;
+
+        match *self {
+            InputsIndex(ref e) => write_err!(f, "inputs index"; e),
+            SingleMissingOutput(ref e) => write_err!(f, "sighash single"; e),
+            PrevoutsSize(ref e) => write_err!(f, "prevouts size"; e),
+            PrevoutsIndex(ref e) => write_err!(f, "prevouts index"; e),
+            PrevoutsKind(ref e) => write_err!(f, "prevouts kind"; e),
+            InvalidSighashType(hash_ty) => write!(f, "invalid taproot sighash type : {} ", hash_ty),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TaprootError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use TaprootError::*;
+
+        match *self {
+            InputsIndex(ref e) => Some(e),
+            SingleMissingOutput(ref e) => Some(e),
+            PrevoutsSize(ref e) => Some(e),
+            PrevoutsIndex(ref e) => Some(e),
+            PrevoutsKind(ref e) => Some(e),
+            InvalidSighashType(_) => None,
+        }
+    }
+}
+
+impl From<transaction::InputsIndexError> for TaprootError {
+    fn from(e: transaction::InputsIndexError) -> Self { Self::InputsIndex(e) }
+}
+
+impl From<PrevoutsSizeError> for TaprootError {
+    fn from(e: PrevoutsSizeError) -> Self { Self::PrevoutsSize(e) }
+}
+
+impl From<PrevoutsKindError> for TaprootError {
+    fn from(e: PrevoutsKindError) -> Self { Self::PrevoutsKind(e) }
+}
+
+impl From<PrevoutsIndexError> for TaprootError {
+    fn from(e: PrevoutsIndexError) -> Self { Self::PrevoutsIndex(e) }
+}
+
+/// Error computing a P2WPKH sighash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum P2wpkhError {
+    /// Error computing the sighash.
+    Sighash(transaction::InputsIndexError),
+    /// Script is not a witness program for a p2wpkh output.
+    NotP2wpkhScript,
+}
+
+internals::impl_from_infallible!(P2wpkhError);
+
+impl From<transaction::InputsIndexError> for P2wpkhError {
+    fn from(value: transaction::InputsIndexError) -> Self { P2wpkhError::Sighash(value) }
+}
+
+impl fmt::Display for P2wpkhError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use P2wpkhError::*;
+
+        match *self {
+            Sighash(ref e) => write_err!(f, "error encoding segwit v0 signing data"; e),
+            NotP2wpkhScript => write!(f, "script is not a script pubkey for a p2wpkh output"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for P2wpkhError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use P2wpkhError::*;
+
+        match *self {
+            Sighash(ref e) => Some(e),
+            NotP2wpkhScript => None,
+        }
+    }
+}
+
+/// Using `SIGHASH_SINGLE` requires an output at the same index as the input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SingleMissingOutputError {
+    /// Input index.
+    pub input_index: usize,
+    /// Length of the output vector.
+    pub outputs_length: usize,
+}
+
+impl fmt::Display for SingleMissingOutputError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "sighash single requires an output at the same index as the input \
+             (input index: {}, outputs length: {})",
+            self.input_index, self.outputs_length
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SingleMissingOutputError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// Annex must be at least one byte long and the first bytes must be `0x50`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AnnexError {
+    /// The annex is empty.
+    Empty,
+    /// Incorrect prefix byte in the annex.
+    IncorrectPrefix(u8),
+}
+
+internals::impl_from_infallible!(AnnexError);
+
+impl fmt::Display for AnnexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use AnnexError::*;
+
+        match *self {
+            Empty => write!(f, "the annex is empty"),
+            IncorrectPrefix(byte) =>
+                write!(f, "incorrect prefix byte in the annex {:02x}, expecting 0x50", byte),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AnnexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use AnnexError::*;
+
+        match *self {
+            Empty | IncorrectPrefix(_) => None,
+        }
+    }
+}
+
+fn is_invalid_use_of_sighash_single(sighash: u32, input_index: usize, outputs_len: usize) -> bool {
+    let ty = EcdsaSighashType::from_consensus(sighash);
+    ty == EcdsaSighashType::Single && input_index >= outputs_len
+}
+
+/// Result of [`SighashCache::legacy_encode_signing_data_to`].
+///
+/// This type forces the caller to handle SIGHASH_SINGLE bug case.
+///
+/// This corner case can't be expressed using standard `Result`,
+/// in a way that is both convenient and not-prone to accidental
+/// mistakes (like calling `.expect("writer never fails")`).
+#[must_use]
+pub enum EncodeSigningDataResult<E> {
+    /// Input data is an instance of `SIGHASH_SINGLE` bug
+    SighashSingleBug,
+    /// Operation performed normally.
+    WriteResult(Result<(), E>),
+}
+
+impl<E> EncodeSigningDataResult<E> {
+    /// Checks for SIGHASH_SINGLE bug returning error if the writer failed.
+    ///
+    /// This method is provided for easy and correct handling of the result because
+    /// SIGHASH_SINGLE bug is a special case that must not be ignored nor cause panicking.
+    /// Since the data is usually written directly into a hasher which never fails,
+    /// the recommended pattern to handle this is:
+    ///
+    /// ```rust
+    /// # use bitcoin::consensus::deserialize;
+    /// # use bitcoin::hashes::{Hash, hex::FromHex};
+    /// # use bitcoin::sighash::{LegacySighash, SighashCache};
+    /// # use bitcoin::Transaction;
+    /// # let mut writer = LegacySighash::engine();
+    /// # let input_index = 0;
+    /// # let script_pubkey = bitcoin::ScriptBuf::new();
+    /// # let sighash_u32 = 0u32;
+    /// # const SOME_TX: &'static str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
+    /// # let raw_tx = Vec::from_hex(SOME_TX).unwrap();
+    /// # let tx: Transaction = deserialize(&raw_tx).unwrap();
+    /// let cache = SighashCache::new(&tx);
+    /// if cache.legacy_encode_signing_data_to(&mut writer, input_index, &script_pubkey, sighash_u32)
+    ///         .is_sighash_single_bug()
+    ///         .expect("writer can't fail") {
+    ///     // use a hash value of "1", instead of computing the actual hash due to SIGHASH_SINGLE bug
+    /// }
+    /// ```
+    pub fn is_sighash_single_bug(self) -> Result<bool, E> {
+        match self {
+            EncodeSigningDataResult::SighashSingleBug => Ok(true),
+            EncodeSigningDataResult::WriteResult(Ok(())) => Ok(false),
+            EncodeSigningDataResult::WriteResult(Err(e)) => Err(e),
+        }
+    }
+
+    /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
+    /// contained [`Err`] value, leaving an [`Ok`] value untouched.
+    ///
+    /// Like [`Result::map_err`].
+    pub fn map_err<E2, F>(self, f: F) -> EncodeSigningDataResult<E2>
+    where
+        F: FnOnce(E) -> E2,
+    {
+        match self {
+            EncodeSigningDataResult::SighashSingleBug => EncodeSigningDataResult::SighashSingleBug,
+            EncodeSigningDataResult::WriteResult(Err(e)) =>
+                EncodeSigningDataResult::WriteResult(Err(f(e))),
+            EncodeSigningDataResult::WriteResult(Ok(o)) =>
+                EncodeSigningDataResult::WriteResult(Ok(o)),
+        }
+    }
+}
+
+/// Error returned when writing signing data fails.
+#[derive(Debug)]
+pub enum SigningDataError<E> {
+    /// Can happen only when using `*_encode_signing_*` methods with custom writers, engines
+    /// like those used in `*_signature_hash` methods do not error.
+    Io(io::Error),
+    /// An argument to the called sighash function was invalid.
+    Sighash(E),
+}
+
+internals::impl_from_infallible!(SigningDataError<E>);
+
+impl<E> SigningDataError<E> {
+    /// Returns the sighash variant, panicking if it's IO.
+    ///
+    /// This is used when encoding to hash engine when we know that IO doesn't fail.
+    fn unwrap_sighash(self) -> E {
+        match self {
+            Self::Sighash(error) => error,
+            Self::Io(error) => panic!("hash engine error {}", error),
+        }
+    }
+
+    fn sighash<E2: Into<E>>(error: E2) -> Self { Self::Sighash(error.into()) }
+}
+
+// We cannot simultaneously impl `From<E>`. it was determined that this alternative requires less
+// manual `map_err` calls.
+impl<E> From<io::Error> for SigningDataError<E> {
+    fn from(value: io::Error) -> Self { Self::Io(value) }
+}
+
+impl<E: fmt::Display> fmt::Display for SigningDataError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Io(error) => write_err!(f, "failed to write sighash data"; error),
+            Self::Sighash(error) => write_err!(f, "failed to compute sighash data"; error),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: std::error::Error + 'static> std::error::Error for SigningDataError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SigningDataError::Io(error) => Some(error),
+            SigningDataError::Sighash(error) => Some(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use hashes::HashEngine;
+    use hex::{test_hex_unwrap as hex, FromHex};
+
+    use super::*;
+    use crate::blockdata::locktime::absolute;
+    use crate::consensus::deserialize;
+
+    extern crate serde_json;
+
+    #[test]
+    fn sighash_single_bug() {
+        const SIGHASH_SINGLE: u32 = 3;
+
+        // We need a tx with more inputs than outputs.
+        let tx = Transaction {
+            version: transaction::Version::ONE,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default(), TxIn::default()],
+            output: vec![TxOut::NULL],
+        };
+        let script = ScriptBuf::new();
+        let cache = SighashCache::new(&tx);
+
+        let got = cache.legacy_signature_hash(1, &script, SIGHASH_SINGLE).expect("sighash");
+        let want = LegacySighash::from_slice(&UINT256_ONE).unwrap();
+
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn legacy_sighash() {
+        use serde_json::Value;
+
+        use crate::sighash::SighashCache;
+
+        fn run_test_sighash(
+            tx: &str,
+            script: &str,
+            input_index: usize,
+            hash_type: i64,
+            expected_result: &str,
+        ) {
+            let tx: Transaction = deserialize(&Vec::from_hex(tx).unwrap()[..]).unwrap();
+            let script = ScriptBuf::from(Vec::from_hex(script).unwrap());
+            let mut raw_expected = Vec::from_hex(expected_result).unwrap();
+            raw_expected.reverse();
+            let want = LegacySighash::from_slice(&raw_expected[..]).unwrap();
+
+            let cache = SighashCache::new(&tx);
+            let got = cache.legacy_signature_hash(input_index, &script, hash_type as u32).unwrap();
+
+            assert_eq!(got, want);
+        }
+
+        // These test vectors were stolen from libbtc, which is Copyright 2014 Jonas Schnelli MIT
+        // They were transformed by replacing {...} with run_test_sighash(...), then the ones containing
+        // OP_CODESEPARATOR in their pubkeys were removed
+        let data = include_str!("../../tests/data/legacy_sighash.json");
+
+        let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
+        for t in testdata.iter().skip(1) {
+            let tx = t.get(0).unwrap().as_str().unwrap();
+            let script = t.get(1).unwrap().as_str().unwrap_or("");
+            let input_index = t.get(2).unwrap().as_u64().unwrap();
+            let hash_type = t.get(3).unwrap().as_i64().unwrap();
+            let expected_sighash = t.get(4).unwrap().as_str().unwrap();
+            run_test_sighash(tx, script, input_index as usize, hash_type, expected_sighash);
+        }
+    }
+
+    #[test]
+    fn test_tap_sighash_hash() {
+        let bytes = hex!("00011b96877db45ffa23b307e9f0ac87b80ef9a80b4c5f0db3fbe734422453e83cc5576f3d542c5d4898fb2b696c15d43332534a7c1d1255fda38993545882df92c3e353ff6d36fbfadc4d168452afd8467f02fe53d71714fcea5dfe2ea759bd00185c4cb02bc76d42620393ca358a1a713f4997f9fc222911890afb3fe56c6a19b202df7bffdcfad08003821294279043746631b00e2dc5e52a111e213bbfe6ef09a19428d418dab0d50000000000");
+        let expected = hex!("04e808aad07a40b3767a1442fead79af6ef7e7c9316d82dec409bb31e77699b0");
+        let mut enc = TapSighash::engine();
+        enc.input(&bytes);
+        let hash = TapSighash::from_engine(enc);
+        assert_eq!(expected, hash.to_byte_array());
+    }
+
+    #[test]
+    fn test_sighashes_keyspending() {
+        // following test case has been taken from Bitcoin Core test framework
+
+        test_taproot_sighash(
+            "020000000164eb050a5e3da0c2a65e4786f26d753b7bc69691fabccafb11f7acef36641f1846010000003101b2b404392a22000000000017a9147f2bde86fe78bf68a0544a4f290e12f0b7e0a08c87580200000000000017a91425d11723074ecfb96a0a83c3956bfaf362ae0c908758020000000000001600147e20f938993641de67bb0cdd71682aa34c4d29ad5802000000000000160014c64984dc8761acfa99418bd6bedc79b9287d652d72000000",
+            "01365724000000000023542156b39dab4f8f3508e0432cfb41fab110170acaa2d4c42539cb90a4dc7c093bc500",
+            0,
+            "33ca0ebfb4a945eeee9569fc0f5040221275f88690b7f8592ada88ce3bdf6703",
+            TapSighashType::Default, None, None, None
+        );
+
+        test_taproot_sighash(
+            "0200000002fff49be59befe7566050737910f6ccdc5e749c7f8860ddc140386463d88c5ad0f3000000002cf68eb4a3d67f9d4c079249f7e4f27b8854815cb1ed13842d4fbf395f9e217fd605ee24090100000065235d9203f458520000000000160014b6d48333bb13b4c644e57c43a9a26df3a44b785e58020000000000001976a914eea9461a9e1e3f765d3af3e726162e0229fe3eb688ac58020000000000001976a9143a8869c9f2b5ea1d4ff3aeeb6a8fb2fffb1ad5fe88ac0ad7125c",
+            "02591f220000000000225120f25ad35583ea31998d968871d7de1abd2a52f6fe4178b54ea158274806ff4ece48fb310000000000225120f25ad35583ea31998d968871d7de1abd2a52f6fe4178b54ea158274806ff4ece",
+            1,
+            "626ab955d58c9a8a600a0c580549d06dc7da4e802eb2a531f62a588e430967a8",
+            TapSighashType::All, None, None, None
+        );
+
+        test_taproot_sighash(
+            "0200000001350005f65aa830ced2079df348e2d8c2bdb4f10e2dde6a161d8a07b40d1ad87dae000000001611d0d603d9dc0e000000000017a914459b6d7d6bbb4d8837b4bf7e9a4556f952da2f5c8758020000000000001976a9141dd70e1299ffc2d5b51f6f87de9dfe9398c33cbb88ac58020000000000001976a9141dd70e1299ffc2d5b51f6f87de9dfe9398c33cbb88aca71c1f4f",
+            "01c4811000000000002251201bf9297d0a2968ae6693aadd0fa514717afefd218087a239afb7418e2d22e65c",
+            0,
+            "dfa9437f9c9a1d1f9af271f79f2f5482f287cdb0d2e03fa92c8a9b216cc6061c",
+            TapSighashType::AllPlusAnyoneCanPay, None, None, None
+        );
+
+        test_taproot_sighash(
+            "020000000185bed1a6da2bffbd60ec681a1bfb71c5111d6395b99b3f8b2bf90167111bcb18f5010000007c83ace802ded24a00000000001600142c4698f9f7a773866879755aa78c516fb332af8e5802000000000000160014d38639dfbac4259323b98a472405db0c461b31fa61073747",
+            "0144c84d0000000000225120e3f2107989c88e67296ab2faca930efa2e3a5bd3ff0904835a11c9e807458621",
+            0,
+            "3129de36a5d05fff97ffca31eb75fcccbbbc27b3147a7a36a9e4b45d8b625067",
+            TapSighashType::None, None, None, None
+        );
+
+        test_taproot_sighash(
+            "eb93dbb901028c8515589dac980b6e7f8e4088b77ed866ca0d6d210a7218b6fd0f6b22dd6d7300000000eb4740a9047efc0e0000000000160014913da2128d8fcf292b3691db0e187414aa1783825802000000000000160014913da2128d8fcf292b3691db0e187414aa178382580200000000000017a9143dd27f01c6f7ef9bb9159937b17f17065ed01a0c875802000000000000160014d7630e19df70ada9905ede1722b800c0005f246641000000",
+            "013fed110000000000225120eb536ae8c33580290630fc495046e998086a64f8f33b93b07967d9029b265c55",
+            0,
+            "2441e8b0e063a2083ee790f14f2045022f07258ddde5ee01de543c9e789d80ae",
+            TapSighashType::NonePlusAnyoneCanPay, None, None, None
+        );
+
+        test_taproot_sighash(
+            "02000000017836b409a5fed32211407e44b971591f2032053f14701fb5b3a30c0ff382f2cc9c0100000061ac55f60288fb5600000000001976a9144ea02f6f182b082fb6ce47e36bbde390b6a41b5088ac58020000000000001976a9144ea02f6f182b082fb6ce47e36bbde390b6a41b5088ace4000000",
+            "01efa558000000000022512007071ea3dc7e331b0687d0193d1e6d6ed10e645ef36f10ef8831d5e522ac9e80",
+            0,
+            "30239345177cadd0e3ea413d49803580abb6cb27971b481b7788a78d35117a88",
+            TapSighashType::Single, None, None, None
+        );
+
+        test_taproot_sighash(
+            "0100000001aa6deae89d5e0aaca58714fc76ef6f3c8284224888089232d4e663843ed3ab3eae010000008b6657a60450cb4c0000000000160014a3d42b5413ef0c0701c4702f3cd7d4df222c147058020000000000001976a91430b4ed8723a4ee8992aa2c8814cfe5c3ad0ab9d988ac5802000000000000160014365b1166a6ed0a5e8e9dff17a6d00bbb43454bc758020000000000001976a914bc98c51a84fe7fad5dc380eb8b39586eff47241688ac4f313247",
+            "0107af4e00000000002251202c36d243dfc06cb56a248e62df27ecba7417307511a81ae61aa41c597a929c69",
+            0,
+            "bf9c83f26c6dd16449e4921f813f551c4218e86f2ec906ca8611175b41b566df",
+            TapSighashType::SinglePlusAnyoneCanPay, None, None, None
+        );
+    }
+
+    #[test]
+    fn test_sighashes_with_annex() {
+        test_taproot_sighash(
+            "0200000001df8123752e8f37d132c4e9f1ff7e4f9b986ade9211267e9ebd5fd22a5e718dec6d01000000ce4023b903cb7b23000000000017a914a18b36ea7a094db2f4940fc09edf154e86de7bd787580200000000000017a914afd0d512a2c5c2b40e25669e9cc460303c325b8b87580200000000000017a914a18b36ea7a094db2f4940fc09edf154e86de7bd787f6020000",
+            "01ea49260000000000225120ab5e9800806bf18cb246edcf5fe63441208fe955a4b5a35bbff65f5db622a010",
+            0,
+            "3b003000add359a364a156e73e02846782a59d0d95ca8c4638aaad99f2ef915c",
+            TapSighashType::SinglePlusAnyoneCanPay,
+            Some("507b979802e62d397acb29f56743a791894b99372872fc5af06a4f6e8d242d0615cda53062bb20e6ec79756fe39183f0c128adfe85559a8fa042b042c018aa8010143799e44f0893c40e1e"),
+            None,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_sighashes_with_script_path() {
+        test_taproot_sighash(
+            "020000000189fc651483f9296b906455dd939813bf086b1bbe7c77635e157c8e14ae29062195010000004445b5c7044561320000000000160014331414dbdada7fb578f700f38fb69995fc9b5ab958020000000000001976a914268db0a8104cc6d8afd91233cc8b3d1ace8ac3ef88ac580200000000000017a914ec00dcb368d6a693e11986d265f659d2f59e8be2875802000000000000160014c715799a49a0bae3956df9c17cb4440a673ac0df6f010000",
+            "011bec34000000000022512028055142ea437db73382e991861446040b61dd2185c4891d7daf6893d79f7182",
+            0,
+            "d66de5274a60400c7b08c86ba6b7f198f40660079edf53aca89d2a9501317f2e",
+            TapSighashType::All,
+            None,
+            Some("20cc4e1107aea1d170c5ff5b6817e1303010049724fb3caa7941792ea9d29b3e2bacab"),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_sighashes_with_script_path_raw_hash() {
+        test_taproot_sighash(
+            "020000000189fc651483f9296b906455dd939813bf086b1bbe7c77635e157c8e14ae29062195010000004445b5c7044561320000000000160014331414dbdada7fb578f700f38fb69995fc9b5ab958020000000000001976a914268db0a8104cc6d8afd91233cc8b3d1ace8ac3ef88ac580200000000000017a914ec00dcb368d6a693e11986d265f659d2f59e8be2875802000000000000160014c715799a49a0bae3956df9c17cb4440a673ac0df6f010000",
+            "011bec34000000000022512028055142ea437db73382e991861446040b61dd2185c4891d7daf6893d79f7182",
+            0,
+            "d66de5274a60400c7b08c86ba6b7f198f40660079edf53aca89d2a9501317f2e",
+            TapSighashType::All,
+            None,
+            None,
+            Some("15a2530514e399f8b5cf0b3d3112cf5b289eaa3e308ba2071b58392fdc6da68a"),
+        );
+    }
+
+    #[test]
+    fn test_sighashes_with_annex_and_script() {
+        test_taproot_sighash(
+            "020000000132fb72cb8fba496755f027a9743e2d698c831fdb8304e4d1a346ac92cbf51acba50100000026bdc7df044aad34000000000017a9144fa2554ed6174586854fa3bc01de58dcf33567d0875802000000000000160014950367e1e62cdf240b35b883fc2f5e39f0eb9ab95802000000000000160014950367e1e62cdf240b35b883fc2f5e39f0eb9ab958020000000000001600141b31217d48ccc8760dcc0710fade5866d628e733a02d5122",
+            "011458360000000000225120a7baec3fb9f84614e3899fcc010c638f80f13539344120e1f4d8b68a9a011a13",
+            0,
+            "a0042aa434f9a75904b64043f2a283f8b4c143c7f4f7f49a6cbe5b9f745f4c15",
+            TapSighashType::All,
+            Some("50a6272b470e1460e3332ade7bb14b81671c564fb6245761bd5bd531394b28860e0b3808ab229fb51791fb6ae6fa82d915b2efb8f6df83ae1f5ab3db13e30928875e2a22b749d89358de481f19286cd4caa792ce27f9559082d227a731c5486882cc707f83da361c51b7aadd9a0cf68fe7480c410fa137b454482d9a1ebf0f96d760b4d61426fc109c6e8e99a508372c45caa7b000a41f8251305da3f206c1849985ba03f3d9592832b4053afbd23ab25d0465df0bc25a36c223aacf8e04ec736a418c72dc319e4da3e972e349713ca600965e7c665f2090d5a70e241ac164115a1f5639f28b1773327715ca307ace64a2de7f0e3df70a2ffee3857689f909c0dad46d8a20fa373a4cc6eed6d4c9806bf146f0d76baae1"),
+            Some("7520ab9160dd8299dc1367659be3e8f66781fe440d52940c7f8d314a89b9f2698d406ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6eadac"),
+            None,
+        );
+    }
+
+    #[test]
+    #[rustfmt::skip] // Allow long function call `taproot_signature_hash`.
+    fn test_sighash_errors() {
+        use crate::transaction::{IndexOutOfBoundsError, InputsIndexError};
+
+        let dumb_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![],
+        };
+        let mut c = SighashCache::new(&dumb_tx);
+
+        // 1.29 fixes
+        let empty_vec = vec![];
+        let empty_prevouts : Prevouts<TxOut> = Prevouts::All(&empty_vec);
+        assert_eq!(
+            c.taproot_signature_hash(0, &empty_prevouts, None, None, TapSighashType::All),
+            Err(TaprootError::PrevoutsSize(PrevoutsSizeError))
+        );
+        let two = vec![TxOut::NULL, TxOut::NULL];
+        let too_many_prevouts = Prevouts::All(&two);
+        assert_eq!(
+            c.taproot_signature_hash(0, &too_many_prevouts, None, None, TapSighashType::All),
+            Err(TaprootError::PrevoutsSize(PrevoutsSizeError))
+        );
+        let tx_out = TxOut::NULL;
+        let prevout = Prevouts::One(1, &tx_out);
+        assert_eq!(
+            c.taproot_signature_hash(0, &prevout, None, None, TapSighashType::All),
+            Err(TaprootError::PrevoutsKind(PrevoutsKindError))
+        );
+        assert_eq!(
+            c.taproot_signature_hash(0, &prevout, None, None, TapSighashType::AllPlusAnyoneCanPay),
+            Err(TaprootError::PrevoutsIndex(PrevoutsIndexError::InvalidOneIndex))
+        );
+        assert_eq!(
+            c.taproot_signature_hash(10, &prevout, None, None, TapSighashType::AllPlusAnyoneCanPay),
+            Err(InputsIndexError(IndexOutOfBoundsError {
+                index: 10,
+                length: 1
+            }).into())
+        );
+        let prevout = Prevouts::One(0, &tx_out);
+        assert_eq!(
+            c.taproot_signature_hash(0, &prevout, None, None, TapSighashType::SinglePlusAnyoneCanPay),
+            Err(TaprootError::SingleMissingOutput(SingleMissingOutputError {
+                input_index: 0,
+                outputs_length: 0
+            }))
+        );
+        assert_eq!(
+            c.legacy_signature_hash(10, Script::new(), 0u32),
+            Err(InputsIndexError(IndexOutOfBoundsError {
+                index: 10,
+                length: 1
+            }))
+        );
+    }
+
+    #[test]
+    fn test_annex_errors() {
+        assert_eq!(Annex::new(&[]), Err(AnnexError::Empty));
+        assert_eq!(Annex::new(&[0x51]), Err(AnnexError::IncorrectPrefix(0x51)));
+        assert_eq!(Annex::new(&[0x51, 0x50]), Err(AnnexError::IncorrectPrefix(0x51)));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn test_taproot_sighash(
+        tx_hex: &str,
+        prevout_hex: &str,
+        input_index: usize,
+        expected_hash: &str,
+        sighash_type: TapSighashType,
+        annex_hex: Option<&str>,
+        script_hex: Option<&str>,
+        script_leaf_hash: Option<&str>,
+    ) {
+        let tx_bytes = Vec::from_hex(tx_hex).unwrap();
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        let prevout_bytes = Vec::from_hex(prevout_hex).unwrap();
+        let prevouts: Vec<TxOut> = deserialize(&prevout_bytes).unwrap();
+        let annex_inner;
+        let annex = match annex_hex {
+            Some(annex_hex) => {
+                annex_inner = Vec::from_hex(annex_hex).unwrap();
+                Some(Annex::new(&annex_inner).unwrap())
+            }
+            None => None,
+        };
+
+        let leaf_hash = match (script_hex, script_leaf_hash) {
+            (Some(script_hex), _) => {
+                let script_inner = ScriptBuf::from_hex(script_hex).unwrap();
+                Some(ScriptPath::with_defaults(&script_inner).leaf_hash())
+            }
+            (_, Some(script_leaf_hash)) => Some(script_leaf_hash.parse::<TapLeafHash>().unwrap()),
+            _ => None,
+        };
+        // All our tests use the default `0xFFFFFFFF` codeseparator value
+        let leaf_hash = leaf_hash.map(|lh| (lh, 0xFFFFFFFF));
+
+        let prevouts = if sighash_type.split_anyonecanpay_flag().1 && tx_bytes[0] % 2 == 0 {
+            // for anyonecanpay the `Prevouts::All` variant is good anyway, but sometimes we want to
+            // test other codepaths
+            Prevouts::One(input_index, prevouts[input_index].clone())
+        } else {
+            Prevouts::All(&prevouts)
+        };
+
+        let mut sighash_cache = SighashCache::new(&tx);
+
+        let hash = sighash_cache
+            .taproot_signature_hash(input_index, &prevouts, annex, leaf_hash, sighash_type)
+            .unwrap();
+        let expected = Vec::from_hex(expected_hash).unwrap();
+        assert_eq!(expected, hash.to_byte_array());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn bip_341_sighash_tests() {
+        use hex::DisplayHex;
+
+        fn sighash_deser_numeric<'de, D>(deserializer: D) -> Result<TapSighashType, D::Error>
+        where
+            D: actual_serde::Deserializer<'de>,
+        {
+            use actual_serde::de::{Deserialize, Error, Unexpected};
+
+            let raw = u8::deserialize(deserializer)?;
+            TapSighashType::from_consensus_u8(raw).map_err(|_| {
+                D::Error::invalid_value(
+                    Unexpected::Unsigned(raw.into()),
+                    &"number in range 0-3 or 0x81-0x83",
+                )
+            })
+        }
+
+        use secp256k1::{SecretKey, XOnlyPublicKey};
+
+        use crate::consensus::serde as con_serde;
+        use crate::taproot::{TapNodeHash, TapTweakHash};
+
+        #[derive(serde::Deserialize)]
+        #[serde(crate = "actual_serde")]
+        struct UtxoSpent {
+            #[serde(rename = "scriptPubKey")]
+            script_pubkey: ScriptBuf,
+            #[serde(rename = "amountSats")]
+            value: Amount,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KpsGiven {
+            #[serde(with = "con_serde::With::<con_serde::Hex>")]
+            raw_unsigned_tx: Transaction,
+            utxos_spent: Vec<UtxoSpent>,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KpsIntermediary {
+            hash_prevouts: sha256::Hash,
+            hash_outputs: sha256::Hash,
+            hash_sequences: sha256::Hash,
+            hash_amounts: sha256::Hash,
+            hash_script_pubkeys: sha256::Hash,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KpsInputSpendingGiven {
+            txin_index: usize,
+            internal_privkey: SecretKey,
+            merkle_root: Option<TapNodeHash>,
+            #[serde(deserialize_with = "sighash_deser_numeric")]
+            hash_type: TapSighashType,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KpsInputSpendingIntermediary {
+            internal_pubkey: XOnlyPublicKey,
+            tweak: TapTweakHash,
+            tweaked_privkey: SecretKey,
+            sig_msg: String,
+            //precomputed_used: Vec<String>, // unused
+            sig_hash: TapSighash,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KpsInputSpendingExpected {
+            witness: Vec<String>,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KpsInputSpending {
+            given: KpsInputSpendingGiven,
+            intermediary: KpsInputSpendingIntermediary,
+            expected: KpsInputSpendingExpected,
+            // auxiliary: KpsAuxiliary, //unused
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct KeyPathSpending {
+            given: KpsGiven,
+            intermediary: KpsIntermediary,
+            input_spending: Vec<KpsInputSpending>,
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(crate = "actual_serde")]
+        struct TestData {
+            version: u64,
+            key_path_spending: Vec<KeyPathSpending>,
+            //script_pubkey: Vec<ScriptPubKey>, // unused
+        }
+
+        let json_str = include_str!("../../tests/data/bip341_tests.json");
+        let mut data =
+            serde_json::from_str::<TestData>(json_str).expect("JSON was not well-formatted");
+
+        assert_eq!(data.version, 1u64);
+        let secp = &secp256k1::Secp256k1::new();
+        let key_path = data.key_path_spending.remove(0);
+
+        let raw_unsigned_tx = key_path.given.raw_unsigned_tx;
+        let utxos = key_path
+            .given
+            .utxos_spent
+            .into_iter()
+            .map(|txo| TxOut { value: txo.value, script_pubkey: txo.script_pubkey })
+            .collect::<Vec<_>>();
+
+        // Test intermediary
+        let mut cache = SighashCache::new(&raw_unsigned_tx);
+
+        let expected = key_path.intermediary;
+        // Compute all caches
+        assert_eq!(expected.hash_amounts, cache.taproot_cache(&utxos).amounts);
+        assert_eq!(expected.hash_outputs, cache.common_cache().outputs);
+        assert_eq!(expected.hash_prevouts, cache.common_cache().prevouts);
+        assert_eq!(expected.hash_script_pubkeys, cache.taproot_cache(&utxos).script_pubkeys);
+        assert_eq!(expected.hash_sequences, cache.common_cache().sequences);
+
+        for mut inp in key_path.input_spending {
+            let tx_ind = inp.given.txin_index;
+            let internal_priv_key = inp.given.internal_privkey;
+            let merkle_root = inp.given.merkle_root;
+            let hash_ty = inp.given.hash_type;
+
+            let expected = inp.intermediary;
+            let sig_str = inp.expected.witness.remove(0);
+            let (expected_key_spend_sig, expected_hash_ty) = if sig_str.len() == 128 {
+                (
+                    secp256k1::schnorr::Signature::from_str(&sig_str).unwrap(),
+                    TapSighashType::Default,
+                )
+            } else {
+                let hash_ty = u8::from_str_radix(&sig_str[128..130], 16).unwrap();
+                let hash_ty = TapSighashType::from_consensus_u8(hash_ty).unwrap();
+                (secp256k1::schnorr::Signature::from_str(&sig_str[..128]).unwrap(), hash_ty)
+            };
+
+            // tests
+            let keypair = secp256k1::Keypair::from_secret_key(secp, &internal_priv_key);
+            let (internal_key, _parity) = XOnlyPublicKey::from_keypair(&keypair);
+            let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
+            let tweaked_keypair = keypair.add_xonly_tweak(secp, &tweak.to_scalar()).unwrap();
+            let mut sig_msg = Vec::new();
+            cache
+                .taproot_encode_signing_data_to(
+                    &mut sig_msg,
+                    tx_ind,
+                    &Prevouts::All(&utxos),
+                    None,
+                    None,
+                    hash_ty,
+                )
+                .unwrap();
+            let sighash = cache
+                .taproot_signature_hash(tx_ind, &Prevouts::All(&utxos), None, None, hash_ty)
+                .unwrap();
+
+            let msg = secp256k1::Message::from(sighash);
+            let key_spend_sig = secp.sign_schnorr_with_aux_rand(&msg, &tweaked_keypair, &[0u8; 32]);
+
+            assert_eq!(expected.internal_pubkey, internal_key);
+            assert_eq!(expected.tweak, tweak);
+            assert_eq!(expected.sig_msg, sig_msg.to_lower_hex_string());
+            assert_eq!(expected.sig_hash, sighash);
+            assert_eq!(expected_hash_ty, hash_ty);
+            assert_eq!(expected_key_spend_sig, key_spend_sig);
+
+            let tweaked_priv_key = SecretKey::from_keypair(&tweaked_keypair);
+            assert_eq!(expected.tweaked_privkey, tweaked_priv_key);
+        }
+    }
+
+    #[test]
+    fn sighashtype_fromstr_display() {
+        let sighashtypes = vec![
+            ("SIGHASH_DEFAULT", TapSighashType::Default),
+            ("SIGHASH_ALL", TapSighashType::All),
+            ("SIGHASH_NONE", TapSighashType::None),
+            ("SIGHASH_SINGLE", TapSighashType::Single),
+            ("SIGHASH_ALL|SIGHASH_ANYONECANPAY", TapSighashType::AllPlusAnyoneCanPay),
+            ("SIGHASH_NONE|SIGHASH_ANYONECANPAY", TapSighashType::NonePlusAnyoneCanPay),
+            ("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY", TapSighashType::SinglePlusAnyoneCanPay),
+        ];
+        for (s, sht) in sighashtypes {
+            assert_eq!(sht.to_string(), s);
+            assert_eq!(TapSighashType::from_str(s).unwrap(), sht);
+        }
+        let sht_mistakes = vec![
+            "SIGHASH_ALL | SIGHASH_ANYONECANPAY",
+            "SIGHASH_NONE |SIGHASH_ANYONECANPAY",
+            "SIGHASH_SINGLE| SIGHASH_ANYONECANPAY",
+            "SIGHASH_ALL SIGHASH_ANYONECANPAY",
+            "SIGHASH_NONE |",
+            "SIGHASH_SIGNLE",
+            "DEFAULT",
+            "ALL",
+            "sighash_none",
+            "Sighash_none",
+            "SigHash_None",
+            "SigHash_NONE",
+        ];
+        for s in sht_mistakes {
+            assert_eq!(
+                TapSighashType::from_str(s).unwrap_err().to_string(),
+                format!("unrecognized SIGHASH string '{}'", s)
+            );
+        }
+    }
+
+    #[test]
+    fn bip143_p2wpkh() {
+        let tx = deserialize::<Transaction>(
+            &hex!(
+                "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f000000\
+                0000eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a01000000\
+                00ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093\
+                510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac11000000"
+            ),
+        ).unwrap();
+
+        let spk = ScriptBuf::from_hex("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1").unwrap();
+        let value = Amount::from_sat(600_000_000);
+
+        let mut cache = SighashCache::new(&tx);
+        assert_eq!(
+            cache.p2wpkh_signature_hash(1, &spk, value, EcdsaSighashType::All).unwrap(),
+            "c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670"
+                .parse::<SegwitV0Sighash>()
+                .unwrap(),
+        );
+
+        let cache = cache.segwit_cache();
+        // Parse hex into Vec because BIP143 test vector displays forwards but our sha256d::Hash displays backwards.
+        assert_eq!(
+            cache.prevouts.as_byte_array(),
+            &Vec::from_hex("96b827c8483d4e9b96712b6713a7b68d6e8003a781feba36c31143470b4efd37")
+                .unwrap()[..],
+        );
+        assert_eq!(
+            cache.sequences.as_byte_array(),
+            &Vec::from_hex("52b0a642eea2fb7ae638c36f6252b6750293dbe574a806984b8e4d8548339a3b")
+                .unwrap()[..],
+        );
+        assert_eq!(
+            cache.outputs.as_byte_array(),
+            &Vec::from_hex("863ef3e1a92afbfdb97f31ad0fc7683ee943e9abcf2501590ff8f6551f47e5e5")
+                .unwrap()[..],
+        );
+    }
+
+    #[test]
+    fn bip143_p2wpkh_nested_in_p2sh() {
+        let tx = deserialize::<Transaction>(
+            &hex!(
+                "0100000001db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000\
+                0000feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac00\
+                08af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac92040000"
+            ),
+        ).unwrap();
+
+        let redeem_script =
+            ScriptBuf::from_hex("001479091972186c449eb1ded22b78e40d009bdf0089").unwrap();
+        let value = Amount::from_sat(1_000_000_000);
+
+        let mut cache = SighashCache::new(&tx);
+        assert_eq!(
+            cache.p2wpkh_signature_hash(0, &redeem_script, value, EcdsaSighashType::All).unwrap(),
+            "64f3b0f4dd2bb3aa1ce8566d220cc74dda9df97d8490cc81d89d735c92e59fb6"
+                .parse::<SegwitV0Sighash>()
+                .unwrap(),
+        );
+
+        let cache = cache.segwit_cache();
+        // Parse hex into Vec because BIP143 test vector displays forwards but our sha256d::Hash displays backwards.
+        assert_eq!(
+            cache.prevouts.as_byte_array(),
+            &Vec::from_hex("b0287b4a252ac05af83d2dcef00ba313af78a3e9c329afa216eb3aa2a7b4613a")
+                .unwrap()[..],
+        );
+        assert_eq!(
+            cache.sequences.as_byte_array(),
+            &Vec::from_hex("18606b350cd8bf565266bc352f0caddcf01e8fa789dd8a15386327cf8cabe198")
+                .unwrap()[..],
+        );
+        assert_eq!(
+            cache.outputs.as_byte_array(),
+            &Vec::from_hex("de984f44532e2173ca0d64314fcefe6d30da6f8cf27bafa706da61df8a226c83")
+                .unwrap()[..],
+        );
+    }
+
+    // Note, if you are looking at the test vectors in BIP-143 and wondering why there is a `cf`
+    // prepended to all the script_code hex it is the length byte, it gets added when we consensus
+    // encode a script.
+    fn bip143_p2wsh_nested_in_p2sh_data() -> (Transaction, ScriptBuf, Amount) {
+        let tx = deserialize::<Transaction>(&hex!(
+            "010000000136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e0100000000\
+             ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688acc0832f\
+             05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac00000000"
+        ))
+        .unwrap();
+
+        let witness_script = ScriptBuf::from_hex(
+            "56210307b8ae49ac90a048e9b53357a2354b3334e9c8bee813ecb98e99a7e07e8c3ba32103b28f0c28\
+             bfab54554ae8c658ac5c3e0ce6e79ad336331f78c428dd43eea8449b21034b8113d703413d57761b8b\
+             9781957b8c0ac1dfe69f492580ca4195f50376ba4a21033400f6afecb833092a9a21cfdf1ed1376e58\
+             c5d1f47de74683123987e967a8f42103a6d48b1131e94ba04d9737d61acdaa1322008af9602b3b1486\
+             2c07a1789aac162102d8b661b0b3302ee2f162b09e07a55ad5dfbe673a9f01d9f0c19617681024306b\
+             56ae",
+        )
+        .unwrap();
+
+        let value = Amount::from_sat(987_654_321);
+        (tx, witness_script, value)
+    }
+
+    #[test]
+    fn bip143_p2wsh_nested_in_p2sh_sighash_type_all() {
+        let (tx, witness_script, value) = bip143_p2wsh_nested_in_p2sh_data();
+        let mut cache = SighashCache::new(&tx);
+        assert_eq!(
+            cache.p2wsh_signature_hash(0, &witness_script, value, EcdsaSighashType::All).unwrap(),
+            "185c0be5263dce5b4bb50a047973c1b6272bfbd0103a89444597dc40b248ee7c"
+                .parse::<SegwitV0Sighash>()
+                .unwrap(),
+        );
+
+        // We only test the cache intermediate values for `EcdsaSighashType::All` because they are
+        // not the same as the BIP test vectors for all the rest of the sighash types. These fields
+        // are private so it does not effect sighash cache usage, we do test against the produced
+        // sighash for all sighash types.
+
+        let cache = cache.segwit_cache();
+        // Parse hex into Vec because BIP143 test vector displays forwards but our sha256d::Hash displays backwards.
+        assert_eq!(
+            cache.prevouts.as_byte_array(),
+            &Vec::from_hex("74afdc312af5183c4198a40ca3c1a275b485496dd3929bca388c4b5e31f7aaa0")
+                .unwrap()[..],
+        );
+        assert_eq!(
+            cache.sequences.as_byte_array(),
+            &Vec::from_hex("3bb13029ce7b1f559ef5e747fcac439f1455a2ec7c5f09b72290795e70665044")
+                .unwrap()[..],
+        );
+        assert_eq!(
+            cache.outputs.as_byte_array(),
+            &Vec::from_hex("bc4d309071414bed932f98832b27b4d76dad7e6c1346f487a8fdbb8eb90307cc")
+                .unwrap()[..],
+        );
+    }
+
+    macro_rules! check_bip143_p2wsh_nested_in_p2sh {
+        ($($test_name:ident, $sighash_type:ident, $sighash:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    use EcdsaSighashType::*;
+
+                    let (tx, witness_script, value) = bip143_p2wsh_nested_in_p2sh_data();
+                    let mut cache = SighashCache::new(&tx);
+                    assert_eq!(
+                        cache
+                            .p2wsh_signature_hash(0, &witness_script, value, $sighash_type)
+                            .unwrap(),
+                        $sighash
+                            .parse::<SegwitV0Sighash>()
+                            .unwrap(),
+                    );
+                }
+            )*
+        }
+    }
+    check_bip143_p2wsh_nested_in_p2sh! {
+        // EcdsaSighashType::All tested above.
+        bip143_p2wsh_nested_in_p2sh_sighash_none, None, "e9733bc60ea13c95c6527066bb975a2ff29a925e80aa14c213f686cbae5d2f36";
+        bip143_p2wsh_nested_in_p2sh_sighash_single, Single, "1e1f1c303dc025bd664acb72e583e933fae4cff9148bf78c157d1e8f78530aea";
+        bip143_p2wsh_nested_in_p2sh_sighash_all_plus_anyonecanpay, AllPlusAnyoneCanPay, "2a67f03e63a6a422125878b40b82da593be8d4efaafe88ee528af6e5a9955c6e";
+        bip143_p2wsh_nested_in_p2sh_sighash_none_plus_anyonecanpay, NonePlusAnyoneCanPay, "781ba15f3779d5542ce8ecb5c18716733a5ee42a6f51488ec96154934e2c890a";
+        bip143_p2wsh_nested_in_p2sh_sighash_single_plus_anyonecanpay, SinglePlusAnyoneCanPay, "511e8e52ed574121fc1b654970395502128263f62662e076dc6baf05c2e6a99b";
+    }
+}

--- a/libs/bitcoin/src/crypto/taproot.rs
+++ b/libs/bitcoin/src/crypto/taproot.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin taproot keys.
+//!
+//! This module provides taproot keys used in Bitcoin (including reexporting secp256k1 keys).
+//!
+
+use core::fmt;
+
+use internals::write_err;
+use io::Write;
+
+use crate::prelude::*;
+use crate::sighash::{InvalidSighashTypeError, TapSighashType};
+use crate::taproot::serialized_signature::{self, SerializedSignature};
+
+/// A BIP340-341 serialized taproot signature with the corresponding hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Signature {
+    /// The underlying schnorr signature.
+    pub signature: secp256k1::schnorr::Signature,
+    /// The corresponding hash type.
+    pub sighash_type: TapSighashType,
+}
+
+impl Signature {
+    /// Deserialize from slice
+    pub fn from_slice(sl: &[u8]) -> Result<Self, SigFromSliceError> {
+        match sl.len() {
+            64 => {
+                // default type
+                let signature = secp256k1::schnorr::Signature::from_slice(sl)?;
+                Ok(Signature { signature, sighash_type: TapSighashType::Default })
+            }
+            65 => {
+                let (sighash_type, signature) = sl.split_last().expect("Slice len checked == 65");
+                let sighash_type = TapSighashType::from_consensus_u8(*sighash_type)?;
+                let signature = secp256k1::schnorr::Signature::from_slice(signature)?;
+                Ok(Signature { signature, sighash_type })
+            }
+            len => Err(SigFromSliceError::InvalidSignatureSize(len)),
+        }
+    }
+
+    /// Serialize Signature
+    ///
+    /// Note: this allocates on the heap, prefer [`serialize`](Self::serialize) if vec is not needed.
+    pub fn to_vec(self) -> Vec<u8> {
+        let mut ser_sig = self.signature.as_ref().to_vec();
+        if self.sighash_type == TapSighashType::Default {
+            // default sighash type, don't add extra sighash byte
+        } else {
+            ser_sig.push(self.sighash_type as u8);
+        }
+        ser_sig
+    }
+
+    /// Serializes the signature to `writer`.
+    #[inline]
+    pub fn serialize_to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        let sig = self.serialize();
+        sig.write_to(writer)
+    }
+
+    /// Serializes the signature (without heap allocation)
+    ///
+    /// This returns a type with an API very similar to that of `Box<[u8]>`.
+    /// You can get a slice from it using deref coercions or turn it into an iterator.
+    pub fn serialize(self) -> SerializedSignature {
+        let mut buf = [0; serialized_signature::MAX_LEN];
+        let ser_sig = self.signature.serialize();
+        buf[..64].copy_from_slice(&ser_sig);
+        let len = if self.sighash_type == TapSighashType::Default {
+            // default sighash type, don't add extra sighash byte
+            64
+        } else {
+            buf[64] = self.sighash_type as u8;
+            65
+        };
+        SerializedSignature::from_raw_parts(buf, len)
+    }
+}
+
+/// An error constructing a [`taproot::Signature`] from a byte slice.
+///
+/// [`taproot::Signature`]: crate::crypto::taproot::Signature
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SigFromSliceError {
+    /// Invalid signature hash type.
+    SighashType(InvalidSighashTypeError),
+    /// A secp256k1 error.
+    Secp256k1(secp256k1::Error),
+    /// Invalid taproot signature size
+    InvalidSignatureSize(usize),
+}
+
+internals::impl_from_infallible!(SigFromSliceError);
+
+impl fmt::Display for SigFromSliceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use SigFromSliceError::*;
+
+        match *self {
+            SighashType(ref e) => write_err!(f, "sighash"; e),
+            Secp256k1(ref e) => write_err!(f, "secp256k1"; e),
+            InvalidSignatureSize(sz) => write!(f, "invalid taproot signature size: {}", sz),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SigFromSliceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use SigFromSliceError::*;
+
+        match *self {
+            Secp256k1(ref e) => Some(e),
+            SighashType(ref e) => Some(e),
+            InvalidSignatureSize(_) => None,
+        }
+    }
+}
+
+impl From<secp256k1::Error> for SigFromSliceError {
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
+}
+
+impl From<InvalidSighashTypeError> for SigFromSliceError {
+    fn from(err: InvalidSighashTypeError) -> Self { Self::SighashType(err) }
+}

--- a/libs/bitcoin/src/error.rs
+++ b/libs/bitcoin/src/error.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Contains error types and other error handling tools.
+
+use core::fmt;
+
+use internals::write_err;
+
+use crate::prelude::*;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use crate::parse::ParseIntError;
+
+/// Error returned when parsing integer from an supposedly prefixed hex string for
+/// a type that can be created infallibly from an integer.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PrefixedHexError {
+    /// Hex string is missing prefix.
+    MissingPrefix(MissingPrefixError),
+    /// Error parsing integer from hex string.
+    ParseInt(ParseIntError),
+}
+
+impl fmt::Display for PrefixedHexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use PrefixedHexError::*;
+
+        match *self {
+            MissingPrefix(ref e) => write_err!(f, "hex string is missing prefix"; e),
+            ParseInt(ref e) => write_err!(f, "prefixed hex string invalid int"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PrefixedHexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use PrefixedHexError::*;
+
+        match *self {
+            MissingPrefix(ref e) => Some(e),
+            ParseInt(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<MissingPrefixError> for PrefixedHexError {
+    fn from(e: MissingPrefixError) -> Self { Self::MissingPrefix(e) }
+}
+
+impl From<ParseIntError> for PrefixedHexError {
+    fn from(e: ParseIntError) -> Self { Self::ParseInt(e) }
+}
+
+/// Error returned when parsing integer from an supposedly un-prefixed hex string.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum UnprefixedHexError {
+    /// Hex string contains prefix.
+    ContainsPrefix(ContainsPrefixError),
+    /// Error parsing integer from string.
+    ParseInt(ParseIntError),
+}
+
+impl fmt::Display for UnprefixedHexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use UnprefixedHexError::*;
+
+        match *self {
+            ContainsPrefix(ref e) => write_err!(f, "hex string is contains prefix"; e),
+            ParseInt(ref e) => write_err!(f, "hex string parse int"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnprefixedHexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use UnprefixedHexError::*;
+
+        match *self {
+            ContainsPrefix(ref e) => Some(e),
+            ParseInt(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ContainsPrefixError> for UnprefixedHexError {
+    fn from(e: ContainsPrefixError) -> Self { Self::ContainsPrefix(e) }
+}
+
+impl From<ParseIntError> for UnprefixedHexError {
+    fn from(e: ParseIntError) -> Self { Self::ParseInt(e) }
+}
+
+/// Error when hex string is missing a prefix (e.g. 0x).
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MissingPrefixError {
+    hex: String,
+}
+
+impl MissingPrefixError {
+    pub(crate) fn new(s: &str) -> Self { Self { hex: s.into() } }
+}
+
+impl fmt::Display for MissingPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "hex string is missing a prefix (e.g. 0x): {}", self.hex)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MissingPrefixError {}
+
+/// Error when hex string contains a prefix (e.g. 0x).
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ContainsPrefixError {
+    hex: String,
+}
+
+impl ContainsPrefixError {
+    pub(crate) fn new(s: &str) -> Self { Self { hex: s.into() } }
+}
+
+impl fmt::Display for ContainsPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "hex string contains a prefix: {}", self.hex)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ContainsPrefixError {}

--- a/libs/bitcoin/src/hash_types.rs
+++ b/libs/bitcoin/src/hash_types.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin hash types.
+//!
+//! This module is deprecated. You can find hash types in their respective, hopefully obvious, modules.
+
+#[deprecated(since = "0.0.0-NEXT-RELEASE", note = "use crate::T instead")]
+pub use crate::{
+    BlockHash, FilterHash, FilterHeader, TxMerkleNode, Txid, WitnessCommitment, WitnessMerkleNode,
+    Wtxid,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hashes::Hash;
+    use crate::{
+        LegacySighash, PubkeyHash, ScriptHash, SegwitV0Sighash, TapSighash, WPubkeyHash,
+        WScriptHash, XKeyIdentifier,
+    };
+
+    #[test]
+    fn hash_display() {
+        assert_eq!(
+            Txid::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+
+        assert_eq!(
+            Wtxid::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+        assert_eq!(
+            BlockHash::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+        assert_eq!(
+            LegacySighash::hash(&[]).to_string(),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456",
+        );
+        assert_eq!(
+            SegwitV0Sighash::hash(&[]).to_string(),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456",
+        );
+        assert_eq!(
+            TapSighash::hash(&[]).to_string(),
+            "dabc11914abcd8072900042a2681e52f8dba99ce82e224f97b5fdb7cd4b9c803",
+        );
+
+        assert_eq!(PubkeyHash::hash(&[]).to_string(), "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",);
+        assert_eq!(ScriptHash::hash(&[]).to_string(), "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",);
+        assert_eq!(WPubkeyHash::hash(&[]).to_string(), "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",);
+        assert_eq!(
+            WScriptHash::hash(&[]).to_string(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+
+        assert_eq!(
+            TxMerkleNode::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+        assert_eq!(
+            WitnessMerkleNode::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+        assert_eq!(
+            WitnessCommitment::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+        assert_eq!(
+            XKeyIdentifier::hash(&[]).to_string(),
+            "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",
+        );
+
+        assert_eq!(
+            FilterHash::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+        assert_eq!(
+            FilterHeader::hash(&[]).to_string(),
+            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
+        );
+    }
+}

--- a/libs/bitcoin/src/internal_macros.rs
+++ b/libs/bitcoin/src/internal_macros.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Internal macros.
+//!
+//! Macros meant to be used inside the Rust Bitcoin library.
+//!
+
+macro_rules! impl_consensus_encoding {
+    ($thing:ident, $($field:ident),+) => (
+        impl $crate::consensus::Encodable for $thing {
+            #[inline]
+            fn consensus_encode<R: $crate::io::Write + ?Sized>(
+                &self,
+                r: &mut R,
+            ) -> core::result::Result<usize, $crate::io::Error> {
+                let mut len = 0;
+                $(len += self.$field.consensus_encode(r)?;)+
+                Ok(len)
+            }
+        }
+
+        impl $crate::consensus::Decodable for $thing {
+
+            #[inline]
+            fn consensus_decode_from_finite_reader<R: $crate::io::Read + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
+                Ok($thing {
+                    $($field: $crate::consensus::Decodable::consensus_decode_from_finite_reader(r)?),+
+                })
+            }
+
+            #[inline]
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
+                let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
+                Ok($thing {
+                    $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
+                })
+            }
+        }
+    );
+}
+pub(crate) use impl_consensus_encoding;
+
+/// Implements several traits for byte-based newtypes.
+/// Implements:
+/// - core::fmt::LowerHex
+/// - core::fmt::UpperHex
+/// - core::fmt::Display
+/// - core::str::FromStr
+macro_rules! impl_bytes_newtype {
+    ($t:ident, $len:literal) => {
+        impl $t {
+            /// Returns a reference the underlying bytes.
+            #[inline]
+            pub fn as_bytes(&self) -> &[u8; $len] { &self.0 }
+
+            /// Returns the underlying bytes.
+            #[inline]
+            pub fn to_bytes(self) -> [u8; $len] {
+                // We rely on `Copy` being implemented for $t so conversion
+                // methods use the correct Rust naming conventions.
+                fn check_copy<T: Copy>() {}
+                check_copy::<$t>();
+
+                self.0
+            }
+
+            /// Creates `Self` from a hex string.
+            pub fn from_hex(s: &str) -> Result<Self, hex::HexToArrayError> {
+                Ok($t($crate::hex::FromHex::from_hex(s)?))
+            }
+        }
+
+        impl core::fmt::LowerHex for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                use $crate::hex::{display, Case};
+                display::fmt_hex_exact!(f, $len, &self.0, Case::Lower)
+            }
+        }
+
+        impl core::fmt::UpperHex for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                use $crate::hex::{display, Case};
+                display::fmt_hex_exact!(f, $len, &self.0, Case::Upper)
+            }
+        }
+
+        impl core::fmt::Display for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                core::fmt::LowerHex::fmt(self, f)
+            }
+        }
+
+        impl core::fmt::Debug for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                core::fmt::LowerHex::fmt(self, f)
+            }
+        }
+
+        impl core::str::FromStr for $t {
+            type Err = $crate::hex::HexToArrayError;
+            fn from_str(s: &str) -> core::result::Result<Self, Self::Err> { Self::from_hex(s) }
+        }
+
+        #[cfg(feature = "serde")]
+        impl $crate::serde::Serialize for $t {
+            fn serialize<S: $crate::serde::Serializer>(
+                &self,
+                s: S,
+            ) -> core::result::Result<S::Ok, S::Error> {
+                if s.is_human_readable() {
+                    s.collect_str(self)
+                } else {
+                    s.serialize_bytes(&self[..])
+                }
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Deserialize<'de> for $t {
+            fn deserialize<D: $crate::serde::Deserializer<'de>>(
+                d: D,
+            ) -> core::result::Result<$t, D::Error> {
+                if d.is_human_readable() {
+                    struct HexVisitor;
+
+                    impl<'de> $crate::serde::de::Visitor<'de> for HexVisitor {
+                        type Value = $t;
+
+                        fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                            f.write_str("an ASCII hex string")
+                        }
+
+                        fn visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            use $crate::serde::de::Unexpected;
+
+                            if let Ok(hex) = core::str::from_utf8(v) {
+                                core::str::FromStr::from_str(hex).map_err(E::custom)
+                            } else {
+                                return Err(E::invalid_value(Unexpected::Bytes(v), &self));
+                            }
+                        }
+
+                        fn visit_str<E>(self, hex: &str) -> core::result::Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            core::str::FromStr::from_str(hex).map_err(E::custom)
+                        }
+                    }
+
+                    d.deserialize_str(HexVisitor)
+                } else {
+                    struct BytesVisitor;
+
+                    impl<'de> $crate::serde::de::Visitor<'de> for BytesVisitor {
+                        type Value = $t;
+
+                        fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                            f.write_str("a bytestring")
+                        }
+
+                        fn visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            if v.len() != $len {
+                                Err(E::invalid_length(v.len(), &stringify!($len)))
+                            } else {
+                                let mut ret = [0; $len];
+                                ret.copy_from_slice(v);
+                                Ok($t(ret))
+                            }
+                        }
+                    }
+
+                    d.deserialize_bytes(BytesVisitor)
+                }
+            }
+        }
+    };
+}
+pub(crate) use impl_bytes_newtype;
+
+#[rustfmt::skip]
+macro_rules! impl_hashencode {
+    ($hashtype:ident) => {
+        impl $crate::consensus::Encodable for $hashtype {
+            fn consensus_encode<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, $crate::io::Error> {
+                self.0.consensus_encode(w)
+            }
+        }
+
+        impl $crate::consensus::Decodable for $hashtype {
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
+                use $crate::hashes::Hash;
+                Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
+            }
+        }
+    };
+}
+pub(crate) use impl_hashencode;
+
+#[rustfmt::skip]
+macro_rules! impl_asref_push_bytes {
+    ($($hashtype:ident),*) => {
+        $(
+            impl AsRef<$crate::blockdata::script::PushBytes> for $hashtype {
+                fn as_ref(&self) -> &$crate::blockdata::script::PushBytes {
+                    use $crate::hashes::Hash;
+                    self.as_byte_array().into()
+                }
+            }
+
+            impl From<$hashtype> for $crate::blockdata::script::PushBytesBuf {
+                fn from(hash: $hashtype) -> Self {
+                    use $crate::hashes::Hash;
+                    hash.as_byte_array().into()
+                }
+            }
+        )*
+    };
+}
+pub(crate) use impl_asref_push_bytes;

--- a/libs/bitcoin/src/lib.rs
+++ b/libs/bitcoin/src/lib.rs
@@ -121,8 +121,8 @@ mod prelude {
     #[cfg(all(not(feature = "std"), not(test)))]
     pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, slice, rc};
 
-    #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
-    pub use alloc::sync;
+    // #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
+    // pub use alloc::sync;
 
     #[cfg(any(feature = "std", test))]
     pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, rc, sync};

--- a/libs/bitcoin/src/lib.rs
+++ b/libs/bitcoin/src/lib.rs
@@ -1,0 +1,177 @@
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(bench, feature(test))]
+// Coding conventions.
+#![warn(missing_docs)]
+// Instead of littering the codebase for non-fuzzing code just globally allow.
+#![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+// For 0.32.x releases only.
+#![allow(deprecated)]
+
+// // Disable 16-bit support at least for now as we can't guarantee it yet.
+// #[cfg(target_pointer_width = "16")]
+// compile_error!(
+//     "rust-bitcoin currently only supports architectures with pointers wider than 16 bits, let us
+//     know if you want 16-bit support. Note that we do NOT guarantee that we will implement it!"
+// );
+
+// #[cfg(bench)]
+// extern crate test;
+
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "base64")]
+/// Encodes and decodes base64 as bytes or utf8.
+pub extern crate base64;
+
+/// Bitcoin base58 encoding and decoding.
+pub extern crate base58;
+
+/// Re-export the `bech32` crate.
+pub extern crate bech32;
+
+/// Rust implementation of cryptographic hash function algorithms.
+pub extern crate hashes;
+
+/// Re-export the `hex-conservative` crate.
+pub extern crate hex;
+
+/// Re-export the `bitcoin-io` crate.
+pub extern crate io;
+
+/// Re-export the `ordered` crate.
+#[cfg(feature = "ordered")]
+pub extern crate ordered;
+
+/// Rust wrapper library for Pieter Wuille's libsecp256k1.  Implements ECDSA and BIP 340 signatures
+/// for the SECG elliptic curve group secp256k1 and related utilities.
+pub extern crate secp256k1;
+
+// #[cfg(feature = "serde")]
+// #[macro_use]
+// extern crate actual_serde as serde;
+
+// #[cfg(test)]
+// #[macro_use]
+// mod test_macros;
+mod internal_macros;
+// #[cfg(feature = "serde")]
+// mod serde_utils;
+
+// #[macro_use]
+pub mod address;
+pub mod bip152;
+pub mod bip158;
+pub mod bip32;
+pub mod blockdata;
+pub mod consensus;
+pub mod p2p;
+// Private until we either make this a crate or flatten it - still to be decided.
+pub(crate) mod crypto;
+pub mod error;
+pub mod hash_types;
+pub mod merkle_tree;
+pub mod network;
+pub mod policy;
+pub mod pow;
+pub mod psbt;
+// pub mod sign_message;
+pub mod taproot;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use crate::{
+    address::{Address, AddressType, KnownHrp},
+    amount::{Amount, Denomination, SignedAmount},
+    bip158::{FilterHash, FilterHeader},
+    bip32::XKeyIdentifier,
+    blockdata::block::{self, Block, BlockHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment},
+    blockdata::constants,
+    blockdata::fee_rate::FeeRate,
+    blockdata::locktime::{self, absolute, relative},
+    blockdata::opcodes::{self, Opcode},
+    blockdata::script::witness_program::{self, WitnessProgram},
+    blockdata::script::witness_version::{self, WitnessVersion},
+    blockdata::script::{self, Script, ScriptBuf, ScriptHash, WScriptHash},
+    blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Wtxid},
+    blockdata::weight::Weight,
+    blockdata::witness::{self, Witness},
+    consensus::encode::VarInt,
+    consensus::params,
+    crypto::ecdsa,
+    crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
+    crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
+    merkle_tree::MerkleBlock,
+    network::{Network, NetworkKind},
+    pow::{CompactTarget, Target, Work},
+    psbt::Psbt,
+    sighash::{EcdsaSighashType, TapSighashType},
+    taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
+};
+
+#[rustfmt::skip]
+#[allow(unused_imports)]
+mod prelude {
+    #[cfg(all(not(feature = "std"), not(test)))]
+    pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, slice, rc};
+
+    #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
+    pub use alloc::sync;
+
+    #[cfg(any(feature = "std", test))]
+    pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, rc, sync};
+
+    #[cfg(all(not(feature = "std"), not(test)))]
+    pub use alloc::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
+
+    #[cfg(any(feature = "std", test))]
+    pub use std::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
+
+    pub use crate::io::sink;
+
+    pub use hex::DisplayHex;
+}
+
+pub mod amount {
+    //! Bitcoin amounts.
+    //!
+    //! This module mainly introduces the [Amount] and [SignedAmount] types.
+    //! We refer to the documentation on the types for more information.
+
+    use crate::consensus::{encode, Decodable, Encodable};
+    use crate::io::{Read, Write};
+
+    #[rustfmt::skip]            // Keep public re-exports separate.
+    #[doc(inline)]
+    pub use units::amount::{
+        Amount, CheckedSum, Denomination, Display, ParseAmountError, SignedAmount,
+    };
+    #[cfg(feature = "serde")]
+    pub use units::amount::serde;
+
+    impl Decodable for Amount {
+        #[inline]
+        fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+            Ok(Amount::from_sat(Decodable::consensus_decode(r)?))
+        }
+    }
+
+    impl Encodable for Amount {
+        #[inline]
+        fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+            self.to_sat().consensus_encode(w)
+        }
+    }
+}
+
+/// Unit parsing utilities.
+pub mod parse {
+    /// Re-export everything from the [`units::parse`] module.
+    pub use units::parse::ParseIntError;
+}

--- a/libs/bitcoin/src/merkle_tree/block.rs
+++ b/libs/bitcoin/src/merkle_tree/block.rs
@@ -1,0 +1,872 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// This code was translated from merkleblock.h, merkleblock.cpp and pmt_tests.cpp
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// SPDX-License-Identifier: MIT
+
+//! Merkle Block and Partial Merkle Tree.
+//!
+//! Support proofs that transaction(s) belong to a block.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use bitcoin::hash_types::Txid;
+//! use bitcoin::hex::FromHex;
+//! use bitcoin::{Block, MerkleBlock};
+//!
+//! // Get the proof from a bitcoind by running in the terminal:
+//! // $ TXID="5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2"
+//! // $ bitcoin-cli gettxoutproof [\"$TXID\"]
+//! let mb_bytes = Vec::from_hex("01000000ba8b9cda965dd8e536670f9ddec10e53aab14b20bacad27b913719\
+//!     0000000000190760b278fe7b8565fda3b968b918d5fd997f993b23674c0af3b6fde300b38f33a5914ce6ed5b\
+//!     1b01e32f570200000002252bf9d75c4f481ebb6278d708257d1f12beb6dd30301d26c623f789b2ba6fc0e2d3\
+//!     2adb5f8ca820731dff234a84e78ec30bce4ec69dbd562d0b2b8266bf4e5a0105").unwrap();
+//! let mb: MerkleBlock = bitcoin::consensus::deserialize(&mb_bytes).unwrap();
+//!
+//! // Authenticate and extract matched transaction ids
+//! let mut matches: Vec<Txid> = vec![];
+//! let mut index: Vec<u32> = vec![];
+//! assert!(mb.extract_matches(&mut matches, &mut index).is_ok());
+//! assert_eq!(1, matches.len());
+//! assert_eq!(
+//!     "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2".parse::<Txid>().unwrap(),
+//!     matches[0]
+//! );
+//! assert_eq!(1, index.len());
+//! assert_eq!(1, index[0]);
+//! ```
+
+use core::fmt;
+
+use hashes::Hash;
+use io::{Read, Write};
+
+use self::MerkleBlockError::*;
+use crate::blockdata::block::{self, Block, TxMerkleNode};
+use crate::blockdata::transaction::{Transaction, Txid};
+use crate::blockdata::weight::Weight;
+use crate::consensus::encode::{self, Decodable, Encodable, MAX_VEC_SIZE};
+use crate::prelude::*;
+
+/// Data structure that represents a block header paired to a partial merkle tree.
+///
+/// NOTE: This assumes that the given Block has *at least* 1 transaction. If the Block has 0 txs,
+/// it will hit an assertion.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct MerkleBlock {
+    /// The block header
+    pub header: block::Header,
+    /// Transactions making up a partial merkle tree
+    pub txn: PartialMerkleTree,
+}
+
+impl MerkleBlock {
+    /// Create a MerkleBlock from a block, that contains proofs for specific txids.
+    ///
+    /// The `block` is a full block containing the header and transactions and `match_txids` is a
+    /// function that returns true for the ids that should be included in the partial merkle tree.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::hash_types::Txid;
+    /// use bitcoin::hex::FromHex;
+    /// use bitcoin::{Block, MerkleBlock};
+    ///
+    /// // Block 80000
+    /// let block_bytes = Vec::from_hex("01000000ba8b9cda965dd8e536670f9ddec10e53aab14b20bacad2\
+    ///     7b9137190000000000190760b278fe7b8565fda3b968b918d5fd997f993b23674c0af3b6fde300b38f33\
+    ///     a5914ce6ed5b1b01e32f5702010000000100000000000000000000000000000000000000000000000000\
+    ///     00000000000000ffffffff0704e6ed5b1b014effffffff0100f2052a01000000434104b68a50eaa0287e\
+    ///     ff855189f949c1c6e5f58b37c88231373d8a59809cbae83059cc6469d65c665ccfd1cfeb75c6e8e19413\
+    ///     bba7fbff9bc762419a76d87b16086eac000000000100000001a6b97044d03da79c005b20ea9c0e1a6d9d\
+    ///     c12d9f7b91a5911c9030a439eed8f5000000004948304502206e21798a42fae0e854281abd38bacd1aee\
+    ///     d3ee3738d9e1446618c4571d1090db022100e2ac980643b0b82c0e88ffdfec6b64e3e6ba35e7ba5fdd7d\
+    ///     5d6cc8d25c6b241501ffffffff0100f2052a010000001976a914404371705fa9bd789a2fcd52d2c580b6\
+    ///     5d35549d88ac00000000").unwrap();
+    /// let block: Block = bitcoin::consensus::deserialize(&block_bytes).unwrap();
+    ///
+    /// // Create a merkle block containing a single transaction
+    /// let txid = "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2".parse::<Txid>().unwrap();
+    /// let match_txids: Vec<Txid> = vec![txid].into_iter().collect();
+    /// let mb = MerkleBlock::from_block_with_predicate(&block, |t| match_txids.contains(t));
+    ///
+    /// // Authenticate and extract matched transaction ids
+    /// let mut matches: Vec<Txid> = vec![];
+    /// let mut index: Vec<u32> = vec![];
+    /// assert!(mb.extract_matches(&mut matches, &mut index).is_ok());
+    /// assert_eq!(txid, matches[0]);
+    /// ```
+    pub fn from_block_with_predicate<F>(block: &Block, match_txids: F) -> Self
+    where
+        F: Fn(&Txid) -> bool,
+    {
+        let block_txids: Vec<_> = block.txdata.iter().map(Transaction::compute_txid).collect();
+        Self::from_header_txids_with_predicate(&block.header, &block_txids, match_txids)
+    }
+
+    /// Create a MerkleBlock from the block's header and txids, that contain proofs for specific txids.
+    ///
+    /// The `header` is the block header, `block_txids` is the full list of txids included in the block and
+    /// `match_txids` is a function that returns true for the ids that should be included in the partial merkle tree.
+    pub fn from_header_txids_with_predicate<F>(
+        header: &block::Header,
+        block_txids: &[Txid],
+        match_txids: F,
+    ) -> Self
+    where
+        F: Fn(&Txid) -> bool,
+    {
+        let matches: Vec<bool> = block_txids.iter().map(match_txids).collect();
+
+        let pmt = PartialMerkleTree::from_txids(block_txids, &matches);
+        MerkleBlock {
+            header: *header,
+            txn: pmt,
+        }
+    }
+
+    /// Extract the matching txid's represented by this partial merkle tree
+    /// and their respective indices within the partial tree.
+    /// returns Ok(()) on success, or error in case of failure
+    pub fn extract_matches(
+        &self,
+        matches: &mut Vec<Txid>,
+        indexes: &mut Vec<u32>,
+    ) -> Result<(), MerkleBlockError> {
+        let merkle_root = self.txn.extract_matches(matches, indexes)?;
+
+        if merkle_root.eq(&self.header.merkle_root) {
+            Ok(())
+        } else {
+            Err(MerkleRootMismatch)
+        }
+    }
+}
+
+impl Encodable for MerkleBlock {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let len = self.header.consensus_encode(w)? + self.txn.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
+impl Decodable for MerkleBlock {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(MerkleBlock {
+            header: Decodable::consensus_decode(r)?,
+            txn: Decodable::consensus_decode(r)?,
+        })
+    }
+}
+
+/// Data structure that represents a partial merkle tree.
+///
+/// It represents a subset of the txid's of a known block, in a way that
+/// allows recovery of the list of txid's and the merkle root, in an
+/// authenticated way.
+///
+/// The encoding works as follows: we traverse the tree in depth-first order,
+/// storing a bit for each traversed node, signifying whether the node is the
+/// parent of at least one matched leaf txid (or a matched txid itself). In
+/// case we are at the leaf level, or this bit is 0, its merkle node hash is
+/// stored, and its children are not explored further. Otherwise, no hash is
+/// stored, but we recurse into both (or the only) child branch. During
+/// decoding, the same depth-first traversal is performed, consuming bits and
+/// hashes as they written during encoding.
+///
+/// The serialization is fixed and provides a hard guarantee about the
+/// encoded size:
+///
+///   SIZE <= 10 + ceil(32.25*N)
+///
+/// Where N represents the number of leaf nodes of the partial tree. N itself
+/// is bounded by:
+///
+///   N <= total_transactions
+///   N <= 1 + matched_transactions*tree_height
+///
+/// The serialization format:
+///  - uint32     total_transactions (4 bytes)
+///  - varint     number of hashes   (1-3 bytes)
+///  - uint256[]  hashes in depth-first order (<= 32*N bytes)
+///  - varint     number of bytes of flag bits (1-3 bytes)
+///  - byte[]     flag bits, packed per 8 in a byte, least significant bit first (<= 2*N-1 bits)
+///
+/// The size constraints follow from this.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct PartialMerkleTree {
+    /// The total number of transactions in the block
+    num_transactions: u32,
+    /// node-is-parent-of-matched-txid bits
+    bits: Vec<bool>,
+    /// Transaction ids and internal hashes
+    hashes: Vec<TxMerkleNode>,
+}
+
+impl PartialMerkleTree {
+    /// Returns the total number of transactions in the block.
+    pub fn num_transactions(&self) -> u32 {
+        self.num_transactions
+    }
+
+    /// Returns the node-is-parent-of-matched-txid bits of the partial merkle tree.
+    pub fn bits(&self) -> &Vec<bool> {
+        &self.bits
+    }
+
+    /// Returns the transaction ids and internal hashes of the partial merkle tree.
+    pub fn hashes(&self) -> &Vec<TxMerkleNode> {
+        &self.hashes
+    }
+
+    /// Construct a partial merkle tree
+    /// The `txids` are the transaction hashes of the block and the `matches` is the contains flags
+    /// wherever a tx hash should be included in the proof.
+    ///
+    /// Panics when `txids` is empty or when `matches` has a different length
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::hash_types::Txid;
+    /// use bitcoin::hex::FromHex;
+    /// use bitcoin::merkle_tree::{MerkleBlock, PartialMerkleTree};
+    ///
+    /// // Block 80000
+    /// let txids: Vec<Txid> = [
+    ///     "c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25",
+    ///     "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2",
+    /// ]
+    /// .iter()
+    /// .map(|hex| hex.parse::<Txid>().unwrap())
+    /// .collect();
+    ///
+    /// // Select the second transaction
+    /// let matches = vec![false, true];
+    /// let tree = PartialMerkleTree::from_txids(&txids, &matches);
+    /// assert!(tree.extract_matches(&mut vec![], &mut vec![]).is_ok());
+    /// ```
+    pub fn from_txids(txids: &[Txid], matches: &[bool]) -> Self {
+        // We can never have zero txs in a merkle block, we always need the coinbase tx
+        assert_ne!(txids.len(), 0);
+        assert_eq!(txids.len(), matches.len());
+
+        let mut pmt = PartialMerkleTree {
+            num_transactions: txids.len() as u32,
+            bits: Vec::with_capacity(txids.len()),
+            hashes: vec![],
+        };
+        let height = pmt.calc_tree_height();
+
+        // traverse the partial tree
+        pmt.traverse_and_build(height, 0, txids, matches);
+        pmt
+    }
+
+    /// Extract the matching txid's represented by this partial merkle tree
+    /// and their respective indices within the partial tree.
+    /// returns the merkle root, or error in case of failure
+    pub fn extract_matches(
+        &self,
+        matches: &mut Vec<Txid>,
+        indexes: &mut Vec<u32>,
+    ) -> Result<TxMerkleNode, MerkleBlockError> {
+        matches.clear();
+        indexes.clear();
+        // An empty set will not work
+        if self.num_transactions == 0 {
+            return Err(NoTransactions);
+        };
+        // check for excessively high numbers of transactions
+        if self.num_transactions as u64 > Weight::MAX_BLOCK / Weight::MIN_TRANSACTION {
+            return Err(TooManyTransactions);
+        }
+        // there can never be more hashes provided than one for every txid
+        if self.hashes.len() as u32 > self.num_transactions {
+            return Err(TooManyHashes);
+        };
+        // there must be at least one bit per node in the partial tree, and at least one node per hash
+        if self.bits.len() < self.hashes.len() {
+            return Err(NotEnoughBits);
+        };
+
+        let height = self.calc_tree_height();
+
+        // traverse the partial tree
+        let mut bits_used = 0u32;
+        let mut hash_used = 0u32;
+        let hash_merkle_root =
+            self.traverse_and_extract(height, 0, &mut bits_used, &mut hash_used, matches, indexes)?;
+        // Verify that all bits were consumed (except for the padding caused by
+        // serializing it as a byte sequence)
+        if (bits_used + 7) / 8 != (self.bits.len() as u32 + 7) / 8 {
+            return Err(NotAllBitsConsumed);
+        }
+        // Verify that all hashes were consumed
+        if hash_used != self.hashes.len() as u32 {
+            return Err(NotAllHashesConsumed);
+        }
+        Ok(TxMerkleNode::from_byte_array(
+            hash_merkle_root.to_byte_array(),
+        ))
+    }
+
+    /// Calculates the height of the tree.
+    fn calc_tree_height(&self) -> u32 {
+        let mut height = 0;
+        while self.calc_tree_width(height) > 1 {
+            height += 1;
+        }
+        height
+    }
+
+    /// Helper function to efficiently calculate the number of nodes at given height
+    /// in the merkle tree
+    #[inline]
+    fn calc_tree_width(&self, height: u32) -> u32 {
+        (self.num_transactions + (1 << height) - 1) >> height
+    }
+
+    /// Calculate the hash of a node in the merkle tree (at leaf level: the txid's themselves)
+    fn calc_hash(&self, height: u32, pos: u32, txids: &[Txid]) -> TxMerkleNode {
+        if height == 0 {
+            // Hash at height 0 is the txid itself
+            TxMerkleNode::from_byte_array(txids[pos as usize].to_byte_array())
+        } else {
+            // Calculate left hash
+            let left = self.calc_hash(height - 1, pos * 2, txids);
+            // Calculate right hash if not beyond the end of the array - copy left hash otherwise
+            let right = if pos * 2 + 1 < self.calc_tree_width(height - 1) {
+                self.calc_hash(height - 1, pos * 2 + 1, txids)
+            } else {
+                left
+            };
+            // Combine subhashes
+            PartialMerkleTree::parent_hash(left, right)
+        }
+    }
+
+    /// Recursive function that traverses tree nodes, storing the data as bits and hashes
+    fn traverse_and_build(&mut self, height: u32, pos: u32, txids: &[Txid], matches: &[bool]) {
+        // Determine whether this node is the parent of at least one matched txid
+        let mut parent_of_match = false;
+        let mut p = pos << height;
+        while p < (pos + 1) << height && p < self.num_transactions {
+            parent_of_match |= matches[p as usize];
+            p += 1;
+        }
+        // Store as flag bit
+        self.bits.push(parent_of_match);
+
+        if height == 0 || !parent_of_match {
+            // If at height 0, or nothing interesting below, store hash and stop
+            let hash = self.calc_hash(height, pos, txids);
+            self.hashes.push(hash);
+        } else {
+            // Otherwise, don't store any hash, but descend into the subtrees
+            self.traverse_and_build(height - 1, pos * 2, txids, matches);
+            if pos * 2 + 1 < self.calc_tree_width(height - 1) {
+                self.traverse_and_build(height - 1, pos * 2 + 1, txids, matches);
+            }
+        }
+    }
+
+    /// Recursive function that traverses tree nodes, consuming the bits and hashes produced by
+    /// TraverseAndBuild. It returns the hash of the respective node and its respective index.
+    fn traverse_and_extract(
+        &self,
+        height: u32,
+        pos: u32,
+        bits_used: &mut u32,
+        hash_used: &mut u32,
+        matches: &mut Vec<Txid>,
+        indexes: &mut Vec<u32>,
+    ) -> Result<TxMerkleNode, MerkleBlockError> {
+        if *bits_used as usize >= self.bits.len() {
+            return Err(BitsArrayOverflow);
+        }
+        let parent_of_match = self.bits[*bits_used as usize];
+        *bits_used += 1;
+        if height == 0 || !parent_of_match {
+            // If at height 0, or nothing interesting below, use stored hash and do not descend
+            if *hash_used as usize >= self.hashes.len() {
+                return Err(HashesArrayOverflow);
+            }
+            let hash = self.hashes[*hash_used as usize];
+            *hash_used += 1;
+            if height == 0 && parent_of_match {
+                // in case of height 0, we have a matched txid
+                matches.push(Txid::from_byte_array(hash.to_byte_array()));
+                indexes.push(pos);
+            }
+            Ok(hash)
+        } else {
+            // otherwise, descend into the subtrees to extract matched txids and hashes
+            let left = self.traverse_and_extract(
+                height - 1,
+                pos * 2,
+                bits_used,
+                hash_used,
+                matches,
+                indexes,
+            )?;
+            let right;
+            if pos * 2 + 1 < self.calc_tree_width(height - 1) {
+                right = self.traverse_and_extract(
+                    height - 1,
+                    pos * 2 + 1,
+                    bits_used,
+                    hash_used,
+                    matches,
+                    indexes,
+                )?;
+                if right == left {
+                    // The left and right branches should never be identical, as the transaction
+                    // hashes covered by them must each be unique.
+                    return Err(IdenticalHashesFound);
+                }
+            } else {
+                right = left;
+            }
+            // and combine them before returning
+            Ok(PartialMerkleTree::parent_hash(left, right))
+        }
+    }
+
+    /// Helper method to produce SHA256D(left + right)
+    fn parent_hash(left: TxMerkleNode, right: TxMerkleNode) -> TxMerkleNode {
+        let mut encoder = TxMerkleNode::engine();
+        left.consensus_encode(&mut encoder)
+            .expect("engines don't error");
+        right
+            .consensus_encode(&mut encoder)
+            .expect("engines don't error");
+        TxMerkleNode::from_engine(encoder)
+    }
+}
+
+impl Encodable for PartialMerkleTree {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut ret = self.num_transactions.consensus_encode(w)?;
+        ret += self.hashes.consensus_encode(w)?;
+
+        let nb_bytes_for_bits = (self.bits.len() + 7) / 8;
+        ret += encode::VarInt::from(nb_bytes_for_bits).consensus_encode(w)?;
+        for chunk in self.bits.chunks(8) {
+            let mut byte = 0u8;
+            for (i, bit) in chunk.iter().enumerate() {
+                byte |= (*bit as u8) << i;
+            }
+            ret += byte.consensus_encode(w)?;
+        }
+        Ok(ret)
+    }
+}
+
+impl Decodable for PartialMerkleTree {
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        r: &mut R,
+    ) -> Result<Self, encode::Error> {
+        let num_transactions: u32 = Decodable::consensus_decode(r)?;
+        let hashes: Vec<TxMerkleNode> = Decodable::consensus_decode(r)?;
+
+        let nb_bytes_for_bits = encode::VarInt::consensus_decode(r)?.0 as usize;
+        if nb_bytes_for_bits > MAX_VEC_SIZE {
+            return Err(encode::Error::OversizedVectorAllocation {
+                requested: nb_bytes_for_bits,
+                max: MAX_VEC_SIZE,
+            });
+        }
+        let mut bits = vec![false; nb_bytes_for_bits * 8];
+        for chunk in bits.chunks_mut(8) {
+            let byte = u8::consensus_decode(r)?;
+            for (i, bit) in chunk.iter_mut().enumerate() {
+                *bit = (byte & (1 << i)) != 0;
+            }
+        }
+
+        Ok(PartialMerkleTree {
+            num_transactions,
+            hashes,
+            bits,
+        })
+    }
+}
+
+/// An error when verifying the merkle block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MerkleBlockError {
+    /// Merkle root in the header doesn't match to the root calculated from partial merkle tree.
+    MerkleRootMismatch,
+    /// Partial merkle tree contains no transactions.
+    NoTransactions,
+    /// There are too many transactions.
+    TooManyTransactions,
+    /// There are too many hashes
+    TooManyHashes,
+    /// There must be at least one bit per node in the partial tree,
+    /// and at least one node per hash
+    NotEnoughBits,
+    /// Not all bits were consumed
+    NotAllBitsConsumed,
+    /// Not all hashes were consumed
+    NotAllHashesConsumed,
+    /// Overflowed the bits array
+    BitsArrayOverflow,
+    /// Overflowed the hashes array
+    HashesArrayOverflow,
+    /// The left and right branches should never be identical
+    IdenticalHashesFound,
+}
+
+internals::impl_from_infallible!(MerkleBlockError);
+
+impl fmt::Display for MerkleBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use MerkleBlockError::*;
+
+        match *self {
+            MerkleRootMismatch => write!(f, "merkle header root doesn't match to the root calculated from the partial merkle tree"),
+            NoTransactions => write!(f, "partial merkle tree contains no transactions"),
+            TooManyTransactions => write!(f, "too many transactions"),
+            TooManyHashes => write!(f, "proof contains more hashes than transactions"),
+            NotEnoughBits => write!(f, "proof contains less bits than hashes"),
+            NotAllBitsConsumed => write!(f, "not all bit were consumed"),
+            NotAllHashesConsumed => write!(f, "not all hashes were consumed"),
+            BitsArrayOverflow => write!(f, "overflowed the bits array"),
+            HashesArrayOverflow => write!(f, "overflowed the hashes array"),
+            IdenticalHashesFound => write!(f, "found identical transaction hashes"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MerkleBlockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use MerkleBlockError::*;
+
+        match *self {
+            MerkleRootMismatch | NoTransactions | TooManyTransactions | TooManyHashes
+            | NotEnoughBits | NotAllBitsConsumed | NotAllHashesConsumed | BitsArrayOverflow
+            | HashesArrayOverflow | IdenticalHashesFound => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex::test_hex_unwrap as hex;
+    #[cfg(feature = "rand-std")]
+    use secp256k1::rand::prelude::*;
+
+    use super::*;
+    use crate::consensus::encode::{deserialize, serialize};
+
+    #[cfg(feature = "rand-std")]
+    macro_rules! pmt_tests {
+        ($($name:ident),* $(,)?) => {
+            $(
+                #[test]
+                fn $name() {
+                    pmt_test_from_name(stringify!($name));
+                }
+            )*
+        }
+    }
+
+    #[cfg(feature = "rand-std")]
+    pmt_tests!(
+        pmt_test_1,
+        pmt_test_4,
+        pmt_test_7,
+        pmt_test_17,
+        pmt_test_56,
+        pmt_test_100,
+        pmt_test_127,
+        pmt_test_256,
+        pmt_test_312,
+        pmt_test_513,
+        pmt_test_1000,
+        pmt_test_4095
+    );
+
+    /// Parses the transaction count out of `name` with form: `pmt_test_$num`.
+    #[cfg(feature = "rand-std")]
+    fn pmt_test_from_name(name: &str) {
+        pmt_test(name[9..].parse().unwrap())
+    }
+
+    #[cfg(feature = "rand-std")]
+    fn pmt_test(tx_count: usize) {
+        use core::cmp::min;
+
+        use crate::merkle_tree;
+
+        let mut rng = thread_rng();
+        // Create some fake tx ids
+        let tx_ids = (1..=tx_count)
+            .map(|i| format!("{:064x}", i).parse::<Txid>().unwrap())
+            .collect::<Vec<_>>();
+
+        // Calculate the merkle root and height
+        let hashes = tx_ids.iter().map(|t| t.to_raw_hash());
+        let merkle_root_1: TxMerkleNode = merkle_tree::calculate_root(hashes)
+            .expect("hashes is not empty")
+            .into();
+        let mut height = 1;
+        let mut ntx = tx_count;
+        while ntx > 1 {
+            ntx = (ntx + 1) / 2;
+            height += 1;
+        }
+
+        // Check with random subsets with inclusion chances 1, 1/2, 1/4, ..., 1/128
+        for att in 1..15 {
+            let mut matches = vec![false; tx_count];
+            let mut match_txid1 = vec![];
+            for j in 0..tx_count {
+                // Generate `att / 2` random bits
+                let rand_bits = match att / 2 {
+                    0 => 0,
+                    bits => rng.gen::<u64>() >> (64 - bits),
+                };
+                let include = rand_bits == 0;
+                matches[j] = include;
+
+                if include {
+                    match_txid1.push(tx_ids[j]);
+                };
+            }
+
+            // Build the partial merkle tree
+            let pmt1 = PartialMerkleTree::from_txids(&tx_ids, &matches);
+            let serialized = serialize(&pmt1);
+
+            // Verify PartialMerkleTree's size guarantees
+            let n = min(tx_count, 1 + match_txid1.len() * height);
+            assert!(serialized.len() <= 10 + (258 * n + 7) / 8);
+
+            // Deserialize into a tester copy
+            let pmt2: PartialMerkleTree =
+                deserialize(&serialized).expect("Could not deserialize own data");
+
+            // Extract merkle root and matched txids from copy
+            let mut match_txid2: Vec<Txid> = vec![];
+            let mut indexes = vec![];
+            let merkle_root_2 = pmt2
+                .extract_matches(&mut match_txid2, &mut indexes)
+                .expect("Could not extract matches");
+
+            // Check that it has the same merkle root as the original, and a valid one
+            assert_eq!(merkle_root_1, merkle_root_2);
+            assert_ne!(merkle_root_2, TxMerkleNode::all_zeros());
+
+            // check that it contains the matched transactions (in the same order!)
+            assert_eq!(match_txid1, match_txid2);
+
+            // check that random bit flips break the authentication
+            for _ in 0..4 {
+                let mut pmt3: PartialMerkleTree = deserialize(&serialized).unwrap();
+                pmt3.damage(&mut rng);
+                let mut match_txid3 = vec![];
+                let merkle_root_3 = pmt3
+                    .extract_matches(&mut match_txid3, &mut indexes)
+                    .unwrap();
+                assert_ne!(merkle_root_3, merkle_root_1);
+            }
+        }
+    }
+
+    #[test]
+    fn pmt_malleability() {
+        // Create some fake tx ids with the last 2 hashes repeating
+        let txids: Vec<Txid> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 10]
+            .iter()
+            .map(|i| format!("{:064x}", i).parse::<Txid>().unwrap())
+            .collect();
+
+        let matches = vec![
+            false, false, false, false, false, false, false, false, false, true, true, false,
+        ];
+
+        let tree = PartialMerkleTree::from_txids(&txids, &matches);
+        // Should fail due to duplicate txs found
+        let result = tree.extract_matches(&mut vec![], &mut vec![]);
+        assert!(result.is_err());
+    }
+
+    // #[test]
+    // fn merkleblock_serialization() {
+    //     // Got it by running the rpc call
+    //     // `gettxoutproof '["220ebc64e21abece964927322cba69180ed853bb187fbc6923bac7d010b9d87a"]'`
+    //     let mb_hex = include_str!("../../tests/data/merkle_block.hex");
+
+    //     let mb: MerkleBlock = deserialize(&hex!(mb_hex)).unwrap();
+    //     assert_eq!(get_block_13b8a().block_hash(), mb.header.block_hash());
+    //     assert_eq!(
+    //         mb.header.merkle_root,
+    //         mb.txn.extract_matches(&mut vec![], &mut vec![]).unwrap()
+    //     );
+    //     // Serialize again and check that it matches the original bytes
+    //     assert_eq!(mb_hex, serialize(&mb).to_lower_hex_string().as_str());
+    // }
+
+    // /// Create a CMerkleBlock using a list of txids which will be found in the
+    // /// given block.
+    // #[test]
+    // fn merkleblock_construct_from_txids_found() {
+    //     let block = get_block_13b8a();
+
+    //     let txids: Vec<Txid> = [
+    //         "74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20",
+    //         "f9fc751cb7dc372406a9f8d738d5e6f8f63bab71986a39cf36ee70ee17036d07",
+    //     ]
+    //     .iter()
+    //     .map(|hex| hex.parse::<Txid>().unwrap())
+    //     .collect();
+
+    //     let txid1 = txids[0];
+    //     let txid2 = txids[1];
+    //     let txids = [txid1, txid2];
+
+    //     let merkle_block = MerkleBlock::from_block_with_predicate(&block, |t| txids.contains(t));
+
+    //     assert_eq!(merkle_block.header.block_hash(), block.block_hash());
+
+    //     let mut matches: Vec<Txid> = vec![];
+    //     let mut index: Vec<u32> = vec![];
+
+    //     assert_eq!(
+    //         merkle_block
+    //             .txn
+    //             .extract_matches(&mut matches, &mut index)
+    //             .unwrap(),
+    //         block.header.merkle_root
+    //     );
+    //     assert_eq!(matches.len(), 2);
+
+    //     // Ordered by occurrence in depth-first tree traversal.
+    //     assert_eq!(matches[0], txid2);
+    //     assert_eq!(index[0], 1);
+
+    //     assert_eq!(matches[1], txid1);
+    //     assert_eq!(index[1], 8);
+    // }
+
+    // /// Create a CMerkleBlock using a list of txids which will not be found in the given block
+    // #[test]
+    // fn merkleblock_construct_from_txids_not_found() {
+    //     let block = get_block_13b8a();
+    //     let txids: Vec<Txid> = ["c0ffee00003bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"]
+    //         .iter()
+    //         .map(|hex| hex.parse::<Txid>().unwrap())
+    //         .collect();
+
+    //     let merkle_block = MerkleBlock::from_block_with_predicate(&block, |t| txids.contains(t));
+
+    //     assert_eq!(merkle_block.header.block_hash(), block.block_hash());
+
+    //     let mut matches: Vec<Txid> = vec![];
+    //     let mut index: Vec<u32> = vec![];
+
+    //     assert_eq!(
+    //         merkle_block
+    //             .txn
+    //             .extract_matches(&mut matches, &mut index)
+    //             .unwrap(),
+    //         block.header.merkle_root
+    //     );
+    //     assert_eq!(matches.len(), 0);
+    //     assert_eq!(index.len(), 0);
+    // }
+
+    #[cfg(feature = "rand-std")]
+    impl PartialMerkleTree {
+        /// Flip one bit in one of the hashes - this should break the authentication
+        fn damage(&mut self, rng: &mut ThreadRng) {
+            let n = rng.gen_range(0..self.hashes.len());
+            let bit = rng.gen::<u8>();
+            let hashes = &mut self.hashes;
+            let mut hash = hashes[n].to_byte_array();
+            hash[(bit >> 3) as usize] ^= 1 << (bit & 7);
+            hashes[n] = TxMerkleNode::from_slice(&hash).unwrap();
+        }
+    }
+
+    // /// Returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
+    // /// with 9 txs.
+    // fn get_block_13b8a() -> Block {
+    //     use hex::FromHex;
+    //     let block_hex = include_str!("../../tests/data/block_13b8a.hex");
+    //     deserialize(&Vec::from_hex(block_hex).unwrap()).unwrap()
+    // }
+
+    macro_rules! check_calc_tree_width {
+        ($($test_name:ident, $num_transactions:literal, $height:literal, $expected_width:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    let pmt = PartialMerkleTree {
+                        num_transactions: $num_transactions,
+                        bits: vec![],
+                        hashes: vec![],
+                    };
+                    let got = pmt.calc_tree_width($height);
+                    assert_eq!(got, $expected_width)
+                }
+            )*
+        }
+    }
+
+    // tree_width_<id> <num txs> <height> <expected_width>
+    //
+    // height 0 is the bottom of the tree, where the leaves are.
+    check_calc_tree_width! {
+        tree_width_01, 1, 0, 1;
+        //
+        tree_width_02, 2, 0, 2;
+        tree_width_03, 2, 1, 1;
+        //
+        tree_width_04, 3, 0, 3;
+        tree_width_05, 3, 1, 2;
+        tree_width_06, 3, 2, 1;
+        //
+        tree_width_07, 4, 0, 4;
+        tree_width_08, 4, 1, 2;
+        tree_width_09, 4, 2, 1;
+        //
+        tree_width_10, 5, 0, 5;
+        tree_width_11, 5, 1, 3;
+        tree_width_12, 5, 2, 2;
+        tree_width_13, 5, 3, 1;
+        //
+        tree_width_14, 6, 0, 6;
+        tree_width_15, 6, 1, 3;
+        tree_width_16, 6, 2, 2;
+        tree_width_17, 6, 3, 1;
+        //
+        tree_width_18, 7, 0, 7;
+        tree_width_19, 7, 1, 4;
+        tree_width_20, 7, 2, 2;
+        tree_width_21, 7, 3, 1;
+    }
+
+    #[test]
+    fn regression_2606() {
+        // Attempt
+        let bytes = hex!(
+            "000006000000000000000004ee00000004c7f1ccb1000000ffff000000010000\
+             0000ffffffffff1f000000000400000000000002000000000500000000000000\
+             000000000300000000000003000000000200000000ff00000000c7f1ccb10407\
+             00000000000000ccb100c76538b100000004bfa9c251681b1b00040000000025\
+             00000004bfaac251681b1b25\
+         "
+        );
+        let deser = crate::consensus::deserialize::<MerkleBlock>(&bytes);
+        assert!(deser.is_err());
+    }
+}

--- a/libs/bitcoin/src/merkle_tree/mod.rs
+++ b/libs/bitcoin/src/merkle_tree/mod.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin merkle tree functions.
+//!
+//! # Examples
+//!
+//! ```
+//! # use bitcoin::{merkle_tree, Txid};
+//! # use bitcoin::hashes::Hash;
+//! # let tx1 = Txid::all_zeros();  // Dummy hash values.
+//! # let tx2 = Txid::all_zeros();
+//! let tx_hashes = vec![tx1, tx2]; // All the hashes we wish to merkelize.
+//! let root = merkle_tree::calculate_root(tx_hashes.into_iter());
+//! ```
+
+mod block;
+
+use core::cmp::min;
+use core::iter;
+
+use hashes::Hash;
+use io::Write;
+
+use crate::consensus::encode::Encodable;
+use crate::prelude::*;
+
+#[rustfmt::skip]
+#[doc(inline)]
+pub use self::block::{MerkleBlock, MerkleBlockError, PartialMerkleTree};
+
+/// Calculates the merkle root of a list of *hashes*, inline (in place) in `hashes`.
+///
+/// In most cases, you'll want to use [`calculate_root`] instead. Please note, calling this function
+/// trashes the data in `hashes` (i.e. the `hashes` is left in an undefined state at conclusion of
+/// this method and should not be used again afterwards).
+///
+/// # Returns
+/// - `None` if `hashes` is empty. The merkle root of an empty tree of hashes is undefined.
+/// - `Some(hash)` if `hashes` contains one element. A single hash is by definition the merkle root.
+/// - `Some(merkle_root)` if length of `hashes` is greater than one.
+pub fn calculate_root_inline<T>(hashes: &mut [T]) -> Option<T>
+where
+    T: Hash + Encodable,
+    <T as Hash>::Engine: Write,
+{
+    match hashes.len() {
+        0 => None,
+        1 => Some(hashes[0]),
+        _ => Some(merkle_root_r(hashes)),
+    }
+}
+
+/// Calculates the merkle root of an iterator of *hashes*.
+///
+/// # Returns
+/// - `None` if `hashes` is empty. The merkle root of an empty tree of hashes is undefined.
+/// - `Some(hash)` if `hashes` contains one element. A single hash is by definition the merkle root.
+/// - `Some(merkle_root)` if length of `hashes` is greater than one.
+pub fn calculate_root<T, I>(mut hashes: I) -> Option<T>
+where
+    T: Hash + Encodable,
+    <T as Hash>::Engine: Write,
+    I: Iterator<Item = T>,
+{
+    let first = hashes.next()?;
+    let second = match hashes.next() {
+        Some(second) => second,
+        None => return Some(first),
+    };
+
+    let mut hashes = iter::once(first).chain(iter::once(second)).chain(hashes);
+
+    // We need a local copy to pass to `merkle_root_r`. It's more efficient to do the first loop of
+    // processing as we make the copy instead of copying the whole iterator.
+    let (min, max) = hashes.size_hint();
+    let mut alloc = Vec::with_capacity(max.unwrap_or(min) / 2 + 1);
+
+    while let Some(hash1) = hashes.next() {
+        // If the size is odd, use the last element twice.
+        let hash2 = hashes.next().unwrap_or(hash1);
+        let mut encoder = T::engine();
+        hash1
+            .consensus_encode(&mut encoder)
+            .expect("in-memory writers don't error");
+        hash2
+            .consensus_encode(&mut encoder)
+            .expect("in-memory writers don't error");
+        alloc.push(T::from_engine(encoder));
+    }
+
+    Some(merkle_root_r(&mut alloc))
+}
+
+// `hashes` must contain at least one hash.
+fn merkle_root_r<T>(hashes: &mut [T]) -> T
+where
+    T: Hash + Encodable,
+    <T as Hash>::Engine: Write,
+{
+    if hashes.len() == 1 {
+        return hashes[0];
+    }
+
+    for idx in 0..((hashes.len() + 1) / 2) {
+        let idx1 = 2 * idx;
+        let idx2 = min(idx1 + 1, hashes.len() - 1);
+        let mut encoder = T::engine();
+        hashes[idx1]
+            .consensus_encode(&mut encoder)
+            .expect("in-memory writers don't error");
+        hashes[idx2]
+            .consensus_encode(&mut encoder)
+            .expect("in-memory writers don't error");
+        hashes[idx] = T::from_engine(encoder);
+    }
+    let half_len = hashes.len() / 2 + hashes.len() % 2;
+
+    merkle_root_r(&mut hashes[0..half_len])
+}
+
+#[cfg(test)]
+mod tests {
+    use hashes::sha256d;
+
+    use super::*;
+    use crate::blockdata::block::Block;
+    use crate::consensus::encode::deserialize;
+
+    // #[test]
+    // fn both_merkle_root_functions_return_the_same_result() {
+    //     // testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
+    //     let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw");
+    //     let block: Block = deserialize(&segwit_block[..]).expect("Failed to deserialize block");
+    //     assert!(block.check_merkle_root()); // Sanity check.
+
+    //     let hashes_iter = block.txdata.iter().map(|obj| obj.compute_txid().to_raw_hash());
+
+    //     let mut hashes_array: [sha256d::Hash; 15] = [Hash::all_zeros(); 15];
+    //     for (i, hash) in hashes_iter.clone().enumerate() {
+    //         hashes_array[i] = hash;
+    //     }
+
+    //     let from_iter = calculate_root(hashes_iter);
+    //     let from_array = calculate_root_inline(&mut hashes_array);
+    //     assert_eq!(from_iter, from_array);
+    // }
+}

--- a/libs/bitcoin/src/network.rs
+++ b/libs/bitcoin/src/network.rs
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin network.
+//!
+//! The term "network" is overloaded, here [`Network`] refers to the specific
+//! Bitcoin network we are operating on e.g., signet, regtest. The terms
+//! "network" and "chain" are often used interchangeably for this concept.
+//!
+//! # Example: encoding a network's magic bytes
+//!
+//! ```rust
+//! use bitcoin::Network;
+//! use bitcoin::consensus::encode::serialize;
+//!
+//! let network = Network::Bitcoin;
+//! let bytes = serialize(&network.magic());
+//!
+//! assert_eq!(&bytes[..], &[0xF9, 0xBE, 0xB4, 0xD9]);
+//! ```
+
+use core::fmt;
+use core::fmt::Display;
+use core::str::FromStr;
+
+use internals::write_err;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::consensus::Params;
+use crate::constants::ChainHash;
+use crate::p2p::Magic;
+use crate::prelude::*;
+
+/// What kind of network we are on.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NetworkKind {
+    /// The Bitcoin mainnet network.
+    Main,
+    /// Some kind of testnet network.
+    Test,
+}
+
+// We explicitly do not provide `is_testnet`, using `!network.is_mainnet()` is less
+// ambiguous due to confusion caused by signet/testnet/regtest.
+impl NetworkKind {
+    /// Returns true if this is real mainnet bitcoin.
+    pub fn is_mainnet(&self) -> bool { *self == NetworkKind::Main }
+}
+
+impl From<Network> for NetworkKind {
+    fn from(n: Network) -> Self {
+        use Network::*;
+
+        match n {
+            Bitcoin => NetworkKind::Main,
+            Testnet | Testnet4 | Signet | Regtest => NetworkKind::Test,
+        }
+    }
+}
+
+/// The cryptocurrency network to act on.
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[non_exhaustive]
+pub enum Network {
+    /// Mainnet Bitcoin.
+    Bitcoin,
+    /// Bitcoin's testnet network. (In future versions this will be combined
+    /// into a single variant containing the version)
+    Testnet,
+    /// Bitcoin's testnet4 network. (In future versions this will be combined
+    /// into a single variant containing the version)
+    Testnet4,
+    /// Bitcoin's signet network.
+    Signet,
+    /// Bitcoin's regtest network.
+    Regtest,
+}
+
+impl Network {
+    /// Creates a `Network` from the magic bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::p2p::Magic;
+    /// use bitcoin::Network;
+    ///
+    /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(Magic::from_bytes([0xF9, 0xBE, 0xB4, 0xD9])));
+    /// assert_eq!(None, Network::from_magic(Magic::from_bytes([0xFF, 0xFF, 0xFF, 0xFF])));
+    /// ```
+    pub fn from_magic(magic: Magic) -> Option<Network> { Network::try_from(magic).ok() }
+
+    /// Return the network magic bytes, which should be encoded little-endian
+    /// at the start of every message
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::p2p::Magic;
+    /// use bitcoin::Network;
+    ///
+    /// let network = Network::Bitcoin;
+    /// assert_eq!(network.magic(), Magic::from_bytes([0xF9, 0xBE, 0xB4, 0xD9]));
+    /// ```
+    pub fn magic(self) -> Magic { Magic::from(self) }
+
+    /// Converts a `Network` to its equivalent `bitcoind -chain` argument name.
+    ///
+    /// ```bash
+    /// $ bitcoin-23.0/bin/bitcoind --help | grep -C 3 '\-chain=<chain>'
+    /// Chain selection options:
+    ///
+    /// -chain=<chain>
+    /// Use the chain <chain> (default: main). Allowed values: main, test, signet, regtest
+    /// ```
+    pub fn to_core_arg(self) -> &'static str {
+        match self {
+            Network::Bitcoin => "main",
+            // For user-side compatibility, testnet3 is retained as test
+            Network::Testnet => "test",
+            Network::Testnet4 => "testnet4",
+            Network::Signet => "signet",
+            Network::Regtest => "regtest",
+        }
+    }
+
+    /// Converts a `bitcoind -chain` argument name to its equivalent `Network`.
+    ///
+    /// ```bash
+    /// $ bitcoin-23.0/bin/bitcoind --help | grep -C 3 '\-chain=<chain>'
+    /// Chain selection options:
+    ///
+    /// -chain=<chain>
+    /// Use the chain <chain> (default: main). Allowed values: main, test, signet, regtest
+    /// ```
+    pub fn from_core_arg(core_arg: &str) -> Result<Self, ParseNetworkError> {
+        use Network::*;
+
+        let network = match core_arg {
+            "main" => Bitcoin,
+            "test" => Testnet,
+            "testnet4" => Testnet4,
+            "signet" => Signet,
+            "regtest" => Regtest,
+            _ => return Err(ParseNetworkError(core_arg.to_owned())),
+        };
+        Ok(network)
+    }
+
+    /// Return the network's chain hash (genesis block hash).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::Network;
+    /// use bitcoin::blockdata::constants::ChainHash;
+    ///
+    /// let network = Network::Bitcoin;
+    /// assert_eq!(network.chain_hash(), ChainHash::BITCOIN);
+    /// ```
+    pub fn chain_hash(self) -> ChainHash { ChainHash::using_genesis_block_const(self) }
+
+    /// Creates a `Network` from the chain hash (genesis block hash).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bitcoin::Network;
+    /// use bitcoin::blockdata::constants::ChainHash;
+    ///
+    /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(ChainHash::BITCOIN));
+    /// ```
+    pub fn from_chain_hash(chain_hash: ChainHash) -> Option<Network> {
+        Network::try_from(chain_hash).ok()
+    }
+
+    /// Returns the associated network parameters.
+    pub const fn params(self) -> &'static Params {
+        match self {
+            Network::Bitcoin => &Params::BITCOIN,
+            Network::Testnet => &Params::TESTNET3,
+            Network::Testnet4 => &Params::TESTNET4,
+            Network::Signet => &Params::SIGNET,
+            Network::Regtest => &Params::REGTEST,
+        }
+    }
+
+    /// Returns a string representation of the `Network` enum variant.
+    /// This is useful for displaying the network type as a string.
+    const fn as_display_str(self) -> &'static str {
+        match self {
+            Network::Bitcoin => "bitcoin",
+            Network::Testnet => "testnet",
+            Network::Testnet4 => "testnet4",
+            Network::Signet => "signet",
+            Network::Regtest => "regtest",
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+pub mod as_core_arg {
+    //! Module for serialization/deserialization of network variants into/from Bitcoin Core values
+    #![allow(missing_docs)]
+
+    use crate::Network;
+
+    pub fn serialize<S>(network: &Network, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(network.to_core_arg())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Network, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NetworkVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for NetworkVisitor {
+            type Value = Network;
+
+            fn visit_str<E: serde::de::Error>(self, s: &str) -> Result<Self::Value, E> {
+                Network::from_core_arg(s).map_err(|_| {
+                    E::invalid_value(
+                        serde::de::Unexpected::Str(s),
+                        &"bitcoin network encoded as a string (either main, test, testnet4, signet or regtest)",
+                    )
+                })
+            }
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(
+                    formatter,
+                    "bitcoin network encoded as a string (either main, test, testnet4, signet or regtest)"
+                )
+            }
+        }
+
+        deserializer.deserialize_str(NetworkVisitor)
+    }
+}
+
+/// An error in parsing network string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ParseNetworkError(String);
+
+impl fmt::Display for ParseNetworkError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write_err!(f, "failed to parse {} as network", self.0; self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseNetworkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+impl FromStr for Network {
+    type Err = ParseNetworkError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bitcoin" => Ok(Network::Bitcoin),
+            // For user-side compatibility, testnet3 is retained as testnet
+            "testnet" => Ok(Network::Testnet),
+            "testnet4" => Ok(Network::Testnet4),
+            "signet" => Ok(Network::Signet),
+            "regtest" => Ok(Network::Regtest),
+            _ => Err(ParseNetworkError(s.to_owned())),
+        }
+    }
+}
+
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.as_display_str())
+    }
+}
+
+/// Error in parsing network from chain hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnknownChainHashError(ChainHash);
+
+impl Display for UnknownChainHashError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "unknown chain hash: {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnknownChainHashError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+impl TryFrom<ChainHash> for Network {
+    type Error = UnknownChainHashError;
+
+    fn try_from(chain_hash: ChainHash) -> Result<Self, Self::Error> {
+        match chain_hash {
+            // Note: any new network entries must be matched against here.
+            ChainHash::BITCOIN => Ok(Network::Bitcoin),
+            ChainHash::TESTNET3 => Ok(Network::Testnet),
+            ChainHash::TESTNET4 => Ok(Network::Testnet4),
+            ChainHash::SIGNET => Ok(Network::Signet),
+            ChainHash::REGTEST => Ok(Network::Regtest),
+            _ => Err(UnknownChainHashError(chain_hash)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Network;
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::p2p::ServiceFlags;
+
+    #[test]
+    fn serialize_test() {
+        assert_eq!(serialize(&Network::Bitcoin.magic()), &[0xf9, 0xbe, 0xb4, 0xd9]);
+        assert_eq!(
+            serialize(&Network::Testnet.magic()),
+            &[0x0b, 0x11, 0x09, 0x07]
+        );
+        assert_eq!(
+            serialize(&Network::Testnet4.magic()),
+            &[0x1c, 0x16, 0x3f, 0x28]
+        );
+        assert_eq!(serialize(&Network::Signet.magic()), &[0x0a, 0x03, 0xcf, 0x40]);
+        assert_eq!(serialize(&Network::Regtest.magic()), &[0xfa, 0xbf, 0xb5, 0xda]);
+
+        assert_eq!(deserialize(&[0xf9, 0xbe, 0xb4, 0xd9]).ok(), Some(Network::Bitcoin.magic()));
+        assert_eq!(
+            deserialize(&[0x0b, 0x11, 0x09, 0x07]).ok(),
+            Some(Network::Testnet.magic())
+        );
+        assert_eq!(
+            deserialize(&[0x1c, 0x16, 0x3f, 0x28]).ok(),
+            Some(Network::Testnet4.magic())
+        );
+        assert_eq!(deserialize(&[0x0a, 0x03, 0xcf, 0x40]).ok(), Some(Network::Signet.magic()));
+        assert_eq!(deserialize(&[0xfa, 0xbf, 0xb5, 0xda]).ok(), Some(Network::Regtest.magic()));
+    }
+
+    #[test]
+    fn string_test() {
+        assert_eq!(Network::Bitcoin.to_string(), "bitcoin");
+        assert_eq!(Network::Testnet.to_string(), "testnet");
+        assert_eq!(Network::Testnet4.to_string(), "testnet4");
+        assert_eq!(Network::Regtest.to_string(), "regtest");
+        assert_eq!(Network::Signet.to_string(), "signet");
+
+        assert_eq!("bitcoin".parse::<Network>().unwrap(), Network::Bitcoin);
+        assert_eq!("testnet".parse::<Network>().unwrap(), Network::Testnet);
+        assert_eq!("testnet4".parse::<Network>().unwrap(), Network::Testnet4);
+        assert_eq!("regtest".parse::<Network>().unwrap(), Network::Regtest);
+        assert_eq!("signet".parse::<Network>().unwrap(), Network::Signet);
+        assert!("fakenet".parse::<Network>().is_err());
+    }
+
+    #[test]
+    fn service_flags_test() {
+        let all = [
+            ServiceFlags::NETWORK,
+            ServiceFlags::GETUTXO,
+            ServiceFlags::BLOOM,
+            ServiceFlags::WITNESS,
+            ServiceFlags::COMPACT_FILTERS,
+            ServiceFlags::NETWORK_LIMITED,
+            ServiceFlags::P2P_V2,
+        ];
+
+        let mut flags = ServiceFlags::NONE;
+        for f in all.iter() {
+            assert!(!flags.has(*f));
+        }
+
+        flags |= ServiceFlags::WITNESS;
+        assert_eq!(flags, ServiceFlags::WITNESS);
+
+        let mut flags2 = flags | ServiceFlags::GETUTXO;
+        for f in all.iter() {
+            assert_eq!(flags2.has(*f), *f == ServiceFlags::WITNESS || *f == ServiceFlags::GETUTXO);
+        }
+
+        flags2 ^= ServiceFlags::WITNESS;
+        assert_eq!(flags2, ServiceFlags::GETUTXO);
+
+        flags2 |= ServiceFlags::COMPACT_FILTERS;
+        flags2 ^= ServiceFlags::GETUTXO;
+        assert_eq!(flags2, ServiceFlags::COMPACT_FILTERS);
+
+        // Test formatting.
+        assert_eq!("ServiceFlags(NONE)", ServiceFlags::NONE.to_string());
+        assert_eq!("ServiceFlags(WITNESS)", ServiceFlags::WITNESS.to_string());
+        let flag = ServiceFlags::WITNESS | ServiceFlags::BLOOM | ServiceFlags::NETWORK;
+        assert_eq!("ServiceFlags(NETWORK|BLOOM|WITNESS)", flag.to_string());
+        let flag = ServiceFlags::WITNESS | 0xf0.into();
+        assert_eq!("ServiceFlags(WITNESS|COMPACT_FILTERS|0xb0)", flag.to_string());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_roundtrip() {
+        use Network::*;
+        let tests = vec![
+            (Bitcoin, "bitcoin"),
+            (Testnet, "testnet"),
+            (Testnet4, "testnet4"),
+            (Signet, "signet"),
+            (Regtest, "regtest"),
+        ];
+
+        for tc in tests {
+            let network = tc.0;
+
+            let want = format!("\"{}\"", tc.1);
+            let got = serde_json::to_string(&tc.0).expect("failed to serialize network");
+            assert_eq!(got, want);
+
+            let back: Network = serde_json::from_str(&got).expect("failed to deserialize network");
+            assert_eq!(back, network);
+        }
+    }
+
+    #[test]
+    fn from_to_core_arg() {
+        let expected_pairs = [
+            (Network::Bitcoin, "main"),
+            (Network::Testnet, "test"),
+            (Network::Testnet4, "testnet4"),
+            (Network::Regtest, "regtest"),
+            (Network::Signet, "signet"),
+        ];
+
+        for (net, core_arg) in &expected_pairs {
+            assert_eq!(Network::from_core_arg(core_arg), Ok(*net));
+            assert_eq!(net.to_core_arg(), *core_arg);
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_as_core_arg() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        #[serde(crate = "actual_serde")]
+        struct T {
+            #[serde(with = "crate::network::as_core_arg")]
+            pub network: Network,
+        }
+
+        serde_test::assert_tokens(
+            &T { network: Network::Bitcoin },
+            &[
+                serde_test::Token::Struct { name: "T", len: 1 },
+                serde_test::Token::Str("network"),
+                serde_test::Token::Str("main"),
+                serde_test::Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/libs/bitcoin/src/p2p/address.rs
+++ b/libs/bitcoin/src/p2p/address.rs
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin network addresses.
+//!
+//! This module defines the structures and functions needed to encode
+//! network addresses in Bitcoin messages.
+//!
+
+use core::{fmt, iter};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
+
+use io::{Read, Write};
+
+use crate::consensus::encode::{self, Decodable, Encodable, ReadExt, VarInt, WriteExt};
+use crate::p2p::ServiceFlags;
+
+/// A message which can be sent on the Bitcoin network
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Address {
+    /// Services provided by the peer whose address this is
+    pub services: ServiceFlags,
+    /// Network byte-order ipv6 address, or ipv4-mapped ipv6 address
+    pub address: [u16; 8],
+    /// Network port
+    pub port: u16,
+}
+
+const ONION: [u16; 3] = [0xFD87, 0xD87E, 0xEB43];
+
+impl Address {
+    /// Create an address message for a socket
+    pub fn new(socket: &SocketAddr, services: ServiceFlags) -> Address {
+        let (address, port) = match *socket {
+            SocketAddr::V4(addr) => (addr.ip().to_ipv6_mapped().segments(), addr.port()),
+            SocketAddr::V6(addr) => (addr.ip().segments(), addr.port()),
+        };
+        Address { address, port, services }
+    }
+
+    /// Extract socket address from an [Address] message.
+    /// This will return [io::Error] [io::ErrorKind::AddrNotAvailable]
+    /// if the message contains a Tor address.
+    pub fn socket_addr(&self) -> Result<SocketAddr, io::Error> {
+        let addr = &self.address;
+        if addr[0..3] == ONION {
+            return Err(io::Error::from(io::ErrorKind::AddrNotAvailable));
+        }
+        let ipv6 =
+            Ipv6Addr::new(addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7]);
+        if let Some(ipv4) = ipv6.to_ipv4() {
+            Ok(SocketAddr::V4(SocketAddrV4::new(ipv4, self.port)))
+        } else {
+            Ok(SocketAddr::V6(SocketAddrV6::new(ipv6, self.port, 0, 0)))
+        }
+    }
+}
+
+impl Encodable for Address {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.services.consensus_encode(w)?;
+
+        for word in &self.address {
+            w.write_all(&word.to_be_bytes())?;
+            len += 2;
+        }
+
+        w.write_all(&self.port.to_be_bytes())?;
+        len += 2;
+
+        Ok(len)
+    }
+}
+
+impl Decodable for Address {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(Address {
+            services: Decodable::consensus_decode(r)?,
+            address: read_be_address(r)?,
+            port: u16::swap_bytes(Decodable::consensus_decode(r)?),
+        })
+    }
+}
+
+/// Read a big-endian address from reader.
+fn read_be_address<R: Read + ?Sized>(r: &mut R) -> Result<[u16; 8], encode::Error> {
+    let mut address = [0u16; 8];
+    let mut buf = [0u8; 2];
+
+    for word in &mut address {
+        Read::read_exact(r, &mut buf)?;
+        *word = u16::from_be_bytes(buf)
+    }
+    Ok(address)
+}
+
+impl fmt::Debug for Address {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ipv6 = Ipv6Addr::from(self.address);
+
+        match ipv6.to_ipv4() {
+            Some(addr) => write!(
+                f,
+                "Address {{services: {}, address: {}, port: {}}}",
+                self.services, addr, self.port
+            ),
+            None => write!(
+                f,
+                "Address {{services: {}, address: {}, port: {}}}",
+                self.services, ipv6, self.port
+            ),
+        }
+    }
+}
+
+impl ToSocketAddrs for Address {
+    type Iter = iter::Once<SocketAddr>;
+    fn to_socket_addrs(&self) -> Result<Self::Iter, std::io::Error> {
+        Ok(iter::once(self.socket_addr()?))
+    }
+}
+
+/// Supported networks for use in BIP155 addrv2 message
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum AddrV2 {
+    /// IPV4
+    Ipv4(Ipv4Addr),
+    /// IPV6
+    Ipv6(Ipv6Addr),
+    /// TORV2
+    TorV2([u8; 10]),
+    /// TORV3
+    TorV3([u8; 32]),
+    /// I2P
+    I2p([u8; 32]),
+    /// CJDNS
+    Cjdns(Ipv6Addr),
+    /// Unknown
+    Unknown(u8, Vec<u8>),
+}
+
+impl Encodable for AddrV2 {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        fn encode_addr<W: Write + ?Sized>(
+            w: &mut W,
+            network: u8,
+            bytes: &[u8],
+        ) -> Result<usize, io::Error> {
+            let len = network.consensus_encode(w)?
+                + VarInt::from(bytes.len()).consensus_encode(w)?
+                + bytes.len();
+            w.emit_slice(bytes)?;
+            Ok(len)
+        }
+        Ok(match *self {
+            AddrV2::Ipv4(ref addr) => encode_addr(w, 1, &addr.octets())?,
+            AddrV2::Ipv6(ref addr) => encode_addr(w, 2, &addr.octets())?,
+            AddrV2::TorV2(ref bytes) => encode_addr(w, 3, bytes)?,
+            AddrV2::TorV3(ref bytes) => encode_addr(w, 4, bytes)?,
+            AddrV2::I2p(ref bytes) => encode_addr(w, 5, bytes)?,
+            AddrV2::Cjdns(ref addr) => encode_addr(w, 6, &addr.octets())?,
+            AddrV2::Unknown(network, ref bytes) => encode_addr(w, network, bytes)?,
+        })
+    }
+}
+
+impl Decodable for AddrV2 {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let network_id = u8::consensus_decode(r)?;
+        let len = VarInt::consensus_decode(r)?.0;
+        if len > 512 {
+            return Err(encode::Error::ParseFailed("IP must be <= 512 bytes"));
+        }
+        Ok(match network_id {
+            1 => {
+                if len != 4 {
+                    return Err(encode::Error::ParseFailed("Invalid IPv4 address"));
+                }
+                let addr: [u8; 4] = Decodable::consensus_decode(r)?;
+                AddrV2::Ipv4(Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]))
+            }
+            2 => {
+                if len != 16 {
+                    return Err(encode::Error::ParseFailed("Invalid IPv6 address"));
+                }
+                let addr: [u16; 8] = read_be_address(r)?;
+                if addr[0..3] == ONION {
+                    return Err(encode::Error::ParseFailed(
+                        "OnionCat address sent with IPv6 network id",
+                    ));
+                }
+                if addr[0..6] == [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xFFFF] {
+                    return Err(encode::Error::ParseFailed(
+                        "IPV4 wrapped address sent with IPv6 network id",
+                    ));
+                }
+                AddrV2::Ipv6(Ipv6Addr::new(
+                    addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],
+                ))
+            }
+            3 => {
+                if len != 10 {
+                    return Err(encode::Error::ParseFailed("Invalid TorV2 address"));
+                }
+                let id = Decodable::consensus_decode(r)?;
+                AddrV2::TorV2(id)
+            }
+            4 => {
+                if len != 32 {
+                    return Err(encode::Error::ParseFailed("Invalid TorV3 address"));
+                }
+                let pubkey = Decodable::consensus_decode(r)?;
+                AddrV2::TorV3(pubkey)
+            }
+            5 => {
+                if len != 32 {
+                    return Err(encode::Error::ParseFailed("Invalid I2P address"));
+                }
+                let hash = Decodable::consensus_decode(r)?;
+                AddrV2::I2p(hash)
+            }
+            6 => {
+                if len != 16 {
+                    return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
+                }
+                let addr: [u16; 8] = read_be_address(r)?;
+                // check the first byte for the CJDNS marker
+                if addr[0] >> 8 != 0xFC {
+                    return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
+                }
+                AddrV2::Cjdns(Ipv6Addr::new(
+                    addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],
+                ))
+            }
+            _ => {
+                // len already checked above to be <= 512
+                let mut addr = vec![0u8; len as usize];
+                r.read_slice(&mut addr)?;
+                AddrV2::Unknown(network_id, addr)
+            }
+        })
+    }
+}
+
+/// Address received from BIP155 addrv2 message
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct AddrV2Message {
+    /// Time that this node was last seen as connected to the network
+    pub time: u32,
+    /// Service bits
+    pub services: ServiceFlags,
+    /// Network ID + Network Address
+    pub addr: AddrV2,
+    /// Network port, 0 if not applicable
+    pub port: u16,
+}
+
+impl AddrV2Message {
+    /// Extract socket address from an [AddrV2Message] message.
+    /// This will return [io::Error] [io::ErrorKind::AddrNotAvailable]
+    /// if the address type can't be converted into a [SocketAddr].
+    pub fn socket_addr(&self) -> Result<SocketAddr, io::Error> {
+        match self.addr {
+            AddrV2::Ipv4(addr) => Ok(SocketAddr::V4(SocketAddrV4::new(addr, self.port))),
+            AddrV2::Ipv6(addr) => Ok(SocketAddr::V6(SocketAddrV6::new(addr, self.port, 0, 0))),
+            _ => Err(io::Error::from(io::ErrorKind::AddrNotAvailable)),
+        }
+    }
+}
+
+impl Encodable for AddrV2Message {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.time.consensus_encode(w)?;
+        len += VarInt(self.services.to_u64()).consensus_encode(w)?;
+        len += self.addr.consensus_encode(w)?;
+
+        w.write_all(&self.port.to_be_bytes())?;
+        len += 2; // port u16 is two bytes.
+
+        Ok(len)
+    }
+}
+
+impl Decodable for AddrV2Message {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(AddrV2Message {
+            time: Decodable::consensus_decode(r)?,
+            services: ServiceFlags::from(VarInt::consensus_decode(r)?.0),
+            addr: Decodable::consensus_decode(r)?,
+            port: u16::swap_bytes(Decodable::consensus_decode(r)?),
+        })
+    }
+}
+
+impl ToSocketAddrs for AddrV2Message {
+    type Iter = iter::Once<SocketAddr>;
+    fn to_socket_addrs(&self) -> Result<Self::Iter, std::io::Error> {
+        Ok(iter::once(self.socket_addr()?))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::str::FromStr;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    use hex::{test_hex_unwrap as hex, FromHex};
+
+    use super::{AddrV2, AddrV2Message, Address};
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::p2p::ServiceFlags;
+
+    #[test]
+    fn serialize_address_test() {
+        assert_eq!(
+            serialize(&Address {
+                services: ServiceFlags::NETWORK,
+                address: [0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001],
+                port: 8333
+            }),
+            vec![
+                1u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x0a, 0, 0, 1,
+                0x20, 0x8d
+            ]
+        );
+    }
+
+    #[test]
+    fn debug_format_test() {
+        let mut flags = ServiceFlags::NETWORK;
+        assert_eq!(
+            format!("The address is: {:?}", Address {
+                services: flags.add(ServiceFlags::WITNESS),
+                address: [0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001],
+                port: 8333
+            }),
+            "The address is: Address {services: ServiceFlags(NETWORK|WITNESS), address: 10.0.0.1, port: 8333}"
+        );
+
+        assert_eq!(
+            format!("The address is: {:?}", Address {
+                services: ServiceFlags::NETWORK_LIMITED,
+                address: [0xFD87, 0xD87E, 0xEB43, 0, 0, 0xffff, 0x0a00, 0x0001],
+                port: 8333
+            }),
+            "The address is: Address {services: ServiceFlags(NETWORK_LIMITED), address: fd87:d87e:eb43::ffff:a00:1, port: 8333}"
+        );
+    }
+
+    #[test]
+    fn deserialize_address_test() {
+        let mut addr: Result<Address, _> = deserialize(&[
+            1u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x0a, 0, 0, 1,
+            0x20, 0x8d,
+        ]);
+        assert!(addr.is_ok());
+        let full = addr.unwrap();
+        assert!(matches!(full.socket_addr().unwrap(), SocketAddr::V4(_)));
+        assert_eq!(full.services, ServiceFlags::NETWORK);
+        assert_eq!(full.address, [0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001]);
+        assert_eq!(full.port, 8333);
+
+        addr = deserialize(&[
+            1u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x0a, 0, 0, 1,
+        ]);
+        assert!(addr.is_err());
+    }
+
+    #[test]
+    fn test_socket_addr() {
+        let s4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(111, 222, 123, 4)), 5555);
+        let a4 = Address::new(&s4, ServiceFlags::NETWORK | ServiceFlags::WITNESS);
+        assert_eq!(a4.socket_addr().unwrap(), s4);
+        let s6 = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(
+                0x1111, 0x2222, 0x3333, 0x4444, 0x5555, 0x6666, 0x7777, 0x8888,
+            )),
+            9999,
+        );
+        let a6 = Address::new(&s6, ServiceFlags::NETWORK | ServiceFlags::WITNESS);
+        assert_eq!(a6.socket_addr().unwrap(), s6);
+    }
+
+    #[test]
+    fn onion_test() {
+        let onionaddr = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::from_str("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").unwrap()),
+            1111,
+        );
+        let addr = Address::new(&onionaddr, ServiceFlags::NONE);
+        assert!(addr.socket_addr().is_err());
+    }
+
+    #[test]
+    fn serialize_addrv2_test() {
+        // Taken from https://github.com/bitcoin/bitcoin/blob/12a1c3ad1a43634d2a98717e49e3f02c4acea2fe/src/test/net_tests.cpp#L348
+
+        let ip = AddrV2::Ipv4(Ipv4Addr::new(1, 2, 3, 4));
+        assert_eq!(serialize(&ip), hex!("010401020304"));
+
+        let ip =
+            AddrV2::Ipv6(Ipv6Addr::from_str("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b").unwrap());
+        assert_eq!(serialize(&ip), hex!("02101a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b"));
+
+        let ip = AddrV2::TorV2(FromHex::from_hex("f1f2f3f4f5f6f7f8f9fa").unwrap());
+        assert_eq!(serialize(&ip), hex!("030af1f2f3f4f5f6f7f8f9fa"));
+
+        let ip = AddrV2::TorV3(
+            FromHex::from_hex("53cd5648488c4707914182655b7664034e09e66f7e8cbf1084e654eb56c5bd88")
+                .unwrap(),
+        );
+        assert_eq!(
+            serialize(&ip),
+            hex!("042053cd5648488c4707914182655b7664034e09e66f7e8cbf1084e654eb56c5bd88")
+        );
+
+        let ip = AddrV2::I2p(
+            FromHex::from_hex("a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87")
+                .unwrap(),
+        );
+        assert_eq!(
+            serialize(&ip),
+            hex!("0520a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87")
+        );
+
+        let ip = AddrV2::Cjdns(Ipv6Addr::from_str("fc01:1:2:3:4:5:6:7").unwrap());
+        assert_eq!(serialize(&ip), hex!("0610fc010001000200030004000500060007"));
+
+        let ip = AddrV2::Unknown(170, hex!("01020304"));
+        assert_eq!(serialize(&ip), hex!("aa0401020304"));
+    }
+
+    #[test]
+    fn deserialize_addrv2_test() {
+        // Taken from https://github.com/bitcoin/bitcoin/blob/12a1c3ad1a43634d2a98717e49e3f02c4acea2fe/src/test/net_tests.cpp#L386
+
+        // Valid IPv4.
+        let ip: AddrV2 = deserialize(&hex!("010401020304")).unwrap();
+        assert_eq!(ip, AddrV2::Ipv4(Ipv4Addr::new(1, 2, 3, 4)));
+
+        // Invalid IPv4, valid length but address itself is shorter.
+        deserialize::<AddrV2>(&hex!("01040102")).unwrap_err();
+
+        // Invalid IPv4, with bogus length.
+        assert!(deserialize::<AddrV2>(&hex!("010501020304")).is_err());
+
+        // Invalid IPv4, with extreme length.
+        assert!(deserialize::<AddrV2>(&hex!("01fd010201020304")).is_err());
+
+        // Valid IPv6.
+        let ip: AddrV2 = deserialize(&hex!("02100102030405060708090a0b0c0d0e0f10")).unwrap();
+        assert_eq!(
+            ip,
+            AddrV2::Ipv6(Ipv6Addr::from_str("102:304:506:708:90a:b0c:d0e:f10").unwrap())
+        );
+
+        // Invalid IPv6, with bogus length.
+        assert!(deserialize::<AddrV2>(&hex!("020400")).is_err());
+
+        // Invalid IPv6, contains embedded IPv4.
+        assert!(deserialize::<AddrV2>(&hex!("021000000000000000000000ffff01020304")).is_err());
+
+        // Invalid IPv6, contains embedded TORv2.
+        assert!(deserialize::<AddrV2>(&hex!("0210fd87d87eeb430102030405060708090a")).is_err());
+
+        // Valid TORv2.
+        let ip: AddrV2 = deserialize(&hex!("030af1f2f3f4f5f6f7f8f9fa")).unwrap();
+        assert_eq!(ip, AddrV2::TorV2(FromHex::from_hex("f1f2f3f4f5f6f7f8f9fa").unwrap()));
+
+        // Invalid TORv2, with bogus length.
+        assert!(deserialize::<AddrV2>(&hex!("030700")).is_err());
+
+        // Valid TORv3.
+        let ip: AddrV2 = deserialize(&hex!(
+            "042079bcc625184b05194975c28b66b66b0469f7f6556fb1ac3189a79b40dda32f1f"
+        ))
+        .unwrap();
+        assert_eq!(
+            ip,
+            AddrV2::TorV3(
+                FromHex::from_hex(
+                    "79bcc625184b05194975c28b66b66b0469f7f6556fb1ac3189a79b40dda32f1f"
+                )
+                .unwrap()
+            )
+        );
+
+        // Invalid TORv3, with bogus length.
+        assert!(deserialize::<AddrV2>(&hex!("040000")).is_err());
+
+        // Valid I2P.
+        let ip: AddrV2 = deserialize(&hex!(
+            "0520a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87"
+        ))
+        .unwrap();
+        assert_eq!(
+            ip,
+            AddrV2::I2p(
+                FromHex::from_hex(
+                    "a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87"
+                )
+                .unwrap()
+            )
+        );
+
+        // Invalid I2P, with bogus length.
+        assert!(deserialize::<AddrV2>(&hex!("050300")).is_err());
+
+        // Valid CJDNS.
+        let ip: AddrV2 = deserialize(&hex!("0610fc000001000200030004000500060007")).unwrap();
+        assert_eq!(ip, AddrV2::Cjdns(Ipv6Addr::from_str("fc00:1:2:3:4:5:6:7").unwrap()));
+
+        // Invalid CJDNS, incorrect marker
+        assert!(deserialize::<AddrV2>(&hex!("0610fd000001000200030004000500060007")).is_err());
+
+        // Invalid CJDNS, with bogus length.
+        assert!(deserialize::<AddrV2>(&hex!("060100")).is_err());
+
+        // Unknown, with extreme length.
+        assert!(deserialize::<AddrV2>(&hex!("aafe0000000201020304050607")).is_err());
+
+        // Unknown, with reasonable length.
+        let ip: AddrV2 = deserialize(&hex!("aa0401020304")).unwrap();
+        assert_eq!(ip, AddrV2::Unknown(170, hex!("01020304")));
+
+        // Unknown, with zero length.
+        let ip: AddrV2 = deserialize(&hex!("aa00")).unwrap();
+        assert_eq!(ip, AddrV2::Unknown(170, vec![]));
+    }
+
+    #[test]
+    fn addrv2message_test() {
+        let raw = hex!("0261bc6649019902abab208d79627683fd4804010409090909208d");
+        let addresses: Vec<AddrV2Message> = deserialize(&raw).unwrap();
+
+        assert_eq!(
+            addresses,
+            vec![
+                AddrV2Message {
+                    services: ServiceFlags::NETWORK,
+                    time: 0x4966bc61,
+                    port: 8333,
+                    addr: AddrV2::Unknown(153, hex!("abab"))
+                },
+                AddrV2Message {
+                    services: ServiceFlags::NETWORK_LIMITED
+                        | ServiceFlags::WITNESS
+                        | ServiceFlags::COMPACT_FILTERS,
+                    time: 0x83766279,
+                    port: 8333,
+                    addr: AddrV2::Ipv4(Ipv4Addr::new(9, 9, 9, 9))
+                },
+            ]
+        );
+
+        assert_eq!(serialize(&addresses), raw);
+    }
+}

--- a/libs/bitcoin/src/p2p/message.rs
+++ b/libs/bitcoin/src/p2p/message.rs
@@ -1,0 +1,846 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin network messages.
+//!
+//! This module defines the `NetworkMessage` and `RawNetworkMessage` types that
+//! are used for (de)serializing Bitcoin objects for transmission on the network.
+//!
+
+use core::{fmt, iter};
+
+use hashes::{sha256d, Hash};
+use io::{Read, Write};
+
+use crate::blockdata::{block, transaction};
+use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};
+use crate::merkle_tree::MerkleBlock;
+use crate::p2p::address::{AddrV2Message, Address};
+use crate::p2p::{
+    message_blockdata, message_bloom, message_compact_blocks, message_filter, message_network,
+    Magic,
+};
+use crate::prelude::*;
+
+/// The maximum number of [super::message_blockdata::Inventory] items in an `inv` message.
+///
+/// This limit is not currently enforced by this implementation.
+pub const MAX_INV_SIZE: usize = 50_000;
+
+/// Maximum size, in bytes, of an encoded message
+/// This by neccessity should be larger tham `MAX_VEC_SIZE`
+pub const MAX_MSG_SIZE: usize = 5_000_000;
+
+/// Serializer for command string
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct CommandString(Cow<'static, str>);
+
+impl CommandString {
+    /// Converts `&'static str` to `CommandString`
+    ///
+    /// This is more efficient for string literals than non-static conversions because it avoids
+    /// allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if, and only if, the string is
+    /// larger than 12 characters in length.
+    pub fn try_from_static(s: &'static str) -> Result<CommandString, CommandStringError> {
+        Self::try_from_static_cow(s.into())
+    }
+
+    fn try_from_static_cow(cow: Cow<'static, str>) -> Result<CommandString, CommandStringError> {
+        if cow.len() > 12 {
+            Err(CommandStringError { cow })
+        } else {
+            Ok(CommandString(cow))
+        }
+    }
+}
+
+impl TryFrom<String> for CommandString {
+    type Error = CommandStringError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from_static_cow(value.into())
+    }
+}
+
+impl TryFrom<Box<str>> for CommandString {
+    type Error = CommandStringError;
+
+    fn try_from(value: Box<str>) -> Result<Self, Self::Error> {
+        Self::try_from_static_cow(String::from(value).into())
+    }
+}
+
+impl<'a> TryFrom<&'a str> for CommandString {
+    type Error = CommandStringError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::try_from_static_cow(value.to_owned().into())
+    }
+}
+
+impl core::str::FromStr for CommandString {
+    type Err = CommandStringError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from_static_cow(s.to_owned().into())
+    }
+}
+
+impl fmt::Display for CommandString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { f.write_str(self.0.as_ref()) }
+}
+
+impl AsRef<str> for CommandString {
+    fn as_ref(&self) -> &str { self.0.as_ref() }
+}
+
+impl Encodable for CommandString {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut rawbytes = [0u8; 12];
+        let strbytes = self.0.as_bytes();
+        debug_assert!(strbytes.len() <= 12);
+        rawbytes[..strbytes.len()].copy_from_slice(strbytes);
+        rawbytes.consensus_encode(w)
+    }
+}
+
+impl Decodable for CommandString {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let rawbytes: [u8; 12] = Decodable::consensus_decode(r)?;
+        let rv = iter::FromIterator::from_iter(rawbytes.iter().filter_map(|&u| {
+            if u > 0 {
+                Some(u as char)
+            } else {
+                None
+            }
+        }));
+        Ok(CommandString(rv))
+    }
+}
+
+/// Error returned when a command string is invalid.
+///
+/// This is currently returned for command strings longer than 12.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CommandStringError {
+    cow: Cow<'static, str>,
+}
+
+impl fmt::Display for CommandStringError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "the command string '{}' has length {} which is larger than 12",
+            self.cow,
+            self.cow.len()
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CommandStringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// A Network message
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawNetworkMessage {
+    magic: Magic,
+    payload: NetworkMessage,
+    payload_len: u32,
+    checksum: [u8; 4],
+}
+
+/// A Network message payload. Proper documentation is available on at
+/// [Bitcoin Wiki: Protocol Specification](https://en.bitcoin.it/wiki/Protocol_specification)
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum NetworkMessage {
+    /// `version`
+    Version(message_network::VersionMessage),
+    /// `verack`
+    Verack,
+    /// `addr`
+    Addr(Vec<(u32, Address)>),
+    /// `inv`
+    Inv(Vec<message_blockdata::Inventory>),
+    /// `getdata`
+    GetData(Vec<message_blockdata::Inventory>),
+    /// `notfound`
+    NotFound(Vec<message_blockdata::Inventory>),
+    /// `getblocks`
+    GetBlocks(message_blockdata::GetBlocksMessage),
+    /// `getheaders`
+    GetHeaders(message_blockdata::GetHeadersMessage),
+    /// `mempool`
+    MemPool,
+    /// tx
+    Tx(transaction::Transaction),
+    /// `block`
+    Block(block::Block),
+    /// `headers`
+    Headers(Vec<block::Header>),
+    /// `sendheaders`
+    SendHeaders,
+    /// `getaddr`
+    GetAddr,
+    /// `ping`
+    Ping(u64),
+    /// `pong`
+    Pong(u64),
+    /// `merkleblock`
+    MerkleBlock(MerkleBlock),
+    /// BIP 37 `filterload`
+    FilterLoad(message_bloom::FilterLoad),
+    /// BIP 37 `filteradd`
+    FilterAdd(message_bloom::FilterAdd),
+    /// BIP 37 `filterclear`
+    FilterClear,
+    /// BIP157 getcfilters
+    GetCFilters(message_filter::GetCFilters),
+    /// BIP157 cfilter
+    CFilter(message_filter::CFilter),
+    /// BIP157 getcfheaders
+    GetCFHeaders(message_filter::GetCFHeaders),
+    /// BIP157 cfheaders
+    CFHeaders(message_filter::CFHeaders),
+    /// BIP157 getcfcheckpt
+    GetCFCheckpt(message_filter::GetCFCheckpt),
+    /// BIP157 cfcheckpt
+    CFCheckpt(message_filter::CFCheckpt),
+    /// BIP152 sendcmpct
+    SendCmpct(message_compact_blocks::SendCmpct),
+    /// BIP152 cmpctblock
+    CmpctBlock(message_compact_blocks::CmpctBlock),
+    /// BIP152 getblocktxn
+    GetBlockTxn(message_compact_blocks::GetBlockTxn),
+    /// BIP152 blocktxn
+    BlockTxn(message_compact_blocks::BlockTxn),
+    /// `alert`
+    Alert(Vec<u8>),
+    /// `reject`
+    Reject(message_network::Reject),
+    /// `feefilter`
+    FeeFilter(i64),
+    /// `wtxidrelay`
+    WtxidRelay,
+    /// `addrv2`
+    AddrV2(Vec<AddrV2Message>),
+    /// `sendaddrv2`
+    SendAddrV2,
+
+    /// Any other message.
+    Unknown {
+        /// The command of this message.
+        command: CommandString,
+        /// The payload of this message.
+        payload: Vec<u8>,
+    },
+}
+
+impl NetworkMessage {
+    /// Return the message command as a static string reference.
+    ///
+    /// This returns `"unknown"` for [NetworkMessage::Unknown],
+    /// regardless of the actual command in the unknown message.
+    /// Use the [Self::command] method to get the command for unknown messages.
+    pub fn cmd(&self) -> &'static str {
+        match *self {
+            NetworkMessage::Version(_) => "version",
+            NetworkMessage::Verack => "verack",
+            NetworkMessage::Addr(_) => "addr",
+            NetworkMessage::Inv(_) => "inv",
+            NetworkMessage::GetData(_) => "getdata",
+            NetworkMessage::NotFound(_) => "notfound",
+            NetworkMessage::GetBlocks(_) => "getblocks",
+            NetworkMessage::GetHeaders(_) => "getheaders",
+            NetworkMessage::MemPool => "mempool",
+            NetworkMessage::Tx(_) => "tx",
+            NetworkMessage::Block(_) => "block",
+            NetworkMessage::Headers(_) => "headers",
+            NetworkMessage::SendHeaders => "sendheaders",
+            NetworkMessage::GetAddr => "getaddr",
+            NetworkMessage::Ping(_) => "ping",
+            NetworkMessage::Pong(_) => "pong",
+            NetworkMessage::MerkleBlock(_) => "merkleblock",
+            NetworkMessage::FilterLoad(_) => "filterload",
+            NetworkMessage::FilterAdd(_) => "filteradd",
+            NetworkMessage::FilterClear => "filterclear",
+            NetworkMessage::GetCFilters(_) => "getcfilters",
+            NetworkMessage::CFilter(_) => "cfilter",
+            NetworkMessage::GetCFHeaders(_) => "getcfheaders",
+            NetworkMessage::CFHeaders(_) => "cfheaders",
+            NetworkMessage::GetCFCheckpt(_) => "getcfcheckpt",
+            NetworkMessage::CFCheckpt(_) => "cfcheckpt",
+            NetworkMessage::SendCmpct(_) => "sendcmpct",
+            NetworkMessage::CmpctBlock(_) => "cmpctblock",
+            NetworkMessage::GetBlockTxn(_) => "getblocktxn",
+            NetworkMessage::BlockTxn(_) => "blocktxn",
+            NetworkMessage::Alert(_) => "alert",
+            NetworkMessage::Reject(_) => "reject",
+            NetworkMessage::FeeFilter(_) => "feefilter",
+            NetworkMessage::WtxidRelay => "wtxidrelay",
+            NetworkMessage::AddrV2(_) => "addrv2",
+            NetworkMessage::SendAddrV2 => "sendaddrv2",
+            NetworkMessage::Unknown { .. } => "unknown",
+        }
+    }
+
+    /// Return the CommandString for the message command.
+    pub fn command(&self) -> CommandString {
+        match *self {
+            NetworkMessage::Unknown { command: ref c, .. } => c.clone(),
+            _ => CommandString::try_from_static(self.cmd()).expect("cmd returns valid commands"),
+        }
+    }
+}
+
+impl RawNetworkMessage {
+    /// Creates a [RawNetworkMessage]
+    pub fn new(magic: Magic, payload: NetworkMessage) -> Self {
+        let mut engine = sha256d::Hash::engine();
+        let payload_len = payload.consensus_encode(&mut engine).expect("engine doesn't error");
+        let payload_len = u32::try_from(payload_len).expect("network message use u32 as length");
+        let checksum = sha256d::Hash::from_engine(engine);
+        let checksum = [checksum[0], checksum[1], checksum[2], checksum[3]];
+        Self { magic, payload, payload_len, checksum }
+    }
+
+    /// Consumes the [RawNetworkMessage] instance and returns the inner payload.
+    pub fn into_payload(self) -> NetworkMessage {
+        self.payload
+    }
+
+    /// The actual message data
+    pub fn payload(&self) -> &NetworkMessage { &self.payload }
+
+    /// Magic bytes to identify the network these messages are meant for
+    pub fn magic(&self) -> &Magic { &self.magic }
+
+    /// Return the message command as a static string reference.
+    ///
+    /// This returns `"unknown"` for [NetworkMessage::Unknown],
+    /// regardless of the actual command in the unknown message.
+    /// Use the [Self::command] method to get the command for unknown messages.
+    pub fn cmd(&self) -> &'static str { self.payload.cmd() }
+
+    /// Return the CommandString for the message command.
+    pub fn command(&self) -> CommandString { self.payload.command() }
+}
+
+struct HeaderSerializationWrapper<'a>(&'a Vec<block::Header>);
+
+impl<'a> Encodable for HeaderSerializationWrapper<'a> {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += VarInt::from(self.0.len()).consensus_encode(w)?;
+        for header in self.0.iter() {
+            len += header.consensus_encode(w)?;
+            len += 0u8.consensus_encode(w)?;
+        }
+        Ok(len)
+    }
+}
+
+impl Encodable for NetworkMessage {
+    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        match self {
+            NetworkMessage::Version(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Addr(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Inv(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetData(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::NotFound(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetBlocks(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetHeaders(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Tx(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Block(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Headers(ref dat) =>
+                HeaderSerializationWrapper(dat).consensus_encode(writer),
+            NetworkMessage::Ping(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Pong(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::MerkleBlock(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::FilterLoad(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::FilterAdd(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetCFilters(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::CFilter(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetCFHeaders(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::CFHeaders(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetCFCheckpt(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::CFCheckpt(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::SendCmpct(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::CmpctBlock(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetBlockTxn(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::BlockTxn(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Alert(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Reject(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::FeeFilter(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::AddrV2(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::Verack
+            | NetworkMessage::SendHeaders
+            | NetworkMessage::MemPool
+            | NetworkMessage::GetAddr
+            | NetworkMessage::WtxidRelay
+            | NetworkMessage::FilterClear
+            | NetworkMessage::SendAddrV2 => Ok(0),
+            NetworkMessage::Unknown { payload: ref data, .. } => data.consensus_encode(writer),
+        }
+    }
+}
+
+impl Encodable for RawNetworkMessage {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.magic.consensus_encode(w)?;
+        len += self.command().consensus_encode(w)?;
+        len += self.payload_len.consensus_encode(w)?;
+        len += self.checksum.consensus_encode(w)?;
+        len += self.payload().consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
+struct HeaderDeserializationWrapper(Vec<block::Header>);
+
+impl Decodable for HeaderDeserializationWrapper {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        r: &mut R,
+    ) -> Result<Self, encode::Error> {
+        let len = VarInt::consensus_decode(r)?.0;
+        // should be above usual number of items to avoid
+        // allocation
+        let mut ret = Vec::with_capacity(core::cmp::min(1024 * 16, len as usize));
+        for _ in 0..len {
+            ret.push(Decodable::consensus_decode(r)?);
+            if u8::consensus_decode(r)? != 0u8 {
+                return Err(encode::Error::ParseFailed(
+                    "Headers message should not contain transactions",
+                ));
+            }
+        }
+        Ok(HeaderDeserializationWrapper(ret))
+    }
+
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
+    }
+}
+
+impl Decodable for RawNetworkMessage {
+    fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
+        r: &mut R,
+    ) -> Result<Self, encode::Error> {
+        let magic = Decodable::consensus_decode_from_finite_reader(r)?;
+        let cmd = CommandString::consensus_decode_from_finite_reader(r)?;
+        let checked_data = CheckedData::consensus_decode_from_finite_reader(r)?;
+        let checksum = checked_data.checksum();
+        let raw_payload = checked_data.into_data();
+        let payload_len = raw_payload.len() as u32;
+
+        let mut mem_d = raw_payload.as_slice();
+        let payload = match &cmd.0[..] {
+            "version" =>
+                NetworkMessage::Version(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "verack" => NetworkMessage::Verack,
+            "addr" =>
+                NetworkMessage::Addr(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "inv" =>
+                NetworkMessage::Inv(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "getdata" =>
+                NetworkMessage::GetData(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "notfound" => NetworkMessage::NotFound(Decodable::consensus_decode_from_finite_reader(
+                &mut mem_d,
+            )?),
+            "getblocks" => NetworkMessage::GetBlocks(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "getheaders" => NetworkMessage::GetHeaders(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "mempool" => NetworkMessage::MemPool,
+            "block" =>
+                NetworkMessage::Block(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "headers" => NetworkMessage::Headers(
+                HeaderDeserializationWrapper::consensus_decode_from_finite_reader(&mut mem_d)?.0,
+            ),
+            "sendheaders" => NetworkMessage::SendHeaders,
+            "getaddr" => NetworkMessage::GetAddr,
+            "ping" =>
+                NetworkMessage::Ping(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "pong" =>
+                NetworkMessage::Pong(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "merkleblock" => NetworkMessage::MerkleBlock(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "filterload" => NetworkMessage::FilterLoad(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "filteradd" => NetworkMessage::FilterAdd(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "filterclear" => NetworkMessage::FilterClear,
+            "tx" => NetworkMessage::Tx(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "getcfilters" => NetworkMessage::GetCFilters(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "cfilter" =>
+                NetworkMessage::CFilter(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "getcfheaders" => NetworkMessage::GetCFHeaders(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "cfheaders" => NetworkMessage::CFHeaders(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "getcfcheckpt" => NetworkMessage::GetCFCheckpt(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "cfcheckpt" => NetworkMessage::CFCheckpt(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "reject" =>
+                NetworkMessage::Reject(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "alert" =>
+                NetworkMessage::Alert(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "feefilter" => NetworkMessage::FeeFilter(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "sendcmpct" => NetworkMessage::SendCmpct(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "cmpctblock" => NetworkMessage::CmpctBlock(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "getblocktxn" => NetworkMessage::GetBlockTxn(
+                Decodable::consensus_decode_from_finite_reader(&mut mem_d)?,
+            ),
+            "blocktxn" => NetworkMessage::BlockTxn(Decodable::consensus_decode_from_finite_reader(
+                &mut mem_d,
+            )?),
+            "wtxidrelay" => NetworkMessage::WtxidRelay,
+            "addrv2" =>
+                NetworkMessage::AddrV2(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
+            "sendaddrv2" => NetworkMessage::SendAddrV2,
+            _ => NetworkMessage::Unknown { command: cmd, payload: raw_payload },
+        };
+        Ok(RawNetworkMessage { magic, payload, payload_len, checksum })
+    }
+
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::Ipv4Addr;
+
+    use hashes::sha256d::Hash;
+    use hashes::Hash as HashTrait;
+    use hex::test_hex_unwrap as hex;
+
+    use super::message_network::{Reject, RejectReason, VersionMessage};
+    use super::*;
+    use crate::bip152::BlockTransactionsRequest;
+    use crate::blockdata::block::Block;
+    use crate::blockdata::script::ScriptBuf;
+    use crate::blockdata::transaction::Transaction;
+    use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
+    use crate::p2p::address::AddrV2;
+    use crate::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
+    use crate::p2p::message_bloom::{BloomFlags, FilterAdd, FilterLoad};
+    use crate::p2p::message_compact_blocks::{GetBlockTxn, SendCmpct};
+    use crate::p2p::message_filter::{
+        CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
+    };
+    use crate::p2p::ServiceFlags;
+
+    fn hash(slice: [u8; 32]) -> Hash { Hash::from_slice(&slice).unwrap() }
+
+    #[test]
+    fn full_round_ser_der_raw_network_message_test() {
+        let version_msg: VersionMessage = deserialize(&hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001")).unwrap();
+        let tx: Transaction = deserialize(&hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000")).unwrap();
+        let block: Block = deserialize(&include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw")[..]).unwrap();
+        let header: block::Header = deserialize(&hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b")).unwrap();
+        let script: ScriptBuf =
+            deserialize(&hex!("1976a91431a420903c05a0a7de2de40c9f02ebedbacdc17288ac")).unwrap();
+        let merkle_block: MerkleBlock = deserialize(&hex!("0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d630100000001b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f19630101")).unwrap();
+        let cmptblock = deserialize(&hex!("00000030d923ad36ff2d955abab07f8a0a6e813bc6e066b973e780c5e36674cad5d1cd1f6e265f2a17a0d35cbe701fe9d06e2c6324cfe135f6233e8b767bfa3fb4479b71115dc562ffff7f2006000000000000000000000000010002000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0302ee00ffffffff0100f9029500000000015100000000")).unwrap();
+        let blocktxn = deserialize(&hex!("2e93c0cff39ff605020072d96bc3a8d20b8447e294d08092351c8583e08d9b5a01020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0402dc0000ffffffff0200f90295000000001976a9142b4569203694fc997e13f2c0a1383b9e16c77a0d88ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")).unwrap();
+
+        let msgs = vec![
+            NetworkMessage::Version(version_msg),
+            NetworkMessage::Verack,
+            NetworkMessage::Addr(vec![(
+                45,
+                Address::new(&([123, 255, 000, 100], 833).into(), ServiceFlags::NETWORK),
+            )]),
+            NetworkMessage::Inv(vec![Inventory::Block(hash([8u8; 32]).into())]),
+            NetworkMessage::GetData(vec![Inventory::Transaction(hash([45u8; 32]).into())]),
+            NetworkMessage::NotFound(vec![Inventory::Error]),
+            NetworkMessage::GetBlocks(GetBlocksMessage::new(
+                vec![hash([1u8; 32]).into(), hash([4u8; 32]).into()],
+                hash([5u8; 32]).into(),
+            )),
+            NetworkMessage::GetHeaders(GetHeadersMessage::new(
+                vec![hash([10u8; 32]).into(), hash([40u8; 32]).into()],
+                hash([50u8; 32]).into(),
+            )),
+            NetworkMessage::MemPool,
+            NetworkMessage::Tx(tx),
+            NetworkMessage::Block(block),
+            NetworkMessage::Headers(vec![header]),
+            NetworkMessage::SendHeaders,
+            NetworkMessage::GetAddr,
+            NetworkMessage::Ping(15),
+            NetworkMessage::Pong(23),
+            NetworkMessage::MerkleBlock(merkle_block),
+            NetworkMessage::FilterLoad(FilterLoad {
+                filter: hex!("03614e9b050000000000000001"),
+                hash_funcs: 1,
+                tweak: 2,
+                flags: BloomFlags::All,
+            }),
+            NetworkMessage::FilterAdd(FilterAdd { data: script.as_bytes().to_vec() }),
+            NetworkMessage::FilterAdd(FilterAdd {
+                data: hash([29u8; 32]).as_byte_array().to_vec(),
+            }),
+            NetworkMessage::FilterClear,
+            NetworkMessage::GetCFilters(GetCFilters {
+                filter_type: 2,
+                start_height: 52,
+                stop_hash: hash([42u8; 32]).into(),
+            }),
+            NetworkMessage::CFilter(CFilter {
+                filter_type: 7,
+                block_hash: hash([25u8; 32]).into(),
+                filter: vec![1, 2, 3],
+            }),
+            NetworkMessage::GetCFHeaders(GetCFHeaders {
+                filter_type: 4,
+                start_height: 102,
+                stop_hash: hash([47u8; 32]).into(),
+            }),
+            NetworkMessage::CFHeaders(CFHeaders {
+                filter_type: 13,
+                stop_hash: hash([53u8; 32]).into(),
+                previous_filter_header: hash([12u8; 32]).into(),
+                filter_hashes: vec![hash([4u8; 32]).into(), hash([12u8; 32]).into()],
+            }),
+            NetworkMessage::GetCFCheckpt(GetCFCheckpt {
+                filter_type: 17,
+                stop_hash: hash([25u8; 32]).into(),
+            }),
+            NetworkMessage::CFCheckpt(CFCheckpt {
+                filter_type: 27,
+                stop_hash: hash([77u8; 32]).into(),
+                filter_headers: vec![hash([3u8; 32]).into(), hash([99u8; 32]).into()],
+            }),
+            NetworkMessage::Alert(vec![45, 66, 3, 2, 6, 8, 9, 12, 3, 130]),
+            NetworkMessage::Reject(Reject {
+                message: "Test reject".into(),
+                ccode: RejectReason::Duplicate,
+                reason: "Cause".into(),
+                hash: hash([255u8; 32]),
+            }),
+            NetworkMessage::FeeFilter(1000),
+            NetworkMessage::WtxidRelay,
+            NetworkMessage::AddrV2(vec![AddrV2Message {
+                addr: AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
+                port: 0,
+                services: ServiceFlags::NONE,
+                time: 0,
+            }]),
+            NetworkMessage::SendAddrV2,
+            NetworkMessage::CmpctBlock(cmptblock),
+            NetworkMessage::GetBlockTxn(GetBlockTxn {
+                txs_request: BlockTransactionsRequest {
+                    block_hash: hash([11u8; 32]).into(),
+                    indexes: vec![0, 1, 2, 3, 10, 3002],
+                },
+            }),
+            NetworkMessage::BlockTxn(blocktxn),
+            NetworkMessage::SendCmpct(SendCmpct { send_compact: true, version: 8333 }),
+        ];
+
+        for msg in msgs {
+            let raw_msg = RawNetworkMessage::new(Magic::from_bytes([57, 0, 0, 0]), msg);
+            assert_eq!(deserialize::<RawNetworkMessage>(&serialize(&raw_msg)).unwrap(), raw_msg);
+        }
+    }
+
+    #[test]
+    fn commandstring_test() {
+        // Test converting.
+        assert_eq!(
+            CommandString::try_from_static("AndrewAndrew").unwrap().as_ref(),
+            "AndrewAndrew"
+        );
+        assert!(CommandString::try_from_static("AndrewAndrewA").is_err());
+
+        // Test serializing.
+        let cs = CommandString("Andrew".into());
+        assert_eq!(serialize(&cs), vec![0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
+
+        // Test deserializing
+        let cs: Result<CommandString, _> =
+            deserialize(&[0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
+        assert!(cs.is_ok());
+        assert_eq!(cs.as_ref().unwrap().to_string(), "Andrew".to_owned());
+        assert_eq!(cs.unwrap(), CommandString::try_from_static("Andrew").unwrap());
+
+        let short_cs: Result<CommandString, _> =
+            deserialize(&[0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0]);
+        assert!(short_cs.is_err());
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_verack_test() {
+        assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::Verack)),
+                   vec![0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x61,
+                        0x63, 0x6B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2]);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_ping_test() {
+        assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::Ping(100))),
+                   vec![0xf9, 0xbe, 0xb4, 0xd9, 0x70, 0x69, 0x6e, 0x67,
+                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x08, 0x00, 0x00, 0x00, 0x24, 0x67, 0xf1, 0x1d,
+                        0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_mempool_test() {
+        assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::MemPool)),
+                   vec![0xf9, 0xbe, 0xb4, 0xd9, 0x6d, 0x65, 0x6d, 0x70,
+                        0x6f, 0x6f, 0x6c, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2]);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_getaddr_test() {
+        assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::GetAddr)),
+                   vec![0xf9, 0xbe, 0xb4, 0xd9, 0x67, 0x65, 0x74, 0x61,
+                        0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2]);
+    }
+
+    #[test]
+    fn deserialize_getaddr_test() {
+        #[rustfmt::skip]
+        let msg = deserialize(&[
+            0xf9, 0xbe, 0xb4, 0xd9, 0x67, 0x65, 0x74, 0x61,
+            0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2
+        ]);
+        let preimage = RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::GetAddr);
+        assert!(msg.is_ok());
+        let msg: RawNetworkMessage = msg.unwrap();
+        assert_eq!(preimage.magic, msg.magic);
+        assert_eq!(preimage.payload, msg.payload);
+    }
+
+    #[test]
+    fn deserialize_version_test() {
+        #[rustfmt::skip]
+        let msg = deserialize::<RawNetworkMessage>(&[
+            0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x73,
+            0x69, 0x6f, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x66, 0x00, 0x00, 0x00, 0xbe, 0x61, 0xb8, 0x27,
+            0x7f, 0x11, 0x01, 0x00, 0x0d, 0x04, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0xf0, 0x0f, 0x4d, 0x5c,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+            0x5b, 0xf0, 0x8c, 0x80, 0xb4, 0xbd, 0x0d, 0x04,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xfa, 0xa9, 0x95, 0x59, 0xcc, 0x68, 0xa1, 0xc1,
+            0x10, 0x2f, 0x53, 0x61, 0x74, 0x6f, 0x73, 0x68,
+            0x69, 0x3a, 0x30, 0x2e, 0x31, 0x37, 0x2e, 0x31,
+            0x2f, 0x93, 0x8c, 0x08, 0x00, 0x01
+        ]);
+
+        assert!(msg.is_ok());
+        let msg = msg.unwrap();
+        assert_eq!(msg.magic, Magic::BITCOIN);
+        if let NetworkMessage::Version(version_msg) = msg.payload {
+            assert_eq!(version_msg.version, 70015);
+            assert_eq!(
+                version_msg.services,
+                ServiceFlags::NETWORK
+                    | ServiceFlags::BLOOM
+                    | ServiceFlags::WITNESS
+                    | ServiceFlags::NETWORK_LIMITED
+            );
+            assert_eq!(version_msg.timestamp, 1548554224);
+            assert_eq!(version_msg.nonce, 13952548347456104954);
+            assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");
+            assert_eq!(version_msg.start_height, 560275);
+            assert!(version_msg.relay);
+        } else {
+            panic!("Wrong message type");
+        }
+    }
+
+    #[test]
+    fn deserialize_partial_message_test() {
+        #[rustfmt::skip]
+        let data = [
+            0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x73,
+            0x69, 0x6f, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x66, 0x00, 0x00, 0x00, 0xbe, 0x61, 0xb8, 0x27,
+            0x7f, 0x11, 0x01, 0x00, 0x0d, 0x04, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0xf0, 0x0f, 0x4d, 0x5c,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+            0x5b, 0xf0, 0x8c, 0x80, 0xb4, 0xbd, 0x0d, 0x04,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xfa, 0xa9, 0x95, 0x59, 0xcc, 0x68, 0xa1, 0xc1,
+            0x10, 0x2f, 0x53, 0x61, 0x74, 0x6f, 0x73, 0x68,
+            0x69, 0x3a, 0x30, 0x2e, 0x31, 0x37, 0x2e, 0x31,
+            0x2f, 0x93, 0x8c, 0x08, 0x00, 0x01, 0x00, 0x00
+        ];
+        let msg = deserialize_partial::<RawNetworkMessage>(&data);
+        assert!(msg.is_ok());
+
+        let (msg, consumed) = msg.unwrap();
+        assert_eq!(consumed, data.to_vec().len() - 2);
+        assert_eq!(msg.magic, Magic::BITCOIN);
+        if let NetworkMessage::Version(version_msg) = msg.payload {
+            assert_eq!(version_msg.version, 70015);
+            assert_eq!(
+                version_msg.services,
+                ServiceFlags::NETWORK
+                    | ServiceFlags::BLOOM
+                    | ServiceFlags::WITNESS
+                    | ServiceFlags::NETWORK_LIMITED
+            );
+            assert_eq!(version_msg.timestamp, 1548554224);
+            assert_eq!(version_msg.nonce, 13952548347456104954);
+            assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");
+            assert_eq!(version_msg.start_height, 560275);
+            assert!(version_msg.relay);
+        } else {
+            panic!("Wrong message type");
+        }
+    }
+}

--- a/libs/bitcoin/src/p2p/message_blockdata.rs
+++ b/libs/bitcoin/src/p2p/message_blockdata.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin blockdata network messages.
+//!
+//! This module describes network messages which are used for passing
+//! Bitcoin data (blocks and transactions) around.
+//!
+
+use hashes::{sha256d, Hash as _};
+use io::{Read, Write};
+
+use crate::blockdata::block::BlockHash;
+use crate::blockdata::transaction::{Txid, Wtxid};
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::internal_macros::impl_consensus_encoding;
+use crate::p2p;
+
+/// An inventory item.
+#[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
+pub enum Inventory {
+    /// Error --- these inventories can be ignored
+    Error,
+    /// Transaction
+    Transaction(Txid),
+    /// Block
+    Block(BlockHash),
+    /// Compact Block
+    CompactBlock(BlockHash),
+    /// Witness Transaction by Wtxid
+    WTx(Wtxid),
+    /// Witness Transaction
+    WitnessTransaction(Txid),
+    /// Witness Block
+    WitnessBlock(BlockHash),
+    /// Unknown inventory type
+    Unknown {
+        /// The inventory item type.
+        inv_type: u32,
+        /// The hash of the inventory item
+        hash: [u8; 32],
+    },
+}
+
+impl Inventory {
+    /// Return the item value represented as a SHA256-d hash.
+    ///
+    /// Returns [None] only for [Inventory::Error].
+    pub fn network_hash(&self) -> Option<[u8; 32]> {
+        match self {
+            Inventory::Error => None,
+            Inventory::Transaction(t) => Some(t.to_byte_array()),
+            Inventory::Block(b) => Some(b.to_byte_array()),
+            Inventory::CompactBlock(b) => Some(b.to_byte_array()),
+            Inventory::WTx(t) => Some(t.to_byte_array()),
+            Inventory::WitnessTransaction(t) => Some(t.to_byte_array()),
+            Inventory::WitnessBlock(b) => Some(b.to_byte_array()),
+            Inventory::Unknown { hash, .. } => Some(*hash),
+        }
+    }
+}
+
+impl Encodable for Inventory {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        macro_rules! encode_inv {
+            ($code:expr, $item:expr) => {
+                u32::consensus_encode(&$code, w)? + $item.consensus_encode(w)?
+            };
+        }
+        Ok(match *self {
+            Inventory::Error => encode_inv!(0, sha256d::Hash::all_zeros()),
+            Inventory::Transaction(ref t) => encode_inv!(1, t),
+            Inventory::Block(ref b) => encode_inv!(2, b),
+            Inventory::CompactBlock(ref b) => encode_inv!(4, b),
+            Inventory::WTx(w) => encode_inv!(5, w),
+            Inventory::WitnessTransaction(ref t) => encode_inv!(0x40000001, t),
+            Inventory::WitnessBlock(ref b) => encode_inv!(0x40000002, b),
+            Inventory::Unknown { inv_type: t, hash: ref d } => encode_inv!(t, d),
+        })
+    }
+}
+
+impl Decodable for Inventory {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let inv_type: u32 = Decodable::consensus_decode(r)?;
+        Ok(match inv_type {
+            0 => Inventory::Error,
+            1 => Inventory::Transaction(Decodable::consensus_decode(r)?),
+            2 => Inventory::Block(Decodable::consensus_decode(r)?),
+            4 => Inventory::CompactBlock(Decodable::consensus_decode(r)?),
+            5 => Inventory::WTx(Decodable::consensus_decode(r)?),
+            0x40000001 => Inventory::WitnessTransaction(Decodable::consensus_decode(r)?),
+            0x40000002 => Inventory::WitnessBlock(Decodable::consensus_decode(r)?),
+            tp => Inventory::Unknown { inv_type: tp, hash: Decodable::consensus_decode(r)? },
+        })
+    }
+}
+
+// Some simple messages
+
+/// The `getblocks` message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetBlocksMessage {
+    /// The protocol version
+    pub version: u32,
+    /// Locator hashes --- ordered newest to oldest. The remote peer will
+    /// reply with its longest known chain, starting from a locator hash
+    /// if possible and block 1 otherwise.
+    pub locator_hashes: Vec<BlockHash>,
+    /// References the block to stop at, or zero to just fetch the maximum 500 blocks
+    pub stop_hash: BlockHash,
+}
+
+/// The `getheaders` message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetHeadersMessage {
+    /// The protocol version
+    pub version: u32,
+    /// Locator hashes --- ordered newest to oldest. The remote peer will
+    /// reply with its longest known chain, starting from a locator hash
+    /// if possible and block 1 otherwise.
+    pub locator_hashes: Vec<BlockHash>,
+    /// References the header to stop at, or zero to just fetch the maximum 2000 headers
+    pub stop_hash: BlockHash,
+}
+
+impl GetBlocksMessage {
+    /// Construct a new `getblocks` message
+    pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
+        GetBlocksMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
+    }
+}
+
+impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
+
+impl GetHeadersMessage {
+    /// Construct a new `getheaders` message
+    pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
+        GetHeadersMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
+    }
+}
+
+impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
+
+#[cfg(test)]
+mod tests {
+    use hashes::Hash;
+    use hex::test_hex_unwrap as hex;
+
+    use super::{GetBlocksMessage, GetHeadersMessage};
+    use crate::consensus::encode::{deserialize, serialize};
+
+    #[test]
+    fn getblocks_message_test() {
+        let from_sat = hex!("72110100014a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b0000000000000000000000000000000000000000000000000000000000000000");
+        let genhash = hex!("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+
+        let decode: Result<GetBlocksMessage, _> = deserialize(&from_sat);
+        assert!(decode.is_ok());
+        let real_decode = decode.unwrap();
+        assert_eq!(real_decode.version, 70002);
+        assert_eq!(real_decode.locator_hashes.len(), 1);
+        assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
+        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+
+        assert_eq!(serialize(&real_decode), from_sat);
+    }
+
+    #[test]
+    fn getheaders_message_test() {
+        let from_sat = hex!("72110100014a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b0000000000000000000000000000000000000000000000000000000000000000");
+        let genhash = hex!("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+
+        let decode: Result<GetHeadersMessage, _> = deserialize(&from_sat);
+        assert!(decode.is_ok());
+        let real_decode = decode.unwrap();
+        assert_eq!(real_decode.version, 70002);
+        assert_eq!(real_decode.locator_hashes.len(), 1);
+        assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
+        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+
+        assert_eq!(serialize(&real_decode), from_sat);
+    }
+}

--- a/libs/bitcoin/src/p2p/message_bloom.rs
+++ b/libs/bitcoin/src/p2p/message_bloom.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin Connection Bloom filtering network messages.
+//!
+//! This module describes BIP37 Connection Bloom filtering network messages.
+//!
+
+use io::{Read, Write};
+
+use crate::consensus::{encode, Decodable, Encodable, ReadExt};
+use crate::internal_macros::impl_consensus_encoding;
+
+/// `filterload` message sets the current bloom filter
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FilterLoad {
+    /// The filter itself
+    pub filter: Vec<u8>,
+    /// The number of hash functions to use
+    pub hash_funcs: u32,
+    /// A random value
+    pub tweak: u32,
+    /// Controls how matched items are added to the filter
+    pub flags: BloomFlags,
+}
+
+impl_consensus_encoding!(FilterLoad, filter, hash_funcs, tweak, flags);
+
+/// Bloom filter update flags
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BloomFlags {
+    /// Never update the filter with outpoints.
+    None,
+    /// Always update the filter with outpoints.
+    All,
+    /// Only update the filter with outpoints if it is P2PK or P2MS
+    PubkeyOnly,
+}
+
+impl Encodable for BloomFlags {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        w.write_all(&[match self {
+            BloomFlags::None => 0,
+            BloomFlags::All => 1,
+            BloomFlags::PubkeyOnly => 2,
+        }])?;
+        Ok(1)
+    }
+}
+
+impl Decodable for BloomFlags {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(match r.read_u8()? {
+            0 => BloomFlags::None,
+            1 => BloomFlags::All,
+            2 => BloomFlags::PubkeyOnly,
+            _ => return Err(encode::Error::ParseFailed("unknown bloom flag")),
+        })
+    }
+}
+
+/// `filteradd` message updates the current filter with new data
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FilterAdd {
+    /// The data element to add to the current filter.
+    pub data: Vec<u8>,
+}
+
+impl_consensus_encoding!(FilterAdd, data);

--- a/libs/bitcoin/src/p2p/message_compact_blocks.rs
+++ b/libs/bitcoin/src/p2p/message_compact_blocks.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//!
+//! BIP152  Compact Blocks network messages
+//!
+
+use crate::bip152;
+use crate::internal_macros::impl_consensus_encoding;
+
+/// sendcmpct message
+#[derive(PartialEq, Eq, Clone, Debug, Copy, PartialOrd, Ord, Hash)]
+pub struct SendCmpct {
+    /// Request to be send compact blocks.
+    pub send_compact: bool,
+    /// Compact Blocks protocol version number.
+    pub version: u64,
+}
+impl_consensus_encoding!(SendCmpct, send_compact, version);
+
+/// cmpctblock message
+///
+/// Note that the rules for validation before relaying compact blocks is
+/// different from headers and regular block messages. Thus, you shouldn't use
+/// compact blocks when relying on an upstream full node to have validated data
+/// being forwarded to you.
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct CmpctBlock {
+    /// The Compact Block.
+    pub compact_block: bip152::HeaderAndShortIds,
+}
+impl_consensus_encoding!(CmpctBlock, compact_block);
+
+/// getblocktxn message
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct GetBlockTxn {
+    /// The block transactions request.
+    pub txs_request: bip152::BlockTransactionsRequest,
+}
+impl_consensus_encoding!(GetBlockTxn, txs_request);
+
+/// blocktxn message
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+pub struct BlockTxn {
+    /// The requested block transactions.
+    pub transactions: bip152::BlockTransactions,
+}
+impl_consensus_encoding!(BlockTxn, transactions);

--- a/libs/bitcoin/src/p2p/message_filter.rs
+++ b/libs/bitcoin/src/p2p/message_filter.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin Client Side Block Filtering network messages.
+//!
+//! This module describes BIP157 Client Side Block Filtering network messages.
+//!
+
+use crate::bip158::{FilterHash, FilterHeader};
+use crate::blockdata::block::BlockHash;
+use crate::internal_macros::impl_consensus_encoding;
+
+/// getcfilters message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetCFilters {
+    /// Filter type for which headers are requested
+    pub filter_type: u8,
+    /// The height of the first block in the requested range
+    pub start_height: u32,
+    /// The hash of the last block in the requested range
+    pub stop_hash: BlockHash,
+}
+impl_consensus_encoding!(GetCFilters, filter_type, start_height, stop_hash);
+
+/// cfilter message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct CFilter {
+    /// Byte identifying the type of filter being returned
+    pub filter_type: u8,
+    /// Block hash of the Bitcoin block for which the filter is being returned
+    pub block_hash: BlockHash,
+    /// The serialized compact filter for this block
+    pub filter: Vec<u8>,
+}
+impl_consensus_encoding!(CFilter, filter_type, block_hash, filter);
+
+/// getcfheaders message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetCFHeaders {
+    /// Byte identifying the type of filter being returned
+    pub filter_type: u8,
+    /// The height of the first block in the requested range
+    pub start_height: u32,
+    /// The hash of the last block in the requested range
+    pub stop_hash: BlockHash,
+}
+impl_consensus_encoding!(GetCFHeaders, filter_type, start_height, stop_hash);
+
+/// cfheaders message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct CFHeaders {
+    /// Filter type for which headers are requested
+    pub filter_type: u8,
+    /// The hash of the last block in the requested range
+    pub stop_hash: BlockHash,
+    /// The filter header preceding the first block in the requested range
+    pub previous_filter_header: FilterHeader,
+    /// The filter hashes for each block in the requested range
+    pub filter_hashes: Vec<FilterHash>,
+}
+impl_consensus_encoding!(CFHeaders, filter_type, stop_hash, previous_filter_header, filter_hashes);
+
+/// getcfcheckpt message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetCFCheckpt {
+    /// Filter type for which headers are requested
+    pub filter_type: u8,
+    /// The hash of the last block in the requested range
+    pub stop_hash: BlockHash,
+}
+impl_consensus_encoding!(GetCFCheckpt, filter_type, stop_hash);
+
+/// cfcheckpt message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct CFCheckpt {
+    /// Filter type for which headers are requested
+    pub filter_type: u8,
+    /// The hash of the last block in the requested range
+    pub stop_hash: BlockHash,
+    /// The filter headers at intervals of 1,000
+    pub filter_headers: Vec<FilterHeader>,
+}
+impl_consensus_encoding!(CFCheckpt, filter_type, stop_hash, filter_headers);

--- a/libs/bitcoin/src/p2p/message_network.rs
+++ b/libs/bitcoin/src/p2p/message_network.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin network-related network messages.
+//!
+//! This module defines network messages which describe peers and their
+//! capabilities.
+//!
+
+use hashes::sha256d;
+use io::{Read, Write};
+
+use crate::consensus::{encode, Decodable, Encodable, ReadExt};
+use crate::internal_macros::impl_consensus_encoding;
+use crate::p2p;
+use crate::p2p::address::Address;
+use crate::p2p::ServiceFlags;
+use crate::prelude::*;
+
+/// Some simple messages
+
+/// The `version` message
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct VersionMessage {
+    /// The P2P network protocol version
+    pub version: u32,
+    /// A bitmask describing the services supported by this node
+    pub services: ServiceFlags,
+    /// The time at which the `version` message was sent
+    pub timestamp: i64,
+    /// The network address of the peer receiving the message
+    pub receiver: Address,
+    /// The network address of the peer sending the message
+    pub sender: Address,
+    /// A random nonce used to detect loops in the network
+    ///
+    /// The nonce can be used to detect situations when a node accidentally
+    /// connects to itself. Set it to a random value and, in case of incoming
+    /// connections, compare the value - same values mean self-connection.
+    ///
+    /// If your application uses P2P to only fetch the data and doesn't listen
+    /// you may just set it to 0.
+    pub nonce: u64,
+    /// A string describing the peer's software
+    pub user_agent: String,
+    /// The height of the maximum-work blockchain that the peer is aware of
+    pub start_height: i32,
+    /// Whether the receiving peer should relay messages to the sender; used
+    /// if the sender is bandwidth-limited and would like to support bloom
+    /// filtering. Defaults to false.
+    pub relay: bool,
+}
+
+impl VersionMessage {
+    /// Constructs a new `version` message with `relay` set to false
+    pub fn new(
+        services: ServiceFlags,
+        timestamp: i64,
+        receiver: Address,
+        sender: Address,
+        nonce: u64,
+        user_agent: String,
+        start_height: i32,
+    ) -> VersionMessage {
+        VersionMessage {
+            version: p2p::PROTOCOL_VERSION,
+            services,
+            timestamp,
+            receiver,
+            sender,
+            nonce,
+            user_agent,
+            start_height,
+            relay: false,
+        }
+    }
+}
+
+impl_consensus_encoding!(
+    VersionMessage,
+    version,
+    services,
+    timestamp,
+    receiver,
+    sender,
+    nonce,
+    user_agent,
+    start_height,
+    relay
+);
+
+/// message rejection reason as a code
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum RejectReason {
+    /// malformed message
+    Malformed = 0x01,
+    /// invalid message
+    Invalid = 0x10,
+    /// obsolete message
+    Obsolete = 0x11,
+    /// duplicate message
+    Duplicate = 0x12,
+    /// nonstandard transaction
+    NonStandard = 0x40,
+    /// an output is below dust limit
+    Dust = 0x41,
+    /// insufficient fee
+    Fee = 0x42,
+    /// checkpoint
+    Checkpoint = 0x43,
+}
+
+impl Encodable for RejectReason {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        w.write_all(&[*self as u8])?;
+        Ok(1)
+    }
+}
+
+impl Decodable for RejectReason {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(match r.read_u8()? {
+            0x01 => RejectReason::Malformed,
+            0x10 => RejectReason::Invalid,
+            0x11 => RejectReason::Obsolete,
+            0x12 => RejectReason::Duplicate,
+            0x40 => RejectReason::NonStandard,
+            0x41 => RejectReason::Dust,
+            0x42 => RejectReason::Fee,
+            0x43 => RejectReason::Checkpoint,
+            _ => return Err(encode::Error::ParseFailed("unknown reject code")),
+        })
+    }
+}
+
+/// Reject message might be sent by peers rejecting one of our messages
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Reject {
+    /// message type rejected
+    pub message: Cow<'static, str>,
+    /// reason of rejection as code
+    pub ccode: RejectReason,
+    /// reason of rejectection
+    pub reason: Cow<'static, str>,
+    /// reference to rejected item
+    pub hash: sha256d::Hash,
+}
+
+impl_consensus_encoding!(Reject, message, ccode, reason, hash);
+
+#[cfg(test)]
+mod tests {
+    use hashes::sha256d;
+    use hex::test_hex_unwrap as hex;
+
+    use super::{Reject, RejectReason, VersionMessage};
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::p2p::ServiceFlags;
+
+    #[test]
+    fn version_message_test() {
+        // This message is from my satoshi node, morning of May 27 2014
+        let from_sat = hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001");
+
+        let decode: Result<VersionMessage, _> = deserialize(&from_sat);
+        assert!(decode.is_ok());
+        let real_decode = decode.unwrap();
+        assert_eq!(real_decode.version, 70002);
+        assert_eq!(real_decode.services, ServiceFlags::NETWORK);
+        assert_eq!(real_decode.timestamp, 1401217254);
+        // address decodes should be covered by Address tests
+        assert_eq!(real_decode.nonce, 16735069437859780935);
+        assert_eq!(real_decode.user_agent, "/Satoshi:0.9.99/".to_string());
+        assert_eq!(real_decode.start_height, 302892);
+        assert!(real_decode.relay);
+
+        assert_eq!(serialize(&real_decode), from_sat);
+    }
+
+    #[test]
+    fn reject_message_test() {
+        let reject_tx_conflict = hex!("027478121474786e2d6d656d706f6f6c2d636f6e666c69637405df54d3860b3c41806a3546ab48279300affacf4b88591b229141dcf2f47004");
+        let reject_tx_nonfinal = hex!("02747840096e6f6e2d66696e616c259bbe6c83db8bbdfca7ca303b19413dc245d9f2371b344ede5f8b1339a5460b");
+
+        let decode_result_conflict: Result<Reject, _> = deserialize(&reject_tx_conflict);
+        let decode_result_nonfinal: Result<Reject, _> = deserialize(&reject_tx_nonfinal);
+
+        assert!(decode_result_conflict.is_ok());
+        assert!(decode_result_nonfinal.is_ok());
+
+        let conflict = decode_result_conflict.unwrap();
+        assert_eq!("tx", conflict.message);
+        assert_eq!(RejectReason::Duplicate, conflict.ccode);
+        assert_eq!("txn-mempool-conflict", conflict.reason);
+        assert_eq!(
+            "0470f4f2dc4191221b59884bcffaaf00932748ab46356a80413c0b86d354df05"
+                .parse::<sha256d::Hash>()
+                .unwrap(),
+            conflict.hash
+        );
+
+        let nonfinal = decode_result_nonfinal.unwrap();
+        assert_eq!("tx", nonfinal.message);
+        assert_eq!(RejectReason::NonStandard, nonfinal.ccode);
+        assert_eq!("non-final", nonfinal.reason);
+        assert_eq!(
+            "0b46a539138b5fde4e341b37f2d945c23d41193b30caa7fcbd8bdb836cbe9b25"
+                .parse::<sha256d::Hash>()
+                .unwrap(),
+            nonfinal.hash
+        );
+
+        assert_eq!(serialize(&conflict), reject_tx_conflict);
+        assert_eq!(serialize(&nonfinal), reject_tx_nonfinal);
+    }
+}

--- a/libs/bitcoin/src/p2p/mod.rs
+++ b/libs/bitcoin/src/p2p/mod.rs
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin p2p network types.
+//!
+//! This module defines support for (de)serialization and network transport
+//! of Bitcoin data and Bitcoin p2p network messages.
+
+#[cfg(feature = "std")]
+pub mod address;
+#[cfg(feature = "std")]
+pub mod message;
+#[cfg(feature = "std")]
+pub mod message_blockdata;
+#[cfg(feature = "std")]
+pub mod message_bloom;
+#[cfg(feature = "std")]
+pub mod message_compact_blocks;
+#[cfg(feature = "std")]
+pub mod message_filter;
+#[cfg(feature = "std")]
+pub mod message_network;
+
+use core::str::FromStr;
+use core::{fmt, ops};
+
+use hex::FromHex;
+use internals::{debug_from_display, write_err};
+use io::{Read, Write};
+
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::Params;
+use crate::prelude::*;
+use crate::network::Network;
+
+#[rustfmt::skip]
+#[doc(inline)]
+#[cfg(feature = "std")]
+pub use self::address::Address;
+
+/// Version of the protocol as appearing in network message headers.
+///
+/// This constant is used to signal to other peers which features you support. Increasing it implies
+/// that your software also supports every feature prior to this version. Doing so without support
+/// may lead to you incorrectly banning other peers or other peers banning you.
+///
+/// These are the features required for each version:
+/// 70016 - Support receiving `wtxidrelay` message between `version` and `verack` message
+/// 70015 - Support receiving invalid compact blocks from a peer without banning them
+/// 70014 - Support compact block messages `sendcmpct`, `cmpctblock`, `getblocktxn` and `blocktxn`
+/// 70013 - Support `feefilter` message
+/// 70012 - Support `sendheaders` message and announce new blocks via headers rather than inv
+/// 70011 - Support NODE_BLOOM service flag and don't support bloom filter messages if it is not set
+/// 70002 - Support `reject` message
+/// 70001 - Support bloom filter messages `filterload`, `filterclear` `filteradd`, `merkleblock` and FILTERED_BLOCK inventory type
+/// 60002 - Support `mempool` message
+/// 60001 - Support `pong` message and nonce in `ping` message
+pub const PROTOCOL_VERSION: u32 = 70001;
+
+/// Flags to indicate which network services a node supports.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ServiceFlags(u64);
+
+impl ServiceFlags {
+    /// NONE means no services supported.
+    pub const NONE: ServiceFlags = ServiceFlags(0);
+
+    /// NETWORK means that the node is capable of serving the complete block chain. It is currently
+    /// set by all Bitcoin Core non pruned nodes, and is unset by SPV clients or other light
+    /// clients.
+    pub const NETWORK: ServiceFlags = ServiceFlags(1 << 0);
+
+    /// GETUTXO means the node is capable of responding to the getutxo protocol request.  Bitcoin
+    /// Core does not support this but a patch set called Bitcoin XT does.
+    /// See BIP 64 for details on how this is implemented.
+    pub const GETUTXO: ServiceFlags = ServiceFlags(1 << 1);
+
+    /// BLOOM means the node is capable and willing to handle bloom-filtered connections.  Bitcoin
+    /// Core nodes used to support this by default, without advertising this bit, but no longer do
+    /// as of protocol version 70011 (= NO_BLOOM_VERSION)
+    pub const BLOOM: ServiceFlags = ServiceFlags(1 << 2);
+
+    /// WITNESS indicates that a node can be asked for blocks and transactions including witness
+    /// data.
+    pub const WITNESS: ServiceFlags = ServiceFlags(1 << 3);
+
+    /// COMPACT_FILTERS means the node will service basic block filter requests.
+    /// See BIP157 and BIP158 for details on how this is implemented.
+    pub const COMPACT_FILTERS: ServiceFlags = ServiceFlags(1 << 6);
+
+    /// NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only serving the last
+    /// 288 (2 day) blocks.
+    /// See BIP159 for details on how this is implemented.
+    pub const NETWORK_LIMITED: ServiceFlags = ServiceFlags(1 << 10);
+
+    /// P2P_V2 indicates that the node supports the P2P v2 encrypted transport protocol.
+    /// See BIP324 for details on how this is implemented.
+    pub const P2P_V2: ServiceFlags = ServiceFlags(1 << 11);
+
+    // NOTE: When adding new flags, remember to update the Display impl accordingly.
+
+    /// Add [ServiceFlags] together.
+    ///
+    /// Returns itself.
+    pub fn add(&mut self, other: ServiceFlags) -> ServiceFlags {
+        self.0 |= other.0;
+        *self
+    }
+
+    /// Remove [ServiceFlags] from this.
+    ///
+    /// Returns itself.
+    pub fn remove(&mut self, other: ServiceFlags) -> ServiceFlags {
+        self.0 ^= other.0;
+        *self
+    }
+
+    /// Check whether [ServiceFlags] are included in this one.
+    pub fn has(self, flags: ServiceFlags) -> bool { (self.0 | flags.0) == self.0 }
+
+    /// Gets the integer representation of this [`ServiceFlags`].
+    pub fn to_u64(self) -> u64 { self.0 }
+}
+
+impl fmt::LowerHex for ServiceFlags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
+}
+
+impl fmt::UpperHex for ServiceFlags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
+}
+
+impl fmt::Display for ServiceFlags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut flags = *self;
+        if flags == ServiceFlags::NONE {
+            return write!(f, "ServiceFlags(NONE)");
+        }
+        let mut first = true;
+        macro_rules! write_flag {
+            ($f:ident) => {
+                if flags.has(ServiceFlags::$f) {
+                    if !first {
+                        write!(f, "|")?;
+                    }
+                    first = false;
+                    write!(f, stringify!($f))?;
+                    flags.remove(ServiceFlags::$f);
+                }
+            };
+        }
+        write!(f, "ServiceFlags(")?;
+        write_flag!(NETWORK);
+        write_flag!(GETUTXO);
+        write_flag!(BLOOM);
+        write_flag!(WITNESS);
+        write_flag!(COMPACT_FILTERS);
+        write_flag!(NETWORK_LIMITED);
+        write_flag!(P2P_V2);
+        // If there are unknown flags left, we append them in hex.
+        if flags != ServiceFlags::NONE {
+            if !first {
+                write!(f, "|")?;
+            }
+            write!(f, "0x{:x}", flags)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl From<u64> for ServiceFlags {
+    fn from(f: u64) -> Self { ServiceFlags(f) }
+}
+
+impl From<ServiceFlags> for u64 {
+    fn from(flags: ServiceFlags) -> Self { flags.0 }
+}
+
+impl ops::BitOr for ServiceFlags {
+    type Output = Self;
+
+    fn bitor(mut self, rhs: Self) -> Self { self.add(rhs) }
+}
+
+impl ops::BitOrAssign for ServiceFlags {
+    fn bitor_assign(&mut self, rhs: Self) { self.add(rhs); }
+}
+
+impl ops::BitXor for ServiceFlags {
+    type Output = Self;
+
+    fn bitxor(mut self, rhs: Self) -> Self { self.remove(rhs) }
+}
+
+impl ops::BitXorAssign for ServiceFlags {
+    fn bitxor_assign(&mut self, rhs: Self) { self.remove(rhs); }
+}
+
+impl Encodable for ServiceFlags {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for ServiceFlags {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(ServiceFlags(Decodable::consensus_decode(r)?))
+    }
+}
+/// Network magic bytes to identify the cryptocurrency network the message was intended for.
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+pub struct Magic([u8; 4]);
+
+impl Magic {
+    /// Bitcoin mainnet network magic bytes.
+    pub const BITCOIN: Self = Self([0xF9, 0xBE, 0xB4, 0xD9]);
+    /// Bitcoin testnet3 network magic bytes.
+    #[deprecated(since = "0.32.4", note = "Use TESTNET3 instead")]
+    pub const TESTNET: Self = Self([0x0B, 0x11, 0x09, 0x07]);
+    /// Bitcoin testnet3 network magic bytes.
+    pub const TESTNET3: Self = Self([0x0B, 0x11, 0x09, 0x07]);
+    /// Bitcoin testnet4 network magic bytes.
+    pub const TESTNET4: Self = Self([0x1c, 0x16, 0x3f, 0x28]);
+    /// Bitcoin signet network magic bytes.
+    pub const SIGNET: Self = Self([0x0A, 0x03, 0xCF, 0x40]);
+    /// Bitcoin regtest network magic bytes.
+    pub const REGTEST: Self = Self([0xFA, 0xBF, 0xB5, 0xDA]);
+
+    /// Create network magic from bytes.
+    pub fn from_bytes(bytes: [u8; 4]) -> Magic { Magic(bytes) }
+
+    /// Get network magic bytes.
+    pub fn to_bytes(self) -> [u8; 4] { self.0 }
+
+    /// Returns the magic bytes for the network defined by `params`.
+    pub fn from_params(params: impl AsRef<Params>) -> Self {
+        params.as_ref().network.into()
+    }
+}
+
+impl FromStr for Magic {
+    type Err = ParseMagicError;
+
+    fn from_str(s: &str) -> Result<Magic, Self::Err> {
+        match <[u8; 4]>::from_hex(s) {
+            Ok(magic) => Ok(Magic::from_bytes(magic)),
+            Err(e) => Err(ParseMagicError { error: e, magic: s.to_owned() }),
+        }
+    }
+}
+
+impl From<Network> for Magic {
+    fn from(network: Network) -> Magic {
+        match network {
+            // Note: new network entries must explicitly be matched in `try_from` below.
+            Network::Bitcoin => Magic::BITCOIN,
+            Network::Testnet => Magic::TESTNET3,
+            Network::Testnet4 => Magic::TESTNET4,
+            Network::Signet => Magic::SIGNET,
+            Network::Regtest => Magic::REGTEST,
+        }
+    }
+}
+
+impl TryFrom<Magic> for Network {
+    type Error = UnknownMagicError;
+
+    fn try_from(magic: Magic) -> Result<Self, Self::Error> {
+        match magic {
+            // Note: any new network entries must be matched against here.
+            Magic::BITCOIN => Ok(Network::Bitcoin),
+            Magic::TESTNET3 => Ok(Network::Testnet),
+            Magic::TESTNET4 => Ok(Network::Testnet4),
+            Magic::SIGNET => Ok(Network::Signet),
+            Magic::REGTEST => Ok(Network::Regtest),
+            _ => Err(UnknownMagicError(magic)),
+        }
+    }
+}
+
+impl fmt::Display for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
+        Ok(())
+    }
+}
+debug_from_display!(Magic);
+
+impl fmt::LowerHex for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Upper)?;
+        Ok(())
+    }
+}
+
+impl Encodable for Magic {
+    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(writer)
+    }
+}
+
+impl Decodable for Magic {
+    fn consensus_decode<R: Read + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
+        Ok(Magic(Decodable::consensus_decode(reader)?))
+    }
+}
+
+impl AsRef<[u8]> for Magic {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsRef<[u8; 4]> for Magic {
+    fn as_ref(&self) -> &[u8; 4] { &self.0 }
+}
+
+impl AsMut<[u8]> for Magic {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl AsMut<[u8; 4]> for Magic {
+    fn as_mut(&mut self) -> &mut [u8; 4] { &mut self.0 }
+}
+
+impl Borrow<[u8]> for Magic {
+    fn borrow(&self) -> &[u8] { &self.0 }
+}
+
+impl Borrow<[u8; 4]> for Magic {
+    fn borrow(&self) -> &[u8; 4] { &self.0 }
+}
+
+impl BorrowMut<[u8]> for Magic {
+    fn borrow_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl BorrowMut<[u8; 4]> for Magic {
+    fn borrow_mut(&mut self) -> &mut [u8; 4] { &mut self.0 }
+}
+
+/// An error in parsing magic bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ParseMagicError {
+    /// The error that occurred when parsing the string.
+    error: hex::HexToArrayError,
+    /// The byte string that failed to parse.
+    magic: String,
+}
+
+impl fmt::Display for ParseMagicError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write_err!(f, "failed to parse {} as network magic", self.magic; self.error)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseMagicError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
+}
+
+/// Error in creating a Network from Magic bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnknownMagicError(Magic);
+
+impl fmt::Display for UnknownMagicError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "unknown network magic {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnknownMagicError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_flags_test() {
+        let all = [
+            ServiceFlags::NETWORK,
+            ServiceFlags::GETUTXO,
+            ServiceFlags::BLOOM,
+            ServiceFlags::WITNESS,
+            ServiceFlags::COMPACT_FILTERS,
+            ServiceFlags::NETWORK_LIMITED,
+        ];
+
+        let mut flags = ServiceFlags::NONE;
+        for f in all.iter() {
+            assert!(!flags.has(*f));
+        }
+
+        flags |= ServiceFlags::WITNESS;
+        assert_eq!(flags, ServiceFlags::WITNESS);
+
+        let mut flags2 = flags | ServiceFlags::GETUTXO;
+        for f in all.iter() {
+            assert_eq!(flags2.has(*f), *f == ServiceFlags::WITNESS || *f == ServiceFlags::GETUTXO);
+        }
+
+        flags2 ^= ServiceFlags::WITNESS;
+        assert_eq!(flags2, ServiceFlags::GETUTXO);
+
+        flags2 |= ServiceFlags::COMPACT_FILTERS;
+        flags2 ^= ServiceFlags::GETUTXO;
+        assert_eq!(flags2, ServiceFlags::COMPACT_FILTERS);
+
+        // Test formatting.
+        assert_eq!("ServiceFlags(NONE)", ServiceFlags::NONE.to_string());
+        assert_eq!("ServiceFlags(WITNESS)", ServiceFlags::WITNESS.to_string());
+        let flag = ServiceFlags::WITNESS | ServiceFlags::BLOOM | ServiceFlags::NETWORK;
+        assert_eq!("ServiceFlags(NETWORK|BLOOM|WITNESS)", flag.to_string());
+        let flag = ServiceFlags::WITNESS | 0xf0.into();
+        assert_eq!("ServiceFlags(WITNESS|COMPACT_FILTERS|0xb0)", flag.to_string());
+    }
+
+    #[test]
+    fn magic_from_str() {
+        let known_network_magic_strs = [
+            ("f9beb4d9", Network::Bitcoin),
+            ("0b110907", Network::Testnet),
+            ("1c163f28", Network::Testnet4),
+            ("fabfb5da", Network::Regtest),
+            ("0a03cf40", Network::Signet),
+        ];
+
+        for (magic_str, network) in &known_network_magic_strs {
+            let magic: Magic = Magic::from_str(magic_str).unwrap();
+            assert_eq!(Network::try_from(magic).unwrap(), *network);
+            assert_eq!(&magic.to_string(), magic_str);
+        }
+    }
+}

--- a/libs/bitcoin/src/policy.rs
+++ b/libs/bitcoin/src/policy.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin policy.
+//!
+//! This module exposes some constants and functions used in the reference
+//! implementation and which, as a consequence, define some network rules.
+//!
+//! # *Warning*
+//! While the constants present in this module are very unlikely to change, they do not define
+//! Bitcoin. As such they must not be relied upon as if they were consensus rules.
+//!
+//! These values were taken from bitcoind v0.21.1 (194b9b8792d9b0798fdb570b79fa51f1d1f5ebaf).
+//!
+
+use core::cmp;
+
+use super::blockdata::constants::{MAX_BLOCK_SIGOPS_COST, WITNESS_SCALE_FACTOR};
+
+/// Maximum weight of a transaction for it to be relayed by most nodes on the network
+pub const MAX_STANDARD_TX_WEIGHT: u32 = 400_000;
+
+/// Minimum non-witness size for a standard transaction (1 segwit input + 1 P2WPKH output = 82 bytes)
+pub const MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 82;
+
+/// Maximum number of sigops in a standard tx.
+pub const MAX_STANDARD_TX_SIGOPS_COST: u32 = MAX_BLOCK_SIGOPS_COST as u32 / 5;
+
+/// The minimum incremental *feerate* (despite the name), in sats per virtual kilobyte for RBF.
+pub const DEFAULT_INCREMENTAL_RELAY_FEE: u32 = 1_000;
+
+/// The number of bytes equivalent per signature operation. Affects transaction relay through the
+/// virtual size computation.
+pub const DEFAULT_BYTES_PER_SIGOP: u32 = 20;
+
+/// The minimum feerate, in sats per kilo-virtualbyte, for defining dust. An output is considered
+/// dust if spending it under this feerate would cost more in fee.
+pub const DUST_RELAY_TX_FEE: u32 = 3_000;
+
+/// Minimum feerate, in sats per virtual kilobyte, for a transaction to be relayed by most nodes on
+/// the network.
+pub const DEFAULT_MIN_RELAY_TX_FEE: u32 = 1_000;
+
+/// Default number of hours for an unconfirmed transaction to expire in most of the network nodes'
+/// mempools.
+pub const DEFAULT_MEMPOOL_EXPIRY: u32 = 336;
+
+/// The virtual transaction size, as computed by default by bitcoind node.
+pub fn get_virtual_tx_size(weight: i64, n_sigops: i64) -> i64 {
+    (cmp::max(weight, n_sigops * DEFAULT_BYTES_PER_SIGOP as i64) + WITNESS_SCALE_FACTOR as i64 - 1)
+        / WITNESS_SCALE_FACTOR as i64
+}

--- a/libs/bitcoin/src/pow.rs
+++ b/libs/bitcoin/src/pow.rs
@@ -1,0 +1,2078 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Proof-of-work related integer types.
+//!
+//! Provides the [`Work`] and [`Target`] types that are used in proof-of-work calculations. The
+//! functions here are designed to be fast, by that we mean it is safe to use them to check headers.
+//!
+
+use core::cmp;
+use core::fmt::{self, LowerHex, UpperHex};
+use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
+
+use io::{Read, Write};
+#[cfg(all(test, mutate))]
+use mutagen::mutate;
+use units::parse;
+
+use crate::block::Header;
+use crate::blockdata::block::BlockHash;
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::Params;
+use crate::error::{ContainsPrefixError, MissingPrefixError, ParseIntError, PrefixedHexError, UnprefixedHexError};
+
+/// Implement traits and methods shared by `Target` and `Work`.
+macro_rules! do_impl {
+    ($ty:ident) => {
+        impl $ty {
+            #[doc = "Creates `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` from a prefixed hex string."]
+            pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
+                Ok($ty(U256::from_hex(s)?))
+            }
+
+            #[doc = "Creates `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` from an unprefixed hex string."]
+            pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
+                Ok($ty(U256::from_unprefixed_hex(s)?))
+            }
+
+            #[doc = "Creates `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` from a big-endian byte array."]
+            #[inline]
+            pub fn from_be_bytes(bytes: [u8; 32]) -> $ty { $ty(U256::from_be_bytes(bytes)) }
+
+            #[doc = "Creates `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` from a little-endian byte array."]
+            #[inline]
+            pub fn from_le_bytes(bytes: [u8; 32]) -> $ty { $ty(U256::from_le_bytes(bytes)) }
+
+            #[doc = "Converts `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` to a big-endian byte array."]
+            #[inline]
+            pub fn to_be_bytes(self) -> [u8; 32] { self.0.to_be_bytes() }
+
+            #[doc = "Converts `"]
+            #[doc = stringify!($ty)]
+            #[doc = "` to a little-endian byte array."]
+            #[inline]
+            pub fn to_le_bytes(self) -> [u8; 32] { self.0.to_le_bytes() }
+        }
+
+        impl fmt::Display for $ty {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl fmt::LowerHex for $ty {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+                fmt::LowerHex::fmt(&self.0, f)
+            }
+        }
+
+        impl fmt::UpperHex for $ty {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+                fmt::UpperHex::fmt(&self.0, f)
+            }
+        }
+    };
+}
+
+/// A 256 bit integer representing work.
+///
+/// Work is a measure of how difficult it is to find a hash below a given [`Target`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Work(U256);
+
+impl Work {
+    /// Converts this [`Work`] to [`Target`].
+    pub fn to_target(self) -> Target { Target(self.0.inverse()) }
+
+    /// Returns log2 of this work.
+    ///
+    /// The result inherently suffers from a loss of precision and is, therefore, meant to be
+    /// used mainly for informative and displaying purposes, similarly to Bitcoin Core's
+    /// `log2_work` output in its logs.
+    #[cfg(feature = "std")]
+    pub fn log2(self) -> f64 { self.0.to_f64().log2() }
+}
+do_impl!(Work);
+
+impl Add for Work {
+    type Output = Work;
+    fn add(self, rhs: Self) -> Self { Work(self.0 + rhs.0) }
+}
+
+impl Sub for Work {
+    type Output = Work;
+    fn sub(self, rhs: Self) -> Self { Work(self.0 - rhs.0) }
+}
+
+/// A 256 bit integer representing target.
+///
+/// The SHA-256 hash of a block's header must be lower than or equal to the current target for the
+/// block to be accepted by the network. The lower the target, the more difficult it is to generate
+/// a block. (See also [`Work`].)
+///
+/// ref: <https://en.bitcoin.it/wiki/Target>
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Target(U256);
+
+impl Target {
+    /// When parsing nBits, Bitcoin Core converts a negative target threshold into a target of zero.
+    pub const ZERO: Target = Target(U256::ZERO);
+    /// The maximum possible target.
+    ///
+    /// This value is used to calculate difficulty, which is defined as how difficult the current
+    /// target makes it to find a block relative to how difficult it would be at the highest
+    /// possible target. Remember highest target == lowest difficulty.
+    ///
+    /// ref: <https://en.bitcoin.it/wiki/Target>
+    // In Bitcoind this is ~(u256)0 >> 32 stored as a floating-point type so it gets truncated, hence
+    // the low 208 bits are all zero.
+    pub const MAX: Self = Target(U256(0xFFFF_u128 << (208 - 128), 0));
+
+    /// The maximum **attainable** target value on mainnet.
+    ///
+    /// Not all target values are attainable because consensus code uses the compact format to
+    /// represent targets (see [`CompactTarget`]).
+    pub const MAX_ATTAINABLE_MAINNET: Self = Target(U256(0xFFFF_u128 << (208 - 128), 0));
+
+    /// The proof of work limit on testnet.
+    // Taken from Bitcoin Core but had lossy conversion to/from compact form.
+    // https://github.com/bitcoin/bitcoin/blob/8105bce5b384c72cf08b25b7c5343622754e7337/src/kernel/chainparams.cpp#L208
+    pub const MAX_ATTAINABLE_TESTNET: Self = Target(U256(0xFFFF_u128 << (208 - 128), 0));
+
+    /// The proof of work limit on regtest.
+    // Taken from Bitcoin Core but had lossy conversion to/from compact form.
+    // https://github.com/bitcoin/bitcoin/blob/8105bce5b384c72cf08b25b7c5343622754e7337/src/kernel/chainparams.cpp#L411
+    pub const MAX_ATTAINABLE_REGTEST: Self = Target(U256(0x7FFF_FF00u128 << 96, 0));
+
+    /// The proof of work limit on signet.
+    // Taken from Bitcoin Core but had lossy conversion to/from compact form.
+    // https://github.com/bitcoin/bitcoin/blob/8105bce5b384c72cf08b25b7c5343622754e7337/src/kernel/chainparams.cpp#L348
+    pub const MAX_ATTAINABLE_SIGNET: Self = Target(U256(0x0377_ae00 << 80, 0));
+
+    /// Computes the [`Target`] value from a compact representation.
+    ///
+    /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
+    pub fn from_compact(c: CompactTarget) -> Target {
+        let bits = c.0;
+        // This is a floating-point "compact" encoding originally used by
+        // OpenSSL, which satoshi put into consensus code, so we're stuck
+        // with it. The exponent needs to have 3 subtracted from it, hence
+        // this goofy decoding code. 3 is due to 3 bytes in the mantissa.
+        let (mant, expt) = {
+            let unshifted_expt = bits >> 24;
+            if unshifted_expt <= 3 {
+                ((bits & 0xFFFFFF) >> (8 * (3 - unshifted_expt as usize)), 0)
+            } else {
+                (bits & 0xFFFFFF, 8 * ((bits >> 24) - 3))
+            }
+        };
+
+        // The mantissa is signed but may not be negative.
+        if mant > 0x7F_FFFF {
+            Target::ZERO
+        } else {
+            Target(U256::from(mant) << expt)
+        }
+    }
+
+    /// Computes the compact value from a [`Target`] representation.
+    ///
+    /// The compact form is by definition lossy, this means that
+    /// `t == Target::from_compact(t.to_compact_lossy())` does not always hold.
+    pub fn to_compact_lossy(self) -> CompactTarget {
+        let mut size = (self.0.bits() + 7) / 8;
+        let mut compact = if size <= 3 {
+            (self.0.low_u64() << (8 * (3 - size))) as u32
+        } else {
+            let bn = self.0 >> (8 * (size - 3));
+            bn.low_u32()
+        };
+
+        if (compact & 0x0080_0000) != 0 {
+            compact >>= 8;
+            size += 1;
+        }
+
+        CompactTarget(compact | (size << 24))
+    }
+
+    /// Returns true if block hash is less than or equal to this [`Target`].
+    ///
+    /// Proof-of-work validity for a block requires the hash of the block to be less than or equal
+    /// to the target.
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn is_met_by(&self, hash: BlockHash) -> bool {
+        use hashes::Hash;
+        let hash = U256::from_le_bytes(hash.to_byte_array());
+        hash <= self.0
+    }
+
+    /// Converts this [`Target`] to [`Work`].
+    ///
+    /// "Work" is defined as the work done to mine a block with this target value (recorded in the
+    /// block header in compact form as nBits). This is not the same as the difficulty to mine a
+    /// block with this target (see `Self::difficulty`).
+    pub fn to_work(self) -> Work { Work(self.0.inverse()) }
+
+    /// Computes the popular "difficulty" measure for mining.
+    ///
+    /// Difficulty represents how difficult the current target makes it to find a block, relative to
+    /// how difficult it would be at the highest possible target (highest target == lowest difficulty).
+    ///
+    /// For example, a difficulty of 6,695,826 means that at a given hash rate, it will, on average,
+    /// take ~6.6 million times as long to find a valid block as it would at a difficulty of 1, or
+    /// alternatively, it will take, again on average, ~6.6 million times as many hashes to find a
+    /// valid block
+    ///
+    /// # Note
+    ///
+    /// Difficulty is calculated using the following algorithm `max / current` where [max] is
+    /// defined for the Bitcoin network and `current` is the current [target] for this block. As
+    /// such, a low target implies a high difficulty. Since [`Target`] is represented as a 256 bit
+    /// integer but `difficulty()` returns only 128 bits this means for targets below approximately
+    /// `0xffff_ffff_ffff_ffff_ffff_ffff` `difficulty()` will saturate at `u128::MAX`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is zero (divide by zero).
+    ///
+    /// [max]: Target::max
+    /// [target]: crate::blockdata::block::Header::target
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn difficulty(&self, params: impl AsRef<Params>) -> u128 {
+        // Panic here may be eaiser to debug than during the actual division.
+        assert_ne!(self.0, U256::ZERO, "divide by zero");
+
+        let max = params.as_ref().max_attainable_target;
+        let d = max.0 / self.0;
+        d.saturating_to_u128()
+    }
+
+    /// Computes the popular "difficulty" measure for mining and returns a float value of f64.
+    ///
+    /// See [`difficulty`] for details.
+    ///
+    /// # Returns
+    ///
+    /// Returns [`f64::INFINITY`] if `self` is zero (caused by divide by zero).
+    ///
+    /// [`difficulty`]: Target::difficulty
+    #[cfg_attr(all(test, mutate), mutate)]
+    pub fn difficulty_float(&self) -> f64 { TARGET_MAX_F64 / self.0.to_f64() }
+
+    /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    #[deprecated(since = "0.32.0", note = "use min_transition_threshold instead")]
+    pub fn min_difficulty_transition_threshold(&self) -> Self { self.min_transition_threshold() }
+
+    /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    #[deprecated(since = "0.32.0", note = "use max_transition_threshold instead")]
+    pub fn max_difficulty_transition_threshold(&self) -> Self {
+        self.max_transition_threshold_unchecked()
+    }
+
+    /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    ///
+    /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
+    /// adjustment period.
+    ///
+    /// # Returns
+    ///
+    /// In line with Bitcoin Core this function may return a target value of zero.
+    pub fn min_transition_threshold(&self) -> Self { Self(self.0 >> 2) }
+
+    /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    ///
+    /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
+    /// adjustment period.
+    ///
+    /// We also check that the calculated target is not greater than the maximum allowed target,
+    /// this value is network specific - hence the `params` parameter.
+    pub fn max_transition_threshold(&self, params: impl AsRef<Params>) -> Self {
+        let max_attainable = params.as_ref().max_attainable_target;
+        cmp::min(self.max_transition_threshold_unchecked(), max_attainable)
+    }
+
+    /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    ///
+    /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
+    /// adjustment period.
+    ///
+    /// # Returns
+    ///
+    /// This function may return a value greater than the maximum allowed target for this network.
+    ///
+    /// The return value should be checked against [`Params::max_attainable_target`] or use one of
+    /// the `Target::MAX_ATTAINABLE_FOO` constants.
+    pub fn max_transition_threshold_unchecked(&self) -> Self { Self(self.0 << 2) }
+}
+do_impl!(Target);
+
+/// Encoding of 256-bit target as 32-bit float.
+///
+/// This is used to encode a target into the block header. Satoshi made this part of consensus code
+/// in the original version of Bitcoin, likely copying an idea from OpenSSL.
+///
+/// OpenSSL's bignum (BN) type has an encoding, which is even called "compact" as in bitcoin, which
+/// is exactly this format.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct CompactTarget(u32);
+
+impl CompactTarget {
+    /// Creates a `CompactTarget` from an prefixed hex string.
+    pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
+        let stripped = if let Some(stripped) = s.strip_prefix("0x") {
+            stripped
+        } else if let Some(stripped) = s.strip_prefix("0X") {
+            stripped
+        } else {
+            return Err(MissingPrefixError::new(s).into());
+        };
+
+        let target = parse::hex_u32(stripped)?;
+        Ok(Self::from_consensus(target))
+    }
+
+    /// Creates a `CompactTarget` from an unprefixed hex string.
+    pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
+        if s.starts_with("0x") || s.starts_with("0X") {
+            return Err(ContainsPrefixError::new(s).into());
+        }
+        let lock_time = parse::hex_u32(s)?;
+        Ok(Self::from_consensus(lock_time))
+    }
+
+    /// Computes the [`CompactTarget`] from a difficulty adjustment.
+    ///
+    /// ref: <https://github.com/bitcoin/bitcoin/blob/0503cbea9aab47ec0a87d34611e5453158727169/src/pow.cpp>
+    ///
+    /// Given the previous Target, represented as a [`CompactTarget`], the difficulty is adjusted
+    /// by taking the timespan between them, and multipling the current [`CompactTarget`] by a factor
+    /// of the net timespan and expected timespan. The [`CompactTarget`] may not adjust by more than
+    /// a factor of 4, or adjust beyond the maximum threshold for the network.
+    ///
+    /// # Note
+    ///
+    /// Under the consensus rules, the difference in the number of blocks between the headers does
+    /// not equate to the `difficulty_adjustment_interval` of [`Params`]. This is due to an off-by-one
+    /// error, and, the expected number of blocks in between headers is `difficulty_adjustment_interval - 1`
+    /// when calculating the difficulty adjustment.
+    ///
+    /// Take the example of the first difficulty adjustment. Block 2016 introduces a new [`CompactTarget`],
+    /// which takes the net timespan between Block 2015 and Block 0, and recomputes the difficulty.
+    ///
+    /// # Returns
+    ///
+    /// The expected [`CompactTarget`] recalculation.
+    pub fn from_next_work_required(
+        last: CompactTarget,
+        timespan: u64,
+        params: impl AsRef<Params>,
+    ) -> CompactTarget {
+        let params = params.as_ref();
+        if params.no_pow_retargeting {
+            return last;
+        }
+        // Comments relate to the `pow.cpp` file from Core.
+        // ref: <https://github.com/bitcoin/bitcoin/blob/0503cbea9aab47ec0a87d34611e5453158727169/src/pow.cpp>
+        let min_timespan = params.pow_target_timespan >> 2; // Lines 56/57
+        let max_timespan = params.pow_target_timespan << 2; // Lines 58/59
+        let actual_timespan = timespan.clamp(min_timespan, max_timespan);
+        let prev_target: Target = last.into();
+        let maximum_retarget = prev_target.max_transition_threshold(params); // bnPowLimit
+        let retarget = prev_target.0; // bnNew
+        let retarget = retarget.mul(actual_timespan.into());
+        let retarget = retarget.div(params.pow_target_timespan.into());
+        let retarget = Target(retarget);
+        if retarget.ge(&maximum_retarget) {
+            return maximum_retarget.to_compact_lossy();
+        }
+        retarget.to_compact_lossy()
+    }
+
+    /// Computes the [`CompactTarget`] from a difficulty adjustment,
+    /// assuming these are the relevant block headers.
+    ///
+    /// Given two headers, representing the start and end of a difficulty adjustment epoch,
+    /// compute the [`CompactTarget`] based on the net time between them and the current
+    /// [`CompactTarget`].
+    ///
+    /// # Note
+    ///
+    /// See [`CompactTarget::from_next_work_required`]
+    ///
+    /// For example, to successfully compute the first difficulty adjustment on the Bitcoin network,
+    /// one would pass the header for Block 2015 as `current` and the header for Block 0 as
+    /// `last_epoch_boundary`.
+    ///
+    /// # Returns
+    ///
+    /// The expected [`CompactTarget`] recalculation.
+    pub fn from_header_difficulty_adjustment(
+        last_epoch_boundary: Header,
+        current: Header,
+        params: impl AsRef<Params>,
+    ) -> CompactTarget {
+        let timespan = current.time - last_epoch_boundary.time;
+        let bits = current.bits;
+        CompactTarget::from_next_work_required(bits, timespan.into(), params)
+    }
+
+    /// Creates a [`CompactTarget`] from a consensus encoded `u32`.
+    pub fn from_consensus(bits: u32) -> Self { Self(bits) }
+
+    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    pub fn to_consensus(self) -> u32 { self.0 }
+}
+
+impl From<CompactTarget> for Target {
+    fn from(c: CompactTarget) -> Self { Target::from_compact(c) }
+}
+
+impl Encodable for CompactTarget {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for CompactTarget {
+    #[inline]
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        u32::consensus_decode(r).map(CompactTarget)
+    }
+}
+
+impl LowerHex for CompactTarget {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { LowerHex::fmt(&self.0, f) }
+}
+
+impl UpperHex for CompactTarget {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { UpperHex::fmt(&self.0, f) }
+}
+
+/// Big-endian 256 bit integer type.
+// (high, low): u.0 contains the high bits, u.1 contains the low bits.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+struct U256(u128, u128);
+
+impl U256 {
+    const MAX: U256 =
+        U256(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+
+    const ZERO: U256 = U256(0, 0);
+
+    const ONE: U256 = U256(0, 1);
+
+    /// Creates a `U256` from a prefixed hex string.
+    fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
+        let stripped = if let Some(stripped) = s.strip_prefix("0x") {
+            stripped
+        } else if let Some(stripped) = s.strip_prefix("0X") {
+            stripped
+        } else {
+            return Err(MissingPrefixError::new(s).into());
+        };
+        Ok(U256::from_hex_internal(stripped)?)
+    }
+
+    /// Creates a `U256` from an unprefixed hex string.
+    fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
+        if s.starts_with("0x") || s.starts_with("0X") {
+            return Err(ContainsPrefixError::new(s).into());
+        }
+        Ok(U256::from_hex_internal(s)?)
+    }
+
+    // Caller to ensure `s` does not contain a prefix.
+    fn from_hex_internal(s: &str) -> Result<Self, ParseIntError> {
+        let (high, low) = if s.len() <= 32 {
+            let low = parse::hex_u128(s)?;
+            (0, low)
+        } else {
+            let high_len = s.len() - 32;
+            let high_s = &s[..high_len];
+            let low_s = &s[high_len..];
+
+            let high = parse::hex_u128(high_s)?;
+            let low = parse::hex_u128(low_s)?;
+            (high, low)
+        };
+
+        Ok(U256(high, low))
+    }
+
+    /// Creates `U256` from a big-endian array of `u8`s.
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn from_be_bytes(a: [u8; 32]) -> U256 {
+        let (high, low) = split_in_half(a);
+        let big = u128::from_be_bytes(high);
+        let little = u128::from_be_bytes(low);
+        U256(big, little)
+    }
+
+    /// Creates a `U256` from a little-endian array of `u8`s.
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn from_le_bytes(a: [u8; 32]) -> U256 {
+        let (high, low) = split_in_half(a);
+        let little = u128::from_le_bytes(high);
+        let big = u128::from_le_bytes(low);
+        U256(big, little)
+    }
+
+    /// Converts `U256` to a big-endian array of `u8`s.
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn to_be_bytes(self) -> [u8; 32] {
+        let mut out = [0; 32];
+        out[..16].copy_from_slice(&self.0.to_be_bytes());
+        out[16..].copy_from_slice(&self.1.to_be_bytes());
+        out
+    }
+
+    /// Converts `U256` to a little-endian array of `u8`s.
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn to_le_bytes(self) -> [u8; 32] {
+        let mut out = [0; 32];
+        out[..16].copy_from_slice(&self.1.to_le_bytes());
+        out[16..].copy_from_slice(&self.0.to_le_bytes());
+        out
+    }
+
+    /// Calculates 2^256 / (x + 1) where x is a 256 bit unsigned integer.
+    ///
+    /// 2**256 / (x + 1) == ~x / (x + 1) + 1
+    ///
+    /// (Equation shamelessly stolen from bitcoind)
+    fn inverse(&self) -> U256 {
+        // We should never have a target/work of zero so this doesn't matter
+        // that much but we define the inverse of 0 as max.
+        if self.is_zero() {
+            return U256::MAX;
+        }
+        // We define the inverse of 1 as max.
+        if self.is_one() {
+            return U256::MAX;
+        }
+        // We define the inverse of max as 1.
+        if self.is_max() {
+            return U256::ONE;
+        }
+
+        let ret = !*self / self.wrapping_inc();
+        ret.wrapping_inc()
+    }
+
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn is_zero(&self) -> bool { self.0 == 0 && self.1 == 0 }
+
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn is_one(&self) -> bool { self.0 == 0 && self.1 == 1 }
+
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn is_max(&self) -> bool { self.0 == u128::MAX && self.1 == u128::MAX }
+
+    /// Returns the low 32 bits.
+    fn low_u32(&self) -> u32 { self.low_u128() as u32 }
+
+    /// Returns the low 64 bits.
+    fn low_u64(&self) -> u64 { self.low_u128() as u64 }
+
+    /// Returns the low 128 bits.
+    fn low_u128(&self) -> u128 { self.1 }
+
+    /// Returns this `U256` as a `u128` saturating to `u128::MAX` if `self` is too big.
+    // Matagen gives false positive because >= and > both return u128::MAX
+    fn saturating_to_u128(&self) -> u128 {
+        if *self > U256::from(u128::MAX) {
+            u128::MAX
+        } else {
+            self.low_u128()
+        }
+    }
+
+    /// Returns the least number of bits needed to represent the number.
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn bits(&self) -> u32 {
+        if self.0 > 0 {
+            256 - self.0.leading_zeros()
+        } else {
+            128 - self.1.leading_zeros()
+        }
+    }
+
+    /// Wrapping multiplication by `u64`.
+    ///
+    /// # Returns
+    ///
+    /// The multiplication result along with a boolean indicating whether an arithmetic overflow
+    /// occurred. If an overflow occurred then the wrapped value is returned.
+    // mutagen false pos mul_u64: replace `|` with `^` (XOR is same as OR when combined with <<)
+    // mutagen false pos mul_u64: replace `|` with `^`
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn mul_u64(self, rhs: u64) -> (U256, bool) {
+        let mut carry: u128 = 0;
+        let mut split_le =
+            [self.1 as u64, (self.1 >> 64) as u64, self.0 as u64, (self.0 >> 64) as u64];
+
+        for word in &mut split_le {
+            // This will not overflow, for proof see https://github.com/rust-bitcoin/rust-bitcoin/pull/1496#issuecomment-1365938572
+            let n = carry + u128::from(rhs) * u128::from(*word);
+
+            *word = n as u64; // Intentional truncation, save the low bits
+            carry = n >> 64; // and carry the high bits.
+        }
+
+        let low = u128::from(split_le[0]) | u128::from(split_le[1]) << 64;
+        let high = u128::from(split_le[2]) | u128::from(split_le[3]) << 64;
+        (Self(high, low), carry != 0)
+    }
+
+    /// Calculates quotient and remainder.
+    ///
+    /// # Returns
+    ///
+    /// (quotient, remainder)
+    ///
+    /// # Panics
+    ///
+    /// If `rhs` is zero.
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn div_rem(self, rhs: Self) -> (Self, Self) {
+        let mut sub_copy = self;
+        let mut shift_copy = rhs;
+        let mut ret = [0u128; 2];
+
+        let my_bits = self.bits();
+        let your_bits = rhs.bits();
+
+        // Check for division by 0
+        assert!(your_bits != 0, "attempted to divide {} by zero", self);
+
+        // Early return in case we are dividing by a larger number than us
+        if my_bits < your_bits {
+            return (U256::ZERO, sub_copy);
+        }
+
+        // Bitwise long division
+        let mut shift = my_bits - your_bits;
+        shift_copy = shift_copy << shift;
+        loop {
+            if sub_copy >= shift_copy {
+                ret[1 - (shift / 128) as usize] |= 1 << (shift % 128);
+                sub_copy = sub_copy.wrapping_sub(shift_copy);
+            }
+            shift_copy = shift_copy >> 1;
+            if shift == 0 {
+                break;
+            }
+            shift -= 1;
+        }
+
+        (U256(ret[0], ret[1]), sub_copy)
+    }
+
+    /// Calculates `self` + `rhs`
+    ///
+    /// Returns a tuple of the addition along with a boolean indicating whether an arithmetic
+    /// overflow would occur. If an overflow would have occurred then the wrapped value is returned.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        let mut ret = U256::ZERO;
+        let mut ret_overflow = false;
+
+        let (high, overflow) = self.0.overflowing_add(rhs.0);
+        ret.0 = high;
+        ret_overflow |= overflow;
+
+        let (low, overflow) = self.1.overflowing_add(rhs.1);
+        ret.1 = low;
+        if overflow {
+            let (high, overflow) = ret.0.overflowing_add(1);
+            ret.0 = high;
+            ret_overflow |= overflow;
+        }
+
+        (ret, ret_overflow)
+    }
+
+    /// Calculates `self` - `rhs`
+    ///
+    /// Returns a tuple of the subtraction along with a boolean indicating whether an arithmetic
+    /// overflow would occur. If an overflow would have occurred then the wrapped value is returned.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        let ret = self.wrapping_add(!rhs).wrapping_add(Self::ONE);
+        let overflow = rhs > self;
+        (ret, overflow)
+    }
+
+    /// Calculates the multiplication of `self` and `rhs`.
+    ///
+    /// Returns a tuple of the multiplication along with a boolean
+    /// indicating whether an arithmetic overflow would occur. If an
+    /// overflow would have occurred then the wrapped value is returned.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
+        let mut ret = U256::ZERO;
+        let mut ret_overflow = false;
+
+        for i in 0..3 {
+            let to_mul = (rhs >> (64 * i)).low_u64();
+            let (mul_res, _) = self.mul_u64(to_mul);
+            ret = ret.wrapping_add(mul_res << (64 * i));
+        }
+
+        let to_mul = (rhs >> 192).low_u64();
+        let (mul_res, overflow) = self.mul_u64(to_mul);
+        ret_overflow |= overflow;
+        let (sum, overflow) = ret.overflowing_add(mul_res);
+        ret = sum;
+        ret_overflow |= overflow;
+
+        (ret, ret_overflow)
+    }
+
+    /// Wrapping (modular) addition. Computes `self + rhs`, wrapping around at the boundary of the
+    /// type.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    fn wrapping_add(self, rhs: Self) -> Self {
+        let (ret, _overflow) = self.overflowing_add(rhs);
+        ret
+    }
+
+    /// Wrapping (modular) subtraction. Computes `self - rhs`, wrapping around at the boundary of
+    /// the type.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    fn wrapping_sub(self, rhs: Self) -> Self {
+        let (ret, _overflow) = self.overflowing_sub(rhs);
+        ret
+    }
+
+    /// Wrapping (modular) multiplication. Computes `self * rhs`, wrapping around at the boundary of
+    /// the type.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[cfg(test)]
+    fn wrapping_mul(self, rhs: Self) -> Self {
+        let (ret, _overflow) = self.overflowing_mul(rhs);
+        ret
+    }
+
+    /// Returns `self` incremented by 1 wrapping around at the boundary of the type.
+    #[must_use = "this returns the result of the increment, without modifying the original"]
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn wrapping_inc(&self) -> U256 {
+        let mut ret = U256::ZERO;
+
+        ret.1 = self.1.wrapping_add(1);
+        if ret.1 == 0 {
+            ret.0 = self.0.wrapping_add(1);
+        } else {
+            ret.0 = self.0;
+        }
+        ret
+    }
+
+    /// Panic-free bitwise shift-left; yields `self << mask(rhs)`, where `mask` removes any
+    /// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of the type.
+    ///
+    /// Note that this is *not* the same as a rotate-left; the RHS of a wrapping shift-left is
+    /// restricted to the range of the type, rather than the bits shifted out of the LHS being
+    /// returned to the other end. We do not currently support `rotate_left`.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn wrapping_shl(self, rhs: u32) -> Self {
+        let shift = rhs & 0x000000ff;
+
+        let mut ret = U256::ZERO;
+        let word_shift = shift >= 128;
+        let bit_shift = shift % 128;
+
+        if word_shift {
+            ret.0 = self.1 << bit_shift
+        } else {
+            ret.0 = self.0 << bit_shift;
+            if bit_shift > 0 {
+                ret.0 += self.1.wrapping_shr(128 - bit_shift);
+            }
+            ret.1 = self.1 << bit_shift;
+        }
+        ret
+    }
+
+    /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`, where `mask` removes any
+    /// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of the type.
+    ///
+    /// Note that this is *not* the same as a rotate-right; the RHS of a wrapping shift-right is
+    /// restricted to the range of the type, rather than the bits shifted out of the LHS being
+    /// returned to the other end. We do not currently support `rotate_right`.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[cfg_attr(all(test, mutate), mutate)]
+    fn wrapping_shr(self, rhs: u32) -> Self {
+        let shift = rhs & 0x000000ff;
+
+        let mut ret = U256::ZERO;
+        let word_shift = shift >= 128;
+        let bit_shift = shift % 128;
+
+        if word_shift {
+            ret.1 = self.0 >> bit_shift
+        } else {
+            ret.0 = self.0 >> bit_shift;
+            ret.1 = self.1 >> bit_shift;
+            if bit_shift > 0 {
+                ret.1 += self.0.wrapping_shl(128 - bit_shift);
+            }
+        }
+        ret
+    }
+
+    /// Format `self` to `f` as a decimal when value is known to be non-zero.
+    fn fmt_decimal(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const DIGITS: usize = 78; // U256::MAX has 78 base 10 digits.
+        const TEN: U256 = U256(0, 10);
+
+        let mut buf = [0_u8; DIGITS];
+        let mut i = DIGITS - 1; // We loop backwards.
+        let mut cur = *self;
+
+        loop {
+            let digit = (cur % TEN).low_u128() as u8; // Cast after rem 10 is lossless.
+            buf[i] = digit + b'0';
+            cur = cur / TEN;
+            if cur.is_zero() {
+                break;
+            }
+            i -= 1;
+        }
+        let s = core::str::from_utf8(&buf[i..]).expect("digits 0-9 are valid UTF8");
+        f.pad_integral(true, "", s)
+    }
+
+    /// Convert self to f64.
+    #[inline]
+    fn to_f64(self) -> f64 {
+        // Reference: https://blog.m-ou.se/floats/
+        // Step 1: Get leading zeroes
+        let leading_zeroes = 256 - self.bits();
+        // Step 2: Get msb to be farthest left bit
+        let left_aligned = self.wrapping_shl(leading_zeroes);
+        // Step 3: Shift msb to fit in lower 53 bits (128-53=75) to get the mantissa
+        // * Shifting the border of the 2 u128s to line up with mantissa and dropped bits
+        let middle_aligned = left_aligned >> 75;
+        // * This is the 53 most significant bits as u128
+        let mantissa = middle_aligned.0;
+        // Step 4: Dropped bits (except for last 75 bits) are all in the second u128.
+        // Bitwise OR the rest of the bits into it, preserving the highest bit,
+        // so we take the lower 75 bits of middle_aligned.1 and mix it in. (See blog for explanation)
+        let dropped_bits = middle_aligned.1 | (left_aligned.1 & 0x7FF_FFFF_FFFF_FFFF_FFFF);
+        // Step 5: The msb of the dropped bits has been preserved, and all other bits
+        // if any were set, would be set somewhere in the other 127 bits.
+        // If msb of dropped bits is 0, it is mantissa + 0
+        // If msb of dropped bits is 1, it is mantissa + 0 only if mantissa lowest bit is 0
+        // and other bits of the dropped bits are all 0.
+        // (This is why we only care if the other non-msb dropped bits are all 0 or not,
+        // so we can just OR them to make sure any bits show up somewhere.)
+        let mantissa =
+            (mantissa + ((dropped_bits - (dropped_bits >> 127 & !mantissa)) >> 127)) as u64;
+        // Step 6: Calculate the exponent
+        // If self is 0, exponent should be 0 (special meaning) and mantissa will end up 0 too
+        // Otherwise, (255 - n) + 1022 so it simplifies to 1277 - n
+        // 1023 and 1022 are the cutoffs for the exponent having the msb next to the decimal point
+        let exponent = if self == Self::ZERO { 0 } else { 1277 - leading_zeroes as u64 };
+        // Step 7: sign bit is always 0, exponent is shifted into place
+        // Use addition instead of bitwise OR to saturate the exponent if mantissa overflows
+        f64::from_bits((exponent << 52) + mantissa)
+    }
+}
+
+// Target::MAX as a float value. Calculated with U256::to_f64.
+// This is validated in the unit tests as well.
+const TARGET_MAX_F64: f64 = 2.695953529101131e67;
+
+impl<T: Into<u128>> From<T> for U256 {
+    fn from(x: T) -> Self { U256(0, x.into()) }
+}
+
+impl Add for U256 {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        let (res, overflow) = self.overflowing_add(rhs);
+        debug_assert!(!overflow, "Addition of U256 values overflowed");
+        res
+    }
+}
+
+impl Sub for U256 {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        let (res, overflow) = self.overflowing_sub(rhs);
+        debug_assert!(!overflow, "Subtraction of U256 values overflowed");
+        res
+    }
+}
+
+impl Mul for U256 {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self {
+        let (res, overflow) = self.overflowing_mul(rhs);
+        debug_assert!(!overflow, "Multiplication of U256 values overflowed");
+        res
+    }
+}
+
+impl Div for U256 {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self { self.div_rem(rhs).0 }
+}
+
+impl Rem for U256 {
+    type Output = Self;
+    fn rem(self, rhs: Self) -> Self { self.div_rem(rhs).1 }
+}
+
+impl Not for U256 {
+    type Output = Self;
+
+    fn not(self) -> Self { U256(!self.0, !self.1) }
+}
+
+impl Shl<u32> for U256 {
+    type Output = Self;
+    fn shl(self, shift: u32) -> U256 { self.wrapping_shl(shift) }
+}
+
+impl Shr<u32> for U256 {
+    type Output = Self;
+    fn shr(self, shift: u32) -> U256 { self.wrapping_shr(shift) }
+}
+
+impl fmt::Display for U256 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_zero() {
+            f.pad_integral(true, "", "0")
+        } else {
+            self.fmt_decimal(f)
+        }
+    }
+}
+
+impl fmt::Debug for U256 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:#x}", self) }
+}
+
+macro_rules! impl_hex {
+    ($hex:ident, $case:expr) => {
+        impl $hex for U256 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+                hex::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
+            }
+        }
+    };
+}
+impl_hex!(LowerHex, hex::Case::Lower);
+impl_hex!(UpperHex, hex::Case::Upper);
+
+#[cfg(feature = "serde")]
+impl crate::serde::Serialize for U256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: crate::serde::Serializer,
+    {
+        struct DisplayHex(U256);
+
+        impl fmt::Display for DisplayHex {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:x}", self.0) }
+        }
+
+        if serializer.is_human_readable() {
+            serializer.collect_str(&DisplayHex(*self))
+        } else {
+            let bytes = self.to_be_bytes();
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> crate::serde::Deserialize<'de> for U256 {
+    fn deserialize<D: crate::serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use hex::FromHex;
+
+        use crate::serde::de;
+
+        if d.is_human_readable() {
+            struct HexVisitor;
+
+            impl<'de> de::Visitor<'de> for HexVisitor {
+                type Value = U256;
+
+                fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    f.write_str("a 32 byte ASCII hex string")
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    if s.len() != 64 {
+                        return Err(de::Error::invalid_length(s.len(), &self));
+                    }
+
+                    let b = <[u8; 32]>::from_hex(s)
+                        .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(s), &self))?;
+
+                    Ok(U256::from_be_bytes(b))
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    if let Ok(hex) = core::str::from_utf8(v) {
+                        let b = <[u8; 32]>::from_hex(hex).map_err(|_| {
+                            de::Error::invalid_value(de::Unexpected::Str(hex), &self)
+                        })?;
+
+                        Ok(U256::from_be_bytes(b))
+                    } else {
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
+                    }
+                }
+            }
+            d.deserialize_str(HexVisitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = U256;
+
+                fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    f.write_str("a sequence of bytes")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    let b = v.try_into().map_err(|_| de::Error::invalid_length(v.len(), &self))?;
+                    Ok(U256::from_be_bytes(b))
+                }
+            }
+
+            d.deserialize_bytes(BytesVisitor)
+        }
+    }
+}
+
+/// Splits a 32 byte array into two 16 byte arrays.
+fn split_in_half(a: [u8; 32]) -> ([u8; 16], [u8; 16]) {
+    let mut high = [0_u8; 16];
+    let mut low = [0_u8; 16];
+
+    high.copy_from_slice(&a[..16]);
+    low.copy_from_slice(&a[16..]);
+
+    (high, low)
+}
+
+#[cfg(kani)]
+impl kani::Arbitrary for U256 {
+    fn any() -> Self {
+        let high: u128 = kani::any();
+        let low: u128 = kani::any();
+        Self(high, low)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl<T: Into<u128>> From<T> for Target {
+        fn from(x: T) -> Self { Self(U256::from(x)) }
+    }
+
+    impl<T: Into<u128>> From<T> for Work {
+        fn from(x: T) -> Self { Self(U256::from(x)) }
+    }
+
+    impl U256 {
+        fn bit_at(&self, index: usize) -> bool {
+            if index > 255 {
+                panic!("index out of bounds");
+            }
+
+            let word = if index < 128 { self.1 } else { self.0 };
+            (word & (1 << (index % 128))) != 0
+        }
+    }
+
+    impl U256 {
+        /// Creates a U256 from a big-endian array of u64's
+        fn from_array(a: [u64; 4]) -> Self {
+            let mut ret = U256::ZERO;
+            ret.0 = (a[0] as u128) << 64 ^ (a[1] as u128);
+            ret.1 = (a[2] as u128) << 64 ^ (a[3] as u128);
+            ret
+        }
+    }
+
+    #[test]
+    fn u256_num_bits() {
+        assert_eq!(U256::from(255_u64).bits(), 8);
+        assert_eq!(U256::from(256_u64).bits(), 9);
+        assert_eq!(U256::from(300_u64).bits(), 9);
+        assert_eq!(U256::from(60000_u64).bits(), 16);
+        assert_eq!(U256::from(70000_u64).bits(), 17);
+
+        let u = U256::from(u128::MAX) << 1;
+        assert_eq!(u.bits(), 129);
+
+        // Try to read the following lines out loud quickly
+        let mut shl = U256::from(70000_u64);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 117);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 217);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 0);
+    }
+
+    #[test]
+    fn u256_bit_at() {
+        assert!(!U256::from(10_u64).bit_at(0));
+        assert!(U256::from(10_u64).bit_at(1));
+        assert!(!U256::from(10_u64).bit_at(2));
+        assert!(U256::from(10_u64).bit_at(3));
+        assert!(!U256::from(10_u64).bit_at(4));
+
+        let u = U256(0xa000_0000_0000_0000_0000_0000_0000_0000, 0);
+        assert!(u.bit_at(255));
+        assert!(!u.bit_at(254));
+        assert!(u.bit_at(253));
+        assert!(!u.bit_at(252));
+    }
+
+    #[test]
+    fn u256_lower_hex() {
+        assert_eq!(
+            format!("{:x}", U256::from(0xDEADBEEF_u64)),
+            "00000000000000000000000000000000000000000000000000000000deadbeef",
+        );
+        assert_eq!(
+            format!("{:#x}", U256::from(0xDEADBEEF_u64)),
+            "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+        );
+        assert_eq!(
+            format!("{:x}", U256::MAX),
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        );
+        assert_eq!(
+            format!("{:#x}", U256::MAX),
+            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        );
+    }
+
+    #[test]
+    fn u256_upper_hex() {
+        assert_eq!(
+            format!("{:X}", U256::from(0xDEADBEEF_u64)),
+            "00000000000000000000000000000000000000000000000000000000DEADBEEF",
+        );
+        assert_eq!(
+            format!("{:#X}", U256::from(0xDEADBEEF_u64)),
+            "0x00000000000000000000000000000000000000000000000000000000DEADBEEF",
+        );
+        assert_eq!(
+            format!("{:X}", U256::MAX),
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        );
+        assert_eq!(
+            format!("{:#X}", U256::MAX),
+            "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        );
+    }
+
+    #[test]
+    fn u256_display() {
+        assert_eq!(format!("{}", U256::from(100_u32)), "100",);
+        assert_eq!(format!("{}", U256::ZERO), "0",);
+        assert_eq!(format!("{}", U256::from(u64::MAX)), format!("{}", u64::MAX),);
+        assert_eq!(
+            format!("{}", U256::MAX),
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        );
+    }
+
+    macro_rules! check_format {
+        ($($test_name:ident, $val:literal, $format_string:literal, $expected:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    assert_eq!(format!($format_string, U256::from($val)), $expected);
+                }
+            )*
+        }
+    }
+    check_format! {
+        check_fmt_0, 0_u32, "{}", "0";
+        check_fmt_1, 0_u32, "{:2}", " 0";
+        check_fmt_2, 0_u32, "{:02}", "00";
+
+        check_fmt_3, 1_u32, "{}", "1";
+        check_fmt_4, 1_u32, "{:2}", " 1";
+        check_fmt_5, 1_u32, "{:02}", "01";
+
+        check_fmt_10, 10_u32, "{}", "10";
+        check_fmt_11, 10_u32, "{:2}", "10";
+        check_fmt_12, 10_u32, "{:02}", "10";
+        check_fmt_13, 10_u32, "{:3}", " 10";
+        check_fmt_14, 10_u32, "{:03}", "010";
+
+        check_fmt_20, 1_u32, "{:<2}", "1 ";
+        check_fmt_21, 1_u32, "{:<02}", "01";
+        check_fmt_22, 1_u32, "{:>2}", " 1"; // This is default but check it anyways.
+        check_fmt_23, 1_u32, "{:>02}", "01";
+        check_fmt_24, 1_u32, "{:^3}", " 1 ";
+        check_fmt_25, 1_u32, "{:^03}", "001";
+        // Sanity check, for integral types precision is ignored.
+        check_fmt_30, 0_u32, "{:.1}", "0";
+        check_fmt_31, 0_u32, "{:4.1}", "   0";
+        check_fmt_32, 0_u32, "{:04.1}", "0000";
+    }
+
+    #[test]
+    fn u256_comp() {
+        let small = U256::from_array([0, 0, 0, 10]);
+        let big = U256::from_array([0, 0, 0x0209_E737_8231_E632, 0x8C8C_3EE7_0C64_4118]);
+        let bigger = U256::from_array([0, 0, 0x0209_E737_8231_E632, 0x9C8C_3EE7_0C64_4118]);
+        let biggest = U256::from_array([1, 0, 0x0209_E737_8231_E632, 0x5C8C_3EE7_0C64_4118]);
+
+        assert!(small < big);
+        assert!(big < bigger);
+        assert!(bigger < biggest);
+        assert!(bigger <= biggest);
+        assert!(biggest <= biggest);
+        assert!(bigger >= big);
+        assert!(bigger >= small);
+        assert!(small <= small);
+    }
+
+    const WANT: U256 =
+        U256(0x1bad_cafe_dead_beef_deaf_babe_2bed_feed, 0xbaad_f00d_defa_ceda_11fe_d2ba_d1c0_ffe0);
+
+    #[rustfmt::skip]
+    const BE_BYTES: [u8; 32] = [
+        0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xaf, 0xba, 0xbe, 0x2b, 0xed, 0xfe, 0xed,
+        0xba, 0xad, 0xf0, 0x0d, 0xde, 0xfa, 0xce, 0xda, 0x11, 0xfe, 0xd2, 0xba, 0xd1, 0xc0, 0xff, 0xe0,
+    ];
+
+    #[rustfmt::skip]
+    const LE_BYTES: [u8; 32] = [
+        0xe0, 0xff, 0xc0, 0xd1, 0xba, 0xd2, 0xfe, 0x11, 0xda, 0xce, 0xfa, 0xde, 0x0d, 0xf0, 0xad, 0xba,
+        0xed, 0xfe, 0xed, 0x2b, 0xbe, 0xba, 0xaf, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b,
+    ];
+
+    // Sanity check that we have the bytes in the correct big-endian order.
+    #[test]
+    fn sanity_be_bytes() {
+        let mut out = [0_u8; 32];
+        out[..16].copy_from_slice(&WANT.0.to_be_bytes());
+        out[16..].copy_from_slice(&WANT.1.to_be_bytes());
+        assert_eq!(out, BE_BYTES);
+    }
+
+    // Sanity check that we have the bytes in the correct little-endian order.
+    #[test]
+    fn sanity_le_bytes() {
+        let mut out = [0_u8; 32];
+        out[..16].copy_from_slice(&WANT.1.to_le_bytes());
+        out[16..].copy_from_slice(&WANT.0.to_le_bytes());
+        assert_eq!(out, LE_BYTES);
+    }
+
+    #[test]
+    fn u256_to_be_bytes() {
+        assert_eq!(WANT.to_be_bytes(), BE_BYTES);
+    }
+
+    #[test]
+    fn u256_from_be_bytes() {
+        assert_eq!(U256::from_be_bytes(BE_BYTES), WANT);
+    }
+
+    #[test]
+    fn u256_to_le_bytes() {
+        assert_eq!(WANT.to_le_bytes(), LE_BYTES);
+    }
+
+    #[test]
+    fn u256_from_le_bytes() {
+        assert_eq!(U256::from_le_bytes(LE_BYTES), WANT);
+    }
+
+    #[test]
+    fn u256_from_u8() {
+        let u = U256::from(0xbe_u8);
+        assert_eq!(u, U256(0, 0xbe));
+    }
+
+    #[test]
+    fn u256_from_u16() {
+        let u = U256::from(0xbeef_u16);
+        assert_eq!(u, U256(0, 0xbeef));
+    }
+
+    #[test]
+    fn u256_from_u32() {
+        let u = U256::from(0xdeadbeef_u32);
+        assert_eq!(u, U256(0, 0xdeadbeef));
+    }
+
+    #[test]
+    fn u256_from_u64() {
+        let u = U256::from(0xdead_beef_cafe_babe_u64);
+        assert_eq!(u, U256(0, 0xdead_beef_cafe_babe));
+    }
+
+    #[test]
+    fn u256_from_u128() {
+        let u = U256::from(0xdead_beef_cafe_babe_0123_4567_89ab_cdefu128);
+        assert_eq!(u, U256(0, 0xdead_beef_cafe_babe_0123_4567_89ab_cdef));
+    }
+
+    macro_rules! test_from_unsigned_integer_type {
+        ($($test_name:ident, $ty:ident);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    // Internal representation is big-endian.
+                    let want = U256(0, 0xAB);
+
+                    let x = 0xAB as $ty;
+                    let got = U256::from(x);
+
+                    assert_eq!(got, want);
+                }
+            )*
+        }
+    }
+    test_from_unsigned_integer_type! {
+        from_unsigned_integer_type_u8, u8;
+        from_unsigned_integer_type_u16, u16;
+        from_unsigned_integer_type_u32, u32;
+        from_unsigned_integer_type_u64, u64;
+        from_unsigned_integer_type_u128, u128;
+    }
+
+    #[test]
+    fn u256_from_be_array_u64() {
+        let array = [
+            0x1bad_cafe_dead_beef,
+            0xdeaf_babe_2bed_feed,
+            0xbaad_f00d_defa_ceda,
+            0x11fe_d2ba_d1c0_ffe0,
+        ];
+
+        let uint = U256::from_array(array);
+        assert_eq!(uint, WANT);
+    }
+
+    #[test]
+    fn u256_shift_left() {
+        let u = U256::from(1_u32);
+        assert_eq!(u << 0, u);
+        assert_eq!(u << 1, U256::from(2_u64));
+        assert_eq!(u << 63, U256::from(0x8000_0000_0000_0000_u64));
+        assert_eq!(u << 64, U256::from_array([0, 0, 0x0000_0000_0000_0001, 0]));
+        assert_eq!(u << 127, U256(0, 0x8000_0000_0000_0000_0000_0000_0000_0000));
+        assert_eq!(u << 128, U256(1, 0));
+
+        let x = U256(0, 0x8000_0000_0000_0000_0000_0000_0000_0000);
+        assert_eq!(x << 1, U256(1, 0));
+    }
+
+    #[test]
+    fn u256_shift_right() {
+        let u = U256(1, 0);
+        assert_eq!(u >> 0, u);
+        assert_eq!(u >> 1, U256(0, 0x8000_0000_0000_0000_0000_0000_0000_0000));
+        assert_eq!(u >> 127, U256(0, 2));
+        assert_eq!(u >> 128, U256(0, 1));
+    }
+
+    #[test]
+    fn u256_arithmetic() {
+        let init = U256::from(0xDEAD_BEEF_DEAD_BEEF_u64);
+        let copy = init;
+
+        let add = init.wrapping_add(copy);
+        assert_eq!(add, U256::from_array([0, 0, 1, 0xBD5B_7DDF_BD5B_7DDE]));
+        // Bitshifts
+        let shl = add << 88;
+        assert_eq!(shl, U256::from_array([0, 0x01BD_5B7D, 0xDFBD_5B7D_DE00_0000, 0]));
+        let shr = shl >> 40;
+        assert_eq!(shr, U256::from_array([0, 0, 0x0001_BD5B_7DDF_BD5B, 0x7DDE_0000_0000_0000]));
+        // Increment
+        let mut incr = shr;
+        incr = incr.wrapping_inc();
+        assert_eq!(incr, U256::from_array([0, 0, 0x0001_BD5B_7DDF_BD5B, 0x7DDE_0000_0000_0001]));
+        // Subtraction
+        let sub = incr.wrapping_sub(init);
+        assert_eq!(sub, U256::from_array([0, 0, 0x0001_BD5B_7DDF_BD5A, 0x9F30_4110_2152_4112]));
+        // Multiplication
+        let (mult, _) = sub.mul_u64(300);
+        assert_eq!(mult, U256::from_array([0, 0, 0x0209_E737_8231_E632, 0x8C8C_3EE7_0C64_4118]));
+        // Division
+        assert_eq!(U256::from(105_u32) / U256::from(5_u32), U256::from(21_u32));
+        let div = mult / U256::from(300_u32);
+        assert_eq!(div, U256::from_array([0, 0, 0x0001_BD5B_7DDF_BD5A, 0x9F30_4110_2152_4112]));
+
+        assert_eq!(U256::from(105_u32) % U256::from(5_u32), U256::ZERO);
+        assert_eq!(U256::from(35498456_u32) % U256::from(3435_u32), U256::from(1166_u32));
+        let rem_src = mult.wrapping_mul(U256::from(39842_u32)).wrapping_add(U256::from(9054_u32));
+        assert_eq!(rem_src % U256::from(39842_u32), U256::from(9054_u32));
+    }
+
+    #[test]
+    fn u256_bit_inversion() {
+        let v = U256(1, 0);
+        let want = U256(
+            0xffff_ffff_ffff_ffff_ffff_ffff_ffff_fffe,
+            0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
+        );
+        assert_eq!(!v, want);
+
+        let v = U256(0x0c0c_0c0c_0c0c_0c0c_0c0c_0c0c_0c0c_0c0c, 0xeeee_eeee_eeee_eeee);
+        let want = U256(
+            0xf3f3_f3f3_f3f3_f3f3_f3f3_f3f3_f3f3_f3f3,
+            0xffff_ffff_ffff_ffff_1111_1111_1111_1111,
+        );
+        assert_eq!(!v, want);
+    }
+
+    #[test]
+    fn u256_mul_u64_by_one() {
+        let v = U256::from(0xDEAD_BEEF_DEAD_BEEF_u64);
+        assert_eq!(v, v.mul_u64(1_u64).0);
+    }
+
+    #[test]
+    fn u256_mul_u64_by_zero() {
+        let v = U256::from(0xDEAD_BEEF_DEAD_BEEF_u64);
+        assert_eq!(U256::ZERO, v.mul_u64(0_u64).0);
+    }
+
+    #[test]
+    fn u256_mul_u64() {
+        let u64_val = U256::from(0xDEAD_BEEF_DEAD_BEEF_u64);
+
+        let u96_res = u64_val.mul_u64(0xFFFF_FFFF).0;
+        let u128_res = u96_res.mul_u64(0xFFFF_FFFF).0;
+        let u160_res = u128_res.mul_u64(0xFFFF_FFFF).0;
+        let u192_res = u160_res.mul_u64(0xFFFF_FFFF).0;
+        let u224_res = u192_res.mul_u64(0xFFFF_FFFF).0;
+        let u256_res = u224_res.mul_u64(0xFFFF_FFFF).0;
+
+        assert_eq!(u96_res, U256::from_array([0, 0, 0xDEAD_BEEE, 0xFFFF_FFFF_2152_4111]));
+        assert_eq!(
+            u128_res,
+            U256::from_array([0, 0, 0xDEAD_BEEE_2152_4110, 0x2152_4111_DEAD_BEEF])
+        );
+        assert_eq!(
+            u160_res,
+            U256::from_array([0, 0xDEAD_BEED, 0x42A4_8222_0000_0001, 0xBD5B_7DDD_2152_4111])
+        );
+        assert_eq!(
+            u192_res,
+            U256::from_array([
+                0,
+                0xDEAD_BEEC_63F6_C334,
+                0xBD5B_7DDF_BD5B_7DDB,
+                0x63F6_C333_DEAD_BEEF
+            ])
+        );
+        assert_eq!(
+            u224_res,
+            U256::from_array([
+                0xDEAD_BEEB,
+                0x8549_0448_5964_BAAA,
+                0xFFFF_FFFB_A69B_4558,
+                0x7AB6_FBBB_2152_4111
+            ])
+        );
+        assert_eq!(
+            u256_res,
+            U256(
+                0xDEAD_BEEA_A69B_455C_D41B_B662_A69B_4550,
+                0xA69B_455C_D41B_B662_A69B_4555_DEAD_BEEF,
+            )
+        );
+    }
+
+    #[test]
+    fn u256_addition() {
+        let x = U256::from(u128::MAX);
+        let (add, overflow) = x.overflowing_add(U256::ONE);
+        assert!(!overflow);
+        assert_eq!(add, U256(1, 0));
+
+        let (add, _) = add.overflowing_add(U256::ONE);
+        assert_eq!(add, U256(1, 1));
+    }
+
+    #[test]
+    fn u256_subtraction() {
+        let (sub, overflow) = U256::ONE.overflowing_sub(U256::ONE);
+        assert!(!overflow);
+        assert_eq!(sub, U256::ZERO);
+
+        let x = U256(1, 0);
+        let (sub, overflow) = x.overflowing_sub(U256::ONE);
+        assert!(!overflow);
+        assert_eq!(sub, U256::from(u128::MAX));
+    }
+
+    #[test]
+    fn u256_multiplication() {
+        let u64_val = U256::from(0xDEAD_BEEF_DEAD_BEEF_u64);
+
+        let u128_res = u64_val.wrapping_mul(u64_val);
+
+        assert_eq!(u128_res, U256(0, 0xC1B1_CD13_A4D1_3D46_048D_1354_216D_A321));
+
+        let u256_res = u128_res.wrapping_mul(u128_res);
+
+        assert_eq!(
+            u256_res,
+            U256(
+                0x928D_92B4_D7F5_DF33_4AFC_FF6F_0375_C608,
+                0xF5CF_7F36_18C2_C886_F4E1_66AA_D40D_0A41,
+            )
+        );
+    }
+
+    #[test]
+    fn u256_multiplication_bits_in_each_word() {
+        // Put a digit in the least significant bit of each 64 bit word.
+        let u = 1_u128 << 64 | 1_u128;
+        let x = U256(u, u);
+
+        // Put a digit in the second least significant bit of each 64 bit word.
+        let u = 2_u128 << 64 | 2_u128;
+        let y = U256(u, u);
+
+        let (got, overflow) = x.overflowing_mul(y);
+
+        let want = U256(
+            0x0000_0000_0000_0008_0000_0000_0000_0008,
+            0x0000_0000_0000_0006_0000_0000_0000_0004,
+        );
+        assert!(!overflow);
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn u256_increment() {
+        let mut val = U256(
+            0xEFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
+            0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFE,
+        );
+        val = val.wrapping_inc();
+        assert_eq!(
+            val,
+            U256(
+                0xEFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
+                0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
+            )
+        );
+        val = val.wrapping_inc();
+        assert_eq!(
+            val,
+            U256(
+                0xF000_0000_0000_0000_0000_0000_0000_0000,
+                0x0000_0000_0000_0000_0000_0000_0000_0000,
+            )
+        );
+
+        assert_eq!(U256::MAX.wrapping_inc(), U256::ZERO);
+    }
+
+    #[test]
+    fn u256_extreme_bitshift() {
+        // Shifting a u64 by 64 bits gives an undefined value, so make sure that
+        // we're doing the Right Thing here
+        let init = U256::from(0xDEAD_BEEF_DEAD_BEEF_u64);
+
+        assert_eq!(init << 64, U256(0, 0xDEAD_BEEF_DEAD_BEEF_0000_0000_0000_0000));
+        let add = (init << 64).wrapping_add(init);
+        assert_eq!(add, U256(0, 0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF));
+        assert_eq!(add >> 0, U256(0, 0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF));
+        assert_eq!(add << 0, U256(0, 0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF));
+        assert_eq!(add >> 64, U256(0, 0x0000_0000_0000_0000_DEAD_BEEF_DEAD_BEEF));
+        assert_eq!(
+            add << 64,
+            U256(0xDEAD_BEEF_DEAD_BEEF, 0xDEAD_BEEF_DEAD_BEEF_0000_0000_0000_0000)
+        );
+    }
+
+    #[test]
+    fn u256_to_from_hex_roundtrips() {
+        let val = U256(
+            0xDEAD_BEEA_A69B_455C_D41B_B662_A69B_4550,
+            0xA69B_455C_D41B_B662_A69B_4555_DEAD_BEEF,
+        );
+        let hex = format!("0x{:x}", val);
+        let got = U256::from_hex(&hex).expect("failed to parse hex");
+        assert_eq!(got, val);
+    }
+
+    #[test]
+    fn u256_to_from_unprefixed_hex_roundtrips() {
+        let val = U256(
+            0xDEAD_BEEA_A69B_455C_D41B_B662_A69B_4550,
+            0xA69B_455C_D41B_B662_A69B_4555_DEAD_BEEF,
+        );
+        let hex = format!("{:x}", val);
+        let got = U256::from_unprefixed_hex(&hex).expect("failed to parse hex");
+        assert_eq!(got, val);
+    }
+
+    #[test]
+    fn u256_from_hex_32_characters_long() {
+        let hex = "a69b455cd41bb662a69b4555deadbeef";
+        let want = U256(0x00, 0xA69B_455C_D41B_B662_A69B_4555_DEAD_BEEF);
+        let got = U256::from_unprefixed_hex(hex).expect("failed to parse hex");
+        assert_eq!(got, want);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn u256_serde() {
+        let check = |uint, hex| {
+            let json = format!("\"{}\"", hex);
+            assert_eq!(::serde_json::to_string(&uint).unwrap(), json);
+            assert_eq!(::serde_json::from_str::<U256>(&json).unwrap(), uint);
+
+            let bin_encoded = bincode::serialize(&uint).unwrap();
+            let bin_decoded: U256 = bincode::deserialize(&bin_encoded).unwrap();
+            assert_eq!(bin_decoded, uint);
+        };
+
+        check(U256::ZERO, "0000000000000000000000000000000000000000000000000000000000000000");
+        check(
+            U256::from(0xDEADBEEF_u32),
+            "00000000000000000000000000000000000000000000000000000000deadbeef",
+        );
+        check(
+            U256::from_array([0xdd44, 0xcc33, 0xbb22, 0xaa11]),
+            "000000000000dd44000000000000cc33000000000000bb22000000000000aa11",
+        );
+        check(U256::MAX, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        check(
+            U256(
+                0xDEAD_BEEA_A69B_455C_D41B_B662_A69B_4550,
+                0xA69B_455C_D41B_B662_A69B_4555_DEAD_BEEF,
+            ),
+            "deadbeeaa69b455cd41bb662a69b4550a69b455cd41bb662a69b4555deadbeef",
+        );
+
+        assert!(::serde_json::from_str::<U256>(
+            "\"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffg\""
+        )
+        .is_err()); // invalid char
+        assert!(::serde_json::from_str::<U256>(
+            "\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+        )
+        .is_err()); // invalid length
+        assert!(::serde_json::from_str::<U256>(
+            "\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+        )
+        .is_err()); // invalid length
+    }
+
+    #[test]
+    fn u256_is_max_correct_negative() {
+        let tc = vec![U256::ZERO, U256::ONE, U256::from(u128::MAX)];
+        for t in tc {
+            assert!(!t.is_max())
+        }
+    }
+
+    #[test]
+    fn u256_is_max_correct_positive() {
+        assert!(U256::MAX.is_max());
+
+        let u = u128::MAX;
+        assert!(((U256::from(u) << 128) + U256::from(u)).is_max());
+    }
+
+    #[test]
+    fn compact_target_from_hex_lower() {
+        let target = CompactTarget::from_hex("0x010034ab").unwrap();
+        assert_eq!(target, CompactTarget(0x010034ab));
+    }
+
+    #[test]
+    fn compact_target_from_hex_upper() {
+        let target = CompactTarget::from_hex("0X010034AB").unwrap();
+        assert_eq!(target, CompactTarget(0x010034ab));
+    }
+
+    #[test]
+    fn compact_target_from_unprefixed_hex_lower() {
+        let target = CompactTarget::from_unprefixed_hex("010034ab").unwrap();
+        assert_eq!(target, CompactTarget(0x010034ab));
+    }
+
+    #[test]
+    fn compact_target_from_unprefixed_hex_upper() {
+        let target = CompactTarget::from_unprefixed_hex("010034AB").unwrap();
+        assert_eq!(target, CompactTarget(0x010034ab));
+    }
+
+    #[test]
+    fn compact_target_from_hex_invalid_hex_should_err() {
+        let hex = "0xzbf9";
+        let result = CompactTarget::from_hex(hex);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn compact_target_lower_hex_and_upper_hex() {
+        assert_eq!(format!("{:08x}", CompactTarget(0x01D0F456)), "01d0f456");
+        assert_eq!(format!("{:08X}", CompactTarget(0x01d0f456)), "01D0F456");
+    }
+
+    #[test]
+    fn compact_target_from_upwards_difficulty_adjustment() {
+        let params = Params::new(crate::Network::Signet);
+        let starting_bits = CompactTarget::from_consensus(503543726); // Genesis compact target on Signet
+        let start_time: u64 = 1598918400; // Genesis block unix time
+        let end_time: u64 = 1599332177; // Block 2015 unix time
+        let timespan = end_time - start_time; // Faster than expected
+        let adjustment = CompactTarget::from_next_work_required(starting_bits, timespan, &params);
+        let adjustment_bits = CompactTarget::from_consensus(503394215); // Block 2016 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_downwards_difficulty_adjustment() {
+        let params = Params::new(crate::Network::Signet);
+        let starting_bits = CompactTarget::from_consensus(503394215); // Block 2016 compact target
+        let start_time: u64 = 1599332844; // Block 2016 unix time
+        let end_time: u64 = 1600591200; // Block 4031 unix time
+        let timespan = end_time - start_time; // Slower than expected
+        let adjustment = CompactTarget::from_next_work_required(starting_bits, timespan, &params);
+        let adjustment_bits = CompactTarget::from_consensus(503397348); // Block 4032 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_upwards_difficulty_adjustment_using_headers() {
+        use crate::{block::Version, constants::genesis_block, TxMerkleNode};
+        use hashes::Hash;
+        let params = Params::new(crate::Network::Signet);
+        let epoch_start = genesis_block(&params).header;
+        // Block 2015, the only information used are `bits` and `time`
+        let current = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1599332177,
+            bits: epoch_start.bits,
+            nonce: epoch_start.nonce
+        };
+        let adjustment = CompactTarget::from_header_difficulty_adjustment(epoch_start, current, params);
+        let adjustment_bits = CompactTarget::from_consensus(503394215); // Block 2016 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_downwards_difficulty_adjustment_using_headers() {
+        use crate::{block::Version, TxMerkleNode};
+        use hashes::Hash;
+        let params = Params::new(crate::Network::Signet);
+        let starting_bits = CompactTarget::from_consensus(503394215); // Block 2016 compact target
+        // Block 2016, the only information used is `time`
+        let epoch_start = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1599332844,
+            bits: starting_bits,
+            nonce: 0
+        };
+        // Block 4031, the only information used are `bits` and `time`
+        let current = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1600591200,
+            bits: starting_bits,
+            nonce: 0
+        };
+        let adjustment = CompactTarget::from_header_difficulty_adjustment(epoch_start, current, params);
+        let adjustment_bits = CompactTarget::from_consensus(503397348); // Block 4032 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_maximum_upward_difficulty_adjustment() {
+        let params = Params::new(crate::Network::Signet);
+        let starting_bits = CompactTarget::from_consensus(503403001);
+        let timespan = (0.2 * params.pow_target_timespan as f64) as u64;
+        let got = CompactTarget::from_next_work_required(starting_bits, timespan, params);
+        let want = Target::from_compact(starting_bits)
+            .min_transition_threshold()
+            .to_compact_lossy();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn compact_target_from_minimum_downward_difficulty_adjustment() {
+        let params = Params::new(crate::Network::Signet);
+        let starting_bits = CompactTarget::from_consensus(403403001); // High difficulty for Signet
+        let timespan =  5 * params.pow_target_timespan; // Really slow.
+        let got = CompactTarget::from_next_work_required(starting_bits, timespan, &params);
+        let want = Target::from_compact(starting_bits)
+            .max_transition_threshold(params)
+            .to_compact_lossy();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn compact_target_from_adjustment_is_max_target() {
+        let params = Params::new(crate::Network::Signet);
+        let starting_bits = CompactTarget::from_consensus(503543726); // Genesis compact target on Signet
+        let timespan =  5 * params.pow_target_timespan; // Really slow.
+        let got = CompactTarget::from_next_work_required(starting_bits, timespan, &params);
+        let want = params.max_attainable_target.to_compact_lossy();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn target_from_compact() {
+        // (nBits, target)
+        let tests = vec![
+            (0x0100_3456_u32, 0x00_u64), // High bit set.
+            (0x0112_3456_u32, 0x12_u64),
+            (0x0200_8000_u32, 0x80_u64),
+            (0x0500_9234_u32, 0x9234_0000_u64),
+            (0x0492_3456_u32, 0x00_u64), // High bit set (0x80 in 0x92).
+            (0x0412_3456_u32, 0x1234_5600_u64), // Inverse of above; no high bit.
+        ];
+
+        for (n_bits, target) in tests {
+            let want = Target::from(target);
+            let got = Target::from_compact(CompactTarget::from_consensus(n_bits));
+            assert_eq!(got, want);
+        }
+    }
+
+    #[test]
+    fn target_is_met_by_for_target_equals_hash() {
+        use std::str::FromStr;
+
+        use hashes::Hash;
+
+        let hash =
+            BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")
+                .expect("failed to parse block hash");
+        let target = Target(U256::from_le_bytes(hash.to_byte_array()));
+        assert!(target.is_met_by(hash));
+    }
+
+    #[test]
+    fn max_target_from_compact() {
+        // The highest possible target is defined as 0x1d00ffff
+        let bits = 0x1d00ffff_u32;
+        let want = Target::MAX;
+        let got = Target::from_compact(CompactTarget::from_consensus(bits));
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn target_difficulty_float() {
+        assert_eq!(Target::MAX.difficulty_float(), 1.0_f64);
+        assert_eq!(
+            Target::from_compact(CompactTarget::from_consensus(0x1c00ffff_u32)).difficulty_float(),
+            256.0_f64
+        );
+        assert_eq!(
+            Target::from_compact(CompactTarget::from_consensus(0x1b00ffff_u32)).difficulty_float(),
+            65536.0_f64
+        );
+        assert_eq!(
+            Target::from_compact(CompactTarget::from_consensus(0x1a00f3a2_u32)).difficulty_float(),
+            17628585.065897066_f64
+        );
+    }
+
+    #[test]
+    fn roundtrip_compact_target() {
+        let consensus = 0x1d00_ffff;
+        let compact = CompactTarget::from_consensus(consensus);
+        let t = Target::from_compact(CompactTarget::from_consensus(consensus));
+        assert_eq!(t, Target::from(compact)); // From/Into sanity check.
+
+        let back = t.to_compact_lossy();
+        assert_eq!(back, compact); // From/Into sanity check.
+
+        assert_eq!(back.to_consensus(), consensus);
+    }
+
+    #[test]
+    fn roundtrip_target_work() {
+        let target = Target::from(0xdeadbeef_u32);
+        let work = target.to_work();
+        let back = work.to_target();
+        assert_eq!(back, target)
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn work_log2() {
+        // Compare work log2 to historical Bitcoin Core values found in Core logs.
+        let tests: Vec<(u128, f64)> = vec![
+            // (chainwork, core log2)                // height
+            (0x200020002, 33.000022),                // 1
+            (0xa97d67041c5e51596ee7, 79.405055),     // 308004
+            (0x1dc45d79394baa8ab18b20, 84.895644),   // 418141
+            (0x8c85acb73287e335d525b98, 91.134654),  // 596624
+            (0x2ef447e01d1642c40a184ada, 93.553183), // 738965
+        ];
+
+        for (chainwork, core_log2) in tests {
+            // Core log2 in the logs is rounded to 6 decimal places.
+            let log2 = (Work::from(chainwork).log2() * 1e6).round() / 1e6;
+            assert_eq!(log2, core_log2)
+        }
+
+        assert_eq!(Work(U256::ONE).log2(), 0.0);
+        assert_eq!(Work(U256::MAX).log2(), 256.0);
+    }
+
+    #[test]
+    fn u256_zero_min_max_inverse() {
+        assert_eq!(U256::MAX.inverse(), U256::ONE);
+        assert_eq!(U256::ONE.inverse(), U256::MAX);
+        assert_eq!(U256::ZERO.inverse(), U256::MAX);
+    }
+
+    #[test]
+    fn u256_max_min_inverse_roundtrip() {
+        let max = U256::MAX;
+
+        for min in [U256::ZERO, U256::ONE].iter() {
+            // lower target means more work required.
+            assert_eq!(Target(max).to_work(), Work(U256::ONE));
+            assert_eq!(Target(*min).to_work(), Work(max));
+
+            assert_eq!(Work(max).to_target(), Target(U256::ONE));
+            assert_eq!(Work(*min).to_target(), Target(max));
+        }
+    }
+
+    #[test]
+    fn u256_wrapping_add_wraps_at_boundary() {
+        assert_eq!(U256::MAX.wrapping_add(U256::ONE), U256::ZERO);
+        assert_eq!(U256::MAX.wrapping_add(U256::from(2_u8)), U256::ONE);
+    }
+
+    #[test]
+    fn u256_wrapping_sub_wraps_at_boundary() {
+        assert_eq!(U256::ZERO.wrapping_sub(U256::ONE), U256::MAX);
+        assert_eq!(U256::ONE.wrapping_sub(U256::from(2_u8)), U256::MAX);
+    }
+
+    #[test]
+    fn mul_u64_overflows() {
+        let (_, overflow) = U256::MAX.mul_u64(2);
+        assert!(overflow, "max * 2 should overflow");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn u256_overflowing_addition_panics() { let _ = U256::MAX + U256::ONE; }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn u256_overflowing_subtraction_panics() { let _ = U256::ZERO - U256::ONE; }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn u256_multiplication_by_max_panics() { let _ = U256::MAX * U256::MAX; }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn work_overflowing_addition_panics() { let _ = Work(U256::MAX) + Work(U256::ONE); }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn work_overflowing_subtraction_panics() { let _ = Work(U256::ZERO) - Work(U256::ONE); }
+
+    #[test]
+    fn u256_to_f64() {
+        // Validate that the Target::MAX value matches the constant also used in difficulty calculation.
+        assert_eq!(Target::MAX.0.to_f64(), TARGET_MAX_F64);
+        assert_eq!(U256::ZERO.to_f64(), 0.0_f64);
+        assert_eq!(U256::ONE.to_f64(), 1.0_f64);
+        assert_eq!(U256::MAX.to_f64(), 1.157920892373162e77_f64);
+        assert_eq!((U256::MAX >> 1).to_f64(), 5.78960446186581e76_f64);
+        assert_eq!((U256::MAX >> 128).to_f64(), 3.402823669209385e38_f64);
+        assert_eq!((U256::MAX >> (256 - 54)).to_f64(), 1.8014398509481984e16_f64);
+        // 53 bits and below should not use exponents
+        assert_eq!((U256::MAX >> (256 - 53)).to_f64(), 9007199254740991.0_f64);
+        assert_eq!((U256::MAX >> (256 - 32)).to_f64(), 4294967295.0_f64);
+        assert_eq!((U256::MAX >> (256 - 16)).to_f64(), 65535.0_f64);
+        assert_eq!((U256::MAX >> (256 - 8)).to_f64(), 255.0_f64);
+    }
+}
+
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    #[kani::unwind(5)] // mul_u64 loops over 4 64 bit ints so use one more than 4
+    #[kani::proof]
+    fn check_mul_u64() {
+        let x: U256 = kani::any();
+        let y: u64 = kani::any();
+
+        let _ = x.mul_u64(y);
+    }
+}

--- a/libs/bitcoin/src/psbt/error.rs
+++ b/libs/bitcoin/src/psbt/error.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use internals::write_err;
+
+use crate::bip32::Xpub;
+use crate::blockdata::transaction::Transaction;
+use crate::consensus::encode;
+use crate::prelude::*;
+use crate::psbt::raw;
+
+/// Enum for marking psbt hash error.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum PsbtHash {
+    Ripemd,
+    Sha256,
+    Hash160,
+    Hash256,
+}
+/// Ways that a Partially Signed Transaction might fail.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Magic bytes for a PSBT must be the ASCII for "psbt" serialized in most
+    /// significant byte order.
+    InvalidMagic,
+    /// Missing both the witness and non-witness utxo.
+    MissingUtxo,
+    /// The separator for a PSBT must be `0xff`.
+    InvalidSeparator,
+    /// Returned when output index is out of bounds in relation to the output in non-witness UTXO.
+    PsbtUtxoOutOfbounds,
+    /// Known keys must be according to spec.
+    InvalidKey(raw::Key),
+    /// Non-proprietary key type found when proprietary key was expected
+    InvalidProprietaryKey,
+    /// Keys within key-value map should never be duplicated.
+    DuplicateKey(raw::Key),
+    /// The scriptSigs for the unsigned transaction must be empty.
+    UnsignedTxHasScriptSigs,
+    /// The scriptWitnesses for the unsigned transaction must be empty.
+    UnsignedTxHasScriptWitnesses,
+    /// A PSBT must have an unsigned transaction.
+    MustHaveUnsignedTx,
+    /// Signals that there are no more key-value pairs in a key-value map.
+    NoMorePairs,
+    /// Attempting to combine with a PSBT describing a different unsigned
+    /// transaction.
+    UnexpectedUnsignedTx {
+        /// Expected
+        expected: Box<Transaction>,
+        /// Actual
+        actual: Box<Transaction>,
+    },
+    /// Unable to parse as a standard sighash type.
+    NonStandardSighashType(u32),
+    /// Invalid hash when parsing slice.
+    InvalidHash(hashes::FromSliceError),
+    /// The pre-image must hash to the corresponding psbt hash
+    InvalidPreimageHashPair {
+        /// Hash-type
+        hash_type: PsbtHash,
+        /// Pre-image
+        preimage: Box<[u8]>,
+        /// Hash value
+        hash: Box<[u8]>,
+    },
+    /// Conflicting data during combine procedure:
+    /// global extended public key has inconsistent key sources
+    CombineInconsistentKeySources(Box<Xpub>),
+    /// Serialization error in bitcoin consensus-encoded structures
+    ConsensusEncoding(encode::Error),
+    /// Negative fee
+    NegativeFee,
+    /// Integer overflow in fee calculation
+    FeeOverflow,
+    /// Parsing error indicating invalid public keys
+    InvalidPublicKey(crate::crypto::key::FromSliceError),
+    /// Parsing error indicating invalid secp256k1 public keys
+    InvalidSecp256k1PublicKey(secp256k1::Error),
+    /// Parsing error indicating invalid xonly public keys
+    InvalidXOnlyPublicKey,
+    /// Parsing error indicating invalid ECDSA signatures
+    InvalidEcdsaSignature(crate::crypto::ecdsa::Error),
+    /// Parsing error indicating invalid taproot signatures
+    InvalidTaprootSignature(crate::crypto::taproot::SigFromSliceError),
+    /// Parsing error indicating invalid control block
+    InvalidControlBlock,
+    /// Parsing error indicating invalid leaf version
+    InvalidLeafVersion,
+    /// Parsing error indicating a taproot error
+    Taproot(&'static str),
+    /// Taproot tree deserilaization error
+    TapTree(crate::taproot::IncompleteBuilderError),
+    /// Error related to an xpub key
+    XPubKey(&'static str),
+    /// Error related to PSBT version
+    Version(&'static str),
+    /// PSBT data is not consumed entirely
+    PartialDataConsumption,
+    /// I/O error.
+    Io(io::Error),
+}
+
+internals::impl_from_infallible!(Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            InvalidMagic => f.write_str("invalid magic"),
+            MissingUtxo => f.write_str("UTXO information is not present in PSBT"),
+            InvalidSeparator => f.write_str("invalid separator"),
+            PsbtUtxoOutOfbounds =>
+                f.write_str("output index is out of bounds of non witness script output array"),
+            InvalidKey(ref rkey) => write!(f, "invalid key: {}", rkey),
+            InvalidProprietaryKey =>
+                write!(f, "non-proprietary key type found when proprietary key was expected"),
+            DuplicateKey(ref rkey) => write!(f, "duplicate key: {}", rkey),
+            UnsignedTxHasScriptSigs => f.write_str("the unsigned transaction has script sigs"),
+            UnsignedTxHasScriptWitnesses =>
+                f.write_str("the unsigned transaction has script witnesses"),
+            MustHaveUnsignedTx =>
+                f.write_str("partially signed transactions must have an unsigned transaction"),
+            NoMorePairs => f.write_str("no more key-value pairs for this psbt map"),
+            UnexpectedUnsignedTx { expected: ref e, actual: ref a } => write!(
+                f,
+                "different unsigned transaction: expected {}, actual {}",
+                e.compute_txid(),
+                a.compute_txid()
+            ),
+            NonStandardSighashType(ref sht) => write!(f, "non-standard sighash type: {}", sht),
+            InvalidHash(ref e) => write_err!(f, "invalid hash when parsing slice"; e),
+            InvalidPreimageHashPair { ref preimage, ref hash, ref hash_type } => {
+                // directly using debug forms of psbthash enums
+                write!(f, "Preimage {:?} does not match {:?} hash {:?}", preimage, hash_type, hash)
+            }
+            CombineInconsistentKeySources(ref s) => {
+                write!(f, "combine conflict: {}", s)
+            }
+            ConsensusEncoding(ref e) => write_err!(f, "bitcoin consensus encoding error"; e),
+            NegativeFee => f.write_str("PSBT has a negative fee which is not allowed"),
+            FeeOverflow => f.write_str("integer overflow in fee calculation"),
+            InvalidPublicKey(ref e) => write_err!(f, "invalid public key"; e),
+            InvalidSecp256k1PublicKey(ref e) => write_err!(f, "invalid secp256k1 public key"; e),
+            InvalidXOnlyPublicKey => f.write_str("invalid xonly public key"),
+            InvalidEcdsaSignature(ref e) => write_err!(f, "invalid ECDSA signature"; e),
+            InvalidTaprootSignature(ref e) => write_err!(f, "invalid taproot signature"; e),
+            InvalidControlBlock => f.write_str("invalid control block"),
+            InvalidLeafVersion => f.write_str("invalid leaf version"),
+            Taproot(s) => write!(f, "taproot error -  {}", s),
+            TapTree(ref e) => write_err!(f, "taproot tree error"; e),
+            XPubKey(s) => write!(f, "xpub key error -  {}", s),
+            Version(s) => write!(f, "version error {}", s),
+            PartialDataConsumption =>
+                f.write_str("data not consumed entirely when explicitly deserializing"),
+            Io(ref e) => write_err!(f, "I/O error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            InvalidHash(ref e) => Some(e),
+            ConsensusEncoding(ref e) => Some(e),
+            Io(ref e) => Some(e),
+            InvalidMagic
+            | MissingUtxo
+            | InvalidSeparator
+            | PsbtUtxoOutOfbounds
+            | InvalidKey(_)
+            | InvalidProprietaryKey
+            | DuplicateKey(_)
+            | UnsignedTxHasScriptSigs
+            | UnsignedTxHasScriptWitnesses
+            | MustHaveUnsignedTx
+            | NoMorePairs
+            | UnexpectedUnsignedTx { .. }
+            | NonStandardSighashType(_)
+            | InvalidPreimageHashPair { .. }
+            | CombineInconsistentKeySources(_)
+            | NegativeFee
+            | FeeOverflow
+            | InvalidPublicKey(_)
+            | InvalidSecp256k1PublicKey(_)
+            | InvalidXOnlyPublicKey
+            | InvalidEcdsaSignature(_)
+            | InvalidTaprootSignature(_)
+            | InvalidControlBlock
+            | InvalidLeafVersion
+            | Taproot(_)
+            | TapTree(_)
+            | XPubKey(_)
+            | Version(_)
+            | PartialDataConsumption => None,
+        }
+    }
+}
+
+impl From<hashes::FromSliceError> for Error {
+    fn from(e: hashes::FromSliceError) -> Error { Error::InvalidHash(e) }
+}
+
+impl From<encode::Error> for Error {
+    fn from(e: encode::Error) -> Self { Error::ConsensusEncoding(e) }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self { Error::Io(e) }
+}

--- a/libs/bitcoin/src/psbt/macros.rs
+++ b/libs/bitcoin/src/psbt/macros.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#[allow(unused_macros)]
+macro_rules! combine {
+    ($thing:ident, $slf:ident, $other:ident) => {
+        if let (&None, Some($thing)) = (&$slf.$thing, $other.$thing) {
+            $slf.$thing = Some($thing);
+        }
+    };
+}
+
+macro_rules! impl_psbt_de_serialize {
+    ($thing:ty) => {
+        impl_psbt_serialize!($thing);
+        impl_psbt_deserialize!($thing);
+    };
+}
+
+macro_rules! impl_psbt_deserialize {
+    ($thing:ty) => {
+        impl $crate::psbt::serialize::Deserialize for $thing {
+            fn deserialize(bytes: &[u8]) -> core::result::Result<Self, $crate::psbt::Error> {
+                $crate::consensus::deserialize(&bytes[..]).map_err(|e| $crate::psbt::Error::from(e))
+            }
+        }
+    };
+}
+
+macro_rules! impl_psbt_serialize {
+    ($thing:ty) => {
+        impl $crate::psbt::serialize::Serialize for $thing {
+            fn serialize(&self) -> $crate::prelude::Vec<u8> { $crate::consensus::serialize(self) }
+        }
+    };
+}
+
+macro_rules! impl_psbtmap_serialize {
+    ($thing:ty) => {
+        impl $crate::psbt::serialize::Serialize for $thing {
+            fn serialize(&self) -> Vec<u8> { self.serialize_map() }
+        }
+    };
+}
+
+macro_rules! impl_psbtmap_deserialize {
+    ($thing:ty) => {
+        impl $crate::psbt::serialize::Deserialize for $thing {
+            fn deserialize(bytes: &[u8]) -> core::result::Result<Self, $crate::psbt::Error> {
+                let mut decoder = bytes;
+                Self::decode(&mut decoder)
+            }
+        }
+    };
+}
+
+macro_rules! impl_psbtmap_decoding {
+    ($thing:ty) => {
+        impl $thing {
+            pub(crate) fn decode<R: $crate::io::Read + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<Self, $crate::psbt::Error> {
+                let mut rv: Self = core::default::Default::default();
+
+                loop {
+                    match $crate::psbt::raw::Pair::decode(r) {
+                        Ok(pair) => rv.insert_pair(pair)?,
+                        Err($crate::psbt::Error::NoMorePairs) => return Ok(rv),
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_psbtmap_ser_de_serialize {
+    ($thing:ty) => {
+        impl_psbtmap_decoding!($thing);
+        impl_psbtmap_serialize!($thing);
+        impl_psbtmap_deserialize!($thing);
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! impl_psbt_insert_pair {
+    ($slf:ident.$unkeyed_name:ident <= <$raw_key:ident: _>|<$raw_value:ident: $unkeyed_value_type:ty>) => {
+        if $raw_key.key.is_empty() {
+            if $slf.$unkeyed_name.is_none() {
+                let val: $unkeyed_value_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
+                $slf.$unkeyed_name = Some(val)
+            } else {
+                return Err($crate::psbt::Error::DuplicateKey($raw_key).into());
+            }
+        } else {
+            return Err($crate::psbt::Error::InvalidKey($raw_key).into());
+        }
+    };
+    ($slf:ident.$keyed_name:ident <= <$raw_key:ident: $keyed_key_type:ty>|<$raw_value:ident: $keyed_value_type:ty>) => {
+        if !$raw_key.key.is_empty() {
+            let key_val: $keyed_key_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_key.key)?;
+            match $slf.$keyed_name.entry(key_val) {
+                $crate::prelude::btree_map::Entry::Vacant(empty_key) => {
+                    let val: $keyed_value_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
+                    empty_key.insert(val);
+                }
+                $crate::prelude::btree_map::Entry::Occupied(_) => return Err($crate::psbt::Error::DuplicateKey($raw_key).into()),
+            }
+        } else {
+            return Err($crate::psbt::Error::InvalidKey($raw_key).into());
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! impl_psbt_get_pair {
+    ($rv:ident.push($slf:ident.$unkeyed_name:ident, $unkeyed_typeval:ident)) => {
+        if let Some(ref $unkeyed_name) = $slf.$unkeyed_name {
+            $rv.push($crate::psbt::raw::Pair {
+                key: $crate::psbt::raw::Key {
+                    type_value: $unkeyed_typeval,
+                    key: vec![],
+                },
+                value: $crate::psbt::serialize::Serialize::serialize($unkeyed_name),
+            });
+        }
+    };
+    ($rv:ident.push_map($slf:ident.$keyed_name:ident, $keyed_typeval:ident)) => {
+        for (key, val) in &$slf.$keyed_name {
+            $rv.push($crate::psbt::raw::Pair {
+                key: $crate::psbt::raw::Key {
+                    type_value: $keyed_typeval,
+                    key: $crate::psbt::serialize::Serialize::serialize(key),
+                },
+                value: $crate::psbt::serialize::Serialize::serialize(val),
+            });
+        }
+    };
+}
+
+// macros for serde of hashes
+macro_rules! impl_psbt_hash_de_serialize {
+    ($hash_type:ty) => {
+        impl_psbt_hash_serialize!($hash_type);
+        impl_psbt_hash_deserialize!($hash_type);
+    };
+}
+
+macro_rules! impl_psbt_hash_deserialize {
+    ($hash_type:ty) => {
+        impl $crate::psbt::serialize::Deserialize for $hash_type {
+            fn deserialize(bytes: &[u8]) -> core::result::Result<Self, $crate::psbt::Error> {
+                <$hash_type>::from_slice(&bytes[..]).map_err(|e| $crate::psbt::Error::from(e))
+            }
+        }
+    };
+}
+
+macro_rules! impl_psbt_hash_serialize {
+    ($hash_type:ty) => {
+        impl $crate::psbt::serialize::Serialize for $hash_type {
+            fn serialize(&self) -> $crate::prelude::Vec<u8> { self.as_byte_array().to_vec() }
+        }
+    };
+}

--- a/libs/bitcoin/src/psbt/map/global.rs
+++ b/libs/bitcoin/src/psbt/map/global.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use io::{Cursor, Read};
+
+use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
+use crate::blockdata::transaction::Transaction;
+use crate::consensus::encode::MAX_VEC_SIZE;
+use crate::consensus::{encode, Decodable};
+use crate::prelude::*;
+use crate::psbt::map::Map;
+use crate::psbt::{raw, Error, Psbt};
+
+/// Type: Unsigned Transaction PSBT_GLOBAL_UNSIGNED_TX = 0x00
+const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;
+/// Type: Extended Public Key PSBT_GLOBAL_XPUB = 0x01
+const PSBT_GLOBAL_XPUB: u8 = 0x01;
+/// Type: Version Number PSBT_GLOBAL_VERSION = 0xFB
+const PSBT_GLOBAL_VERSION: u8 = 0xFB;
+/// Type: Proprietary Use Type PSBT_GLOBAL_PROPRIETARY = 0xFC
+const PSBT_GLOBAL_PROPRIETARY: u8 = 0xFC;
+
+impl Map for Psbt {
+    fn get_pairs(&self) -> Vec<raw::Pair> {
+        let mut rv: Vec<raw::Pair> = Default::default();
+
+        rv.push(raw::Pair {
+            key: raw::Key { type_value: PSBT_GLOBAL_UNSIGNED_TX, key: vec![] },
+            value: {
+                // Manually serialized to ensure 0-input txs are serialized
+                // without witnesses.
+                let mut ret = Vec::new();
+                ret.extend(encode::serialize(&self.unsigned_tx.version));
+                ret.extend(encode::serialize(&self.unsigned_tx.input));
+                ret.extend(encode::serialize(&self.unsigned_tx.output));
+                ret.extend(encode::serialize(&self.unsigned_tx.lock_time));
+                ret
+            },
+        });
+
+        for (xpub, (fingerprint, derivation)) in &self.xpub {
+            rv.push(raw::Pair {
+                key: raw::Key { type_value: PSBT_GLOBAL_XPUB, key: xpub.encode().to_vec() },
+                value: {
+                    let mut ret = Vec::with_capacity(4 + derivation.len() * 4);
+                    ret.extend(fingerprint.as_bytes());
+                    derivation.into_iter().for_each(|n| ret.extend(&u32::from(*n).to_le_bytes()));
+                    ret
+                },
+            });
+        }
+
+        // Serializing version only for non-default value; otherwise test vectors fail
+        if self.version > 0 {
+            rv.push(raw::Pair {
+                key: raw::Key { type_value: PSBT_GLOBAL_VERSION, key: vec![] },
+                value: self.version.to_le_bytes().to_vec(),
+            });
+        }
+
+        for (key, value) in self.proprietary.iter() {
+            rv.push(raw::Pair { key: key.to_key(), value: value.clone() });
+        }
+
+        for (key, value) in self.unknown.iter() {
+            rv.push(raw::Pair { key: key.clone(), value: value.clone() });
+        }
+
+        rv
+    }
+}
+
+impl Psbt {
+    pub(crate) fn decode_global<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let mut r = r.take(MAX_VEC_SIZE as u64);
+        let mut tx: Option<Transaction> = None;
+        let mut version: Option<u32> = None;
+        let mut unknowns: BTreeMap<raw::Key, Vec<u8>> = Default::default();
+        let mut xpub_map: BTreeMap<Xpub, (Fingerprint, DerivationPath)> = Default::default();
+        let mut proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>> = Default::default();
+
+        loop {
+            match raw::Pair::decode(&mut r) {
+                Ok(pair) => {
+                    match pair.key.type_value {
+                        PSBT_GLOBAL_UNSIGNED_TX => {
+                            // key has to be empty
+                            if pair.key.key.is_empty() {
+                                // there can only be one unsigned transaction
+                                if tx.is_none() {
+                                    let vlen: usize = pair.value.len();
+                                    let mut decoder = Cursor::new(pair.value);
+
+                                    // Manually deserialized to ensure 0-input
+                                    // txs without witnesses are deserialized
+                                    // properly.
+                                    tx = Some(Transaction {
+                                        version: Decodable::consensus_decode(&mut decoder)?,
+                                        input: Decodable::consensus_decode(&mut decoder)?,
+                                        output: Decodable::consensus_decode(&mut decoder)?,
+                                        lock_time: Decodable::consensus_decode(&mut decoder)?,
+                                    });
+
+                                    if decoder.position() != vlen as u64 {
+                                        return Err(Error::PartialDataConsumption);
+                                    }
+                                } else {
+                                    return Err(Error::DuplicateKey(pair.key));
+                                }
+                            } else {
+                                return Err(Error::InvalidKey(pair.key));
+                            }
+                        }
+                        PSBT_GLOBAL_XPUB => {
+                            if !pair.key.key.is_empty() {
+                                let xpub = Xpub::decode(&pair.key.key)
+                                    .map_err(|_| Error::XPubKey(
+                                        "Can't deserialize ExtendedPublicKey from global XPUB key data"
+                                    ))?;
+
+                                if pair.value.is_empty() || pair.value.len() % 4 != 0 {
+                                    return Err(Error::XPubKey(
+                                        "Incorrect length of global xpub derivation data",
+                                    ));
+                                }
+
+                                let child_count = pair.value.len() / 4 - 1;
+                                let mut decoder = Cursor::new(pair.value);
+                                let mut fingerprint = [0u8; 4];
+                                decoder.read_exact(&mut fingerprint[..]).map_err(|_| {
+                                    Error::XPubKey("Can't read global xpub fingerprint")
+                                })?;
+                                let mut path = Vec::<ChildNumber>::with_capacity(child_count);
+                                while let Ok(index) = u32::consensus_decode(&mut decoder) {
+                                    path.push(ChildNumber::from(index))
+                                }
+                                let derivation = DerivationPath::from(path);
+                                // Keys, according to BIP-174, must be unique
+                                if xpub_map
+                                    .insert(xpub, (Fingerprint::from(fingerprint), derivation))
+                                    .is_some()
+                                {
+                                    return Err(Error::XPubKey("Repeated global xpub key"));
+                                }
+                            } else {
+                                return Err(Error::XPubKey(
+                                    "Xpub global key must contain serialized Xpub data",
+                                ));
+                            }
+                        }
+                        PSBT_GLOBAL_VERSION => {
+                            // key has to be empty
+                            if pair.key.key.is_empty() {
+                                // there can only be one version
+                                if version.is_none() {
+                                    let vlen: usize = pair.value.len();
+                                    let mut decoder = Cursor::new(pair.value);
+                                    if vlen != 4 {
+                                        return Err(Error::Version(
+                                            "invalid global version value length (must be 4 bytes)",
+                                        ));
+                                    }
+                                    version = Some(Decodable::consensus_decode(&mut decoder)?);
+                                    // We only understand version 0 PSBTs. According to BIP-174 we
+                                    // should throw an error if we see anything other than version 0.
+                                    if version != Some(0) {
+                                        return Err(Error::Version(
+                                            "PSBT versions greater than 0 are not supported",
+                                        ));
+                                    }
+                                } else {
+                                    return Err(Error::DuplicateKey(pair.key));
+                                }
+                            } else {
+                                return Err(Error::InvalidKey(pair.key));
+                            }
+                        }
+                        PSBT_GLOBAL_PROPRIETARY => match proprietary
+                            .entry(raw::ProprietaryKey::try_from(pair.key.clone())?)
+                        {
+                            btree_map::Entry::Vacant(empty_key) => {
+                                empty_key.insert(pair.value);
+                            }
+                            btree_map::Entry::Occupied(_) =>
+                                return Err(Error::DuplicateKey(pair.key)),
+                        },
+                        _ => match unknowns.entry(pair.key) {
+                            btree_map::Entry::Vacant(empty_key) => {
+                                empty_key.insert(pair.value);
+                            }
+                            btree_map::Entry::Occupied(k) =>
+                                return Err(Error::DuplicateKey(k.key().clone())),
+                        },
+                    }
+                }
+                Err(crate::psbt::Error::NoMorePairs) => break,
+                Err(e) => return Err(e),
+            }
+        }
+
+        if let Some(tx) = tx {
+            Ok(Psbt {
+                unsigned_tx: tx,
+                version: version.unwrap_or(0),
+                xpub: xpub_map,
+                proprietary,
+                unknown: unknowns,
+                inputs: vec![],
+                outputs: vec![],
+            })
+        } else {
+            Err(Error::MustHaveUnsignedTx)
+        }
+    }
+}

--- a/libs/bitcoin/src/psbt/map/input.rs
+++ b/libs/bitcoin/src/psbt/map/input.rs
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+use core::str::FromStr;
+
+use hashes::{hash160, ripemd160, sha256, sha256d};
+use secp256k1::XOnlyPublicKey;
+
+use crate::bip32::KeySource;
+use crate::blockdata::script::ScriptBuf;
+use crate::blockdata::transaction::{Transaction, TxOut};
+use crate::blockdata::witness::Witness;
+use crate::crypto::key::PublicKey;
+use crate::crypto::{ecdsa, taproot};
+use crate::prelude::*;
+use crate::psbt::map::Map;
+use crate::psbt::serialize::Deserialize;
+use crate::psbt::{self, error, raw, Error};
+use crate::sighash::{
+    EcdsaSighashType, InvalidSighashTypeError, NonStandardSighashTypeError, SighashTypeParseError,
+    TapSighashType,
+};
+use crate::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapNodeHash};
+
+/// Type: Non-Witness UTXO PSBT_IN_NON_WITNESS_UTXO = 0x00
+const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;
+/// Type: Witness UTXO PSBT_IN_WITNESS_UTXO = 0x01
+const PSBT_IN_WITNESS_UTXO: u8 = 0x01;
+/// Type: Partial Signature PSBT_IN_PARTIAL_SIG = 0x02
+const PSBT_IN_PARTIAL_SIG: u8 = 0x02;
+/// Type: Sighash Type PSBT_IN_SIGHASH_TYPE = 0x03
+const PSBT_IN_SIGHASH_TYPE: u8 = 0x03;
+/// Type: Redeem Script PSBT_IN_REDEEM_SCRIPT = 0x04
+const PSBT_IN_REDEEM_SCRIPT: u8 = 0x04;
+/// Type: Witness Script PSBT_IN_WITNESS_SCRIPT = 0x05
+const PSBT_IN_WITNESS_SCRIPT: u8 = 0x05;
+/// Type: BIP 32 Derivation Path PSBT_IN_BIP32_DERIVATION = 0x06
+const PSBT_IN_BIP32_DERIVATION: u8 = 0x06;
+/// Type: Finalized scriptSig PSBT_IN_FINAL_SCRIPTSIG = 0x07
+const PSBT_IN_FINAL_SCRIPTSIG: u8 = 0x07;
+/// Type: Finalized scriptWitness PSBT_IN_FINAL_SCRIPTWITNESS = 0x08
+const PSBT_IN_FINAL_SCRIPTWITNESS: u8 = 0x08;
+/// Type: RIPEMD160 preimage PSBT_IN_RIPEMD160 = 0x0a
+const PSBT_IN_RIPEMD160: u8 = 0x0a;
+/// Type: SHA256 preimage PSBT_IN_SHA256 = 0x0b
+const PSBT_IN_SHA256: u8 = 0x0b;
+/// Type: HASH160 preimage PSBT_IN_HASH160 = 0x0c
+const PSBT_IN_HASH160: u8 = 0x0c;
+/// Type: HASH256 preimage PSBT_IN_HASH256 = 0x0d
+const PSBT_IN_HASH256: u8 = 0x0d;
+/// Type: Taproot Signature in Key Spend PSBT_IN_TAP_KEY_SIG = 0x13
+const PSBT_IN_TAP_KEY_SIG: u8 = 0x13;
+/// Type: Taproot Signature in Script Spend PSBT_IN_TAP_SCRIPT_SIG = 0x14
+const PSBT_IN_TAP_SCRIPT_SIG: u8 = 0x14;
+/// Type: Taproot Leaf Script PSBT_IN_TAP_LEAF_SCRIPT = 0x14
+const PSBT_IN_TAP_LEAF_SCRIPT: u8 = 0x15;
+/// Type: Taproot Key BIP 32 Derivation Path PSBT_IN_TAP_BIP32_DERIVATION = 0x16
+const PSBT_IN_TAP_BIP32_DERIVATION: u8 = 0x16;
+/// Type: Taproot Internal Key PSBT_IN_TAP_INTERNAL_KEY = 0x17
+const PSBT_IN_TAP_INTERNAL_KEY: u8 = 0x17;
+/// Type: Taproot Merkle Root PSBT_IN_TAP_MERKLE_ROOT = 0x18
+const PSBT_IN_TAP_MERKLE_ROOT: u8 = 0x18;
+/// Type: Proprietary Use Type PSBT_IN_PROPRIETARY = 0xFC
+const PSBT_IN_PROPRIETARY: u8 = 0xFC;
+
+/// A key-value map for an input of the corresponding index in the unsigned
+/// transaction.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Input {
+    /// The non-witness transaction this input spends from. Should only be
+    /// `Option::Some` for inputs which spend non-segwit outputs or
+    /// if it is unknown whether an input spends a segwit output.
+    pub non_witness_utxo: Option<Transaction>,
+    /// The transaction output this input spends from. Should only be
+    /// `Option::Some` for inputs which spend segwit outputs,
+    /// including P2SH embedded ones.
+    pub witness_utxo: Option<TxOut>,
+    /// A map from public keys to their corresponding signature as would be
+    /// pushed to the stack from a scriptSig or witness for a non-taproot inputs.
+    pub partial_sigs: BTreeMap<PublicKey, ecdsa::Signature>,
+    /// The sighash type to be used for this input. Signatures for this input
+    /// must use the sighash type.
+    pub sighash_type: Option<PsbtSighashType>,
+    /// The redeem script for this input.
+    pub redeem_script: Option<ScriptBuf>,
+    /// The witness script for this input.
+    pub witness_script: Option<ScriptBuf>,
+    /// A map from public keys needed to sign this input to their corresponding
+    /// master key fingerprints and derivation paths.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
+    pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
+    /// The finalized, fully-constructed scriptSig with signatures and any other
+    /// scripts necessary for this input to pass validation.
+    pub final_script_sig: Option<ScriptBuf>,
+    /// The finalized, fully-constructed scriptWitness with signatures and any
+    /// other scripts necessary for this input to pass validation.
+    pub final_script_witness: Option<Witness>,
+    /// RIPEMD160 hash to preimage map.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
+    pub ripemd160_preimages: BTreeMap<ripemd160::Hash, Vec<u8>>,
+    /// SHA256 hash to preimage map.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
+    pub sha256_preimages: BTreeMap<sha256::Hash, Vec<u8>>,
+    /// HSAH160 hash to preimage map.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
+    pub hash160_preimages: BTreeMap<hash160::Hash, Vec<u8>>,
+    /// HAS256 hash to preimage map.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
+    pub hash256_preimages: BTreeMap<sha256d::Hash, Vec<u8>>,
+    /// Serialized taproot signature with sighash type for key spend.
+    pub tap_key_sig: Option<taproot::Signature>,
+    /// Map of `<xonlypubkey>|<leafhash>` with signature.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
+    pub tap_script_sigs: BTreeMap<(XOnlyPublicKey, TapLeafHash), taproot::Signature>,
+    /// Map of Control blocks to Script version pair.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
+    pub tap_scripts: BTreeMap<ControlBlock, (ScriptBuf, LeafVersion)>,
+    /// Map of tap root x only keys to origin info and leaf hashes contained in it.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
+    pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
+    /// Taproot Internal key.
+    pub tap_internal_key: Option<XOnlyPublicKey>,
+    /// Taproot Merkle root.
+    pub tap_merkle_root: Option<TapNodeHash>,
+    /// Proprietary key-value pairs for this input.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
+    pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
+    /// Unknown key-value pairs for this input.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
+    pub unknown: BTreeMap<raw::Key, Vec<u8>>,
+}
+
+/// A Signature hash type for the corresponding input.
+///
+/// As of taproot upgrade, the signature hash type can be either [`EcdsaSighashType`] or
+/// [`TapSighashType`] but it is not possible to know directly which signature hash type the user is
+/// dealing with. Therefore, the user is responsible for converting to/from [`PsbtSighashType`]
+/// from/to the desired signature hash type they need.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct PsbtSighashType {
+    pub(in crate::psbt) inner: u32,
+}
+
+impl fmt::Display for PsbtSighashType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.taproot_hash_ty() {
+            Err(_) => write!(f, "{:#x}", self.inner),
+            Ok(taproot_hash_ty) => fmt::Display::fmt(&taproot_hash_ty, f),
+        }
+    }
+}
+
+impl FromStr for PsbtSighashType {
+    type Err = SighashTypeParseError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // We accept strings of form: "SIGHASH_ALL" etc.
+        //
+        // NB: some of Taproot sighash types are non-standard for pre-taproot
+        // inputs. We also do not support SIGHASH_RESERVED in verbatim form
+        // ("0xFF" string should be used instead).
+        if let Ok(ty) = TapSighashType::from_str(s) {
+            return Ok(ty.into());
+        }
+
+        // We accept non-standard sighash values.
+        if let Ok(inner) = u32::from_str_radix(s.trim_start_matches("0x"), 16) {
+            return Ok(PsbtSighashType { inner });
+        }
+
+        Err(SighashTypeParseError { unrecognized: s.to_owned() })
+    }
+}
+impl From<EcdsaSighashType> for PsbtSighashType {
+    fn from(ecdsa_hash_ty: EcdsaSighashType) -> Self {
+        PsbtSighashType { inner: ecdsa_hash_ty as u32 }
+    }
+}
+
+impl From<TapSighashType> for PsbtSighashType {
+    fn from(taproot_hash_ty: TapSighashType) -> Self {
+        PsbtSighashType { inner: taproot_hash_ty as u32 }
+    }
+}
+
+impl PsbtSighashType {
+    /// Returns the [`EcdsaSighashType`] if the [`PsbtSighashType`] can be
+    /// converted to one.
+    pub fn ecdsa_hash_ty(self) -> Result<EcdsaSighashType, NonStandardSighashTypeError> {
+        EcdsaSighashType::from_standard(self.inner)
+    }
+
+    /// Returns the [`TapSighashType`] if the [`PsbtSighashType`] can be
+    /// converted to one.
+    pub fn taproot_hash_ty(self) -> Result<TapSighashType, InvalidSighashTypeError> {
+        if self.inner > 0xffu32 {
+            Err(InvalidSighashTypeError(self.inner))
+        } else {
+            TapSighashType::from_consensus_u8(self.inner as u8)
+        }
+    }
+
+    /// Creates a [`PsbtSighashType`] from a raw `u32`.
+    ///
+    /// Allows construction of a non-standard or non-valid sighash flag
+    /// ([`EcdsaSighashType`], [`TapSighashType`] respectively).
+    pub fn from_u32(n: u32) -> PsbtSighashType { PsbtSighashType { inner: n } }
+
+    /// Converts [`PsbtSighashType`] to a raw `u32` sighash flag.
+    ///
+    /// No guarantees are made as to the standardness or validity of the returned value.
+    pub fn to_u32(self) -> u32 { self.inner }
+}
+
+impl Input {
+    /// Obtains the [`EcdsaSighashType`] for this input if one is specified. If no sighash type is
+    /// specified, returns [`EcdsaSighashType::All`].
+    ///
+    /// # Errors
+    ///
+    /// If the `sighash_type` field is set to a non-standard ECDSA sighash value.
+    pub fn ecdsa_hash_ty(&self) -> Result<EcdsaSighashType, NonStandardSighashTypeError> {
+        self.sighash_type
+            .map(|sighash_type| sighash_type.ecdsa_hash_ty())
+            .unwrap_or(Ok(EcdsaSighashType::All))
+    }
+
+    /// Obtains the [`TapSighashType`] for this input if one is specified. If no sighash type is
+    /// specified, returns [`TapSighashType::Default`].
+    ///
+    /// # Errors
+    ///
+    /// If the `sighash_type` field is set to a invalid Taproot sighash value.
+    pub fn taproot_hash_ty(&self) -> Result<TapSighashType, InvalidSighashTypeError> {
+        self.sighash_type
+            .map(|sighash_type| sighash_type.taproot_hash_ty())
+            .unwrap_or(Ok(TapSighashType::Default))
+    }
+
+    pub(super) fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), Error> {
+        let raw::Pair { key: raw_key, value: raw_value } = pair;
+
+        match raw_key.type_value {
+            PSBT_IN_NON_WITNESS_UTXO => {
+                impl_psbt_insert_pair! {
+                    self.non_witness_utxo <= <raw_key: _>|<raw_value: Transaction>
+                }
+            }
+            PSBT_IN_WITNESS_UTXO => {
+                impl_psbt_insert_pair! {
+                    self.witness_utxo <= <raw_key: _>|<raw_value: TxOut>
+                }
+            }
+            PSBT_IN_PARTIAL_SIG => {
+                impl_psbt_insert_pair! {
+                    self.partial_sigs <= <raw_key: PublicKey>|<raw_value: ecdsa::Signature>
+                }
+            }
+            PSBT_IN_SIGHASH_TYPE => {
+                impl_psbt_insert_pair! {
+                    self.sighash_type <= <raw_key: _>|<raw_value: PsbtSighashType>
+                }
+            }
+            PSBT_IN_REDEEM_SCRIPT => {
+                impl_psbt_insert_pair! {
+                    self.redeem_script <= <raw_key: _>|<raw_value: ScriptBuf>
+                }
+            }
+            PSBT_IN_WITNESS_SCRIPT => {
+                impl_psbt_insert_pair! {
+                    self.witness_script <= <raw_key: _>|<raw_value: ScriptBuf>
+                }
+            }
+            PSBT_IN_BIP32_DERIVATION => {
+                impl_psbt_insert_pair! {
+                    self.bip32_derivation <= <raw_key: secp256k1::PublicKey>|<raw_value: KeySource>
+                }
+            }
+            PSBT_IN_FINAL_SCRIPTSIG => {
+                impl_psbt_insert_pair! {
+                    self.final_script_sig <= <raw_key: _>|<raw_value: ScriptBuf>
+                }
+            }
+            PSBT_IN_FINAL_SCRIPTWITNESS => {
+                impl_psbt_insert_pair! {
+                    self.final_script_witness <= <raw_key: _>|<raw_value: Witness>
+                }
+            }
+            PSBT_IN_RIPEMD160 => {
+                psbt_insert_hash_pair(
+                    &mut self.ripemd160_preimages,
+                    raw_key,
+                    raw_value,
+                    error::PsbtHash::Ripemd,
+                )?;
+            }
+            PSBT_IN_SHA256 => {
+                psbt_insert_hash_pair(
+                    &mut self.sha256_preimages,
+                    raw_key,
+                    raw_value,
+                    error::PsbtHash::Sha256,
+                )?;
+            }
+            PSBT_IN_HASH160 => {
+                psbt_insert_hash_pair(
+                    &mut self.hash160_preimages,
+                    raw_key,
+                    raw_value,
+                    error::PsbtHash::Hash160,
+                )?;
+            }
+            PSBT_IN_HASH256 => {
+                psbt_insert_hash_pair(
+                    &mut self.hash256_preimages,
+                    raw_key,
+                    raw_value,
+                    error::PsbtHash::Hash256,
+                )?;
+            }
+            PSBT_IN_TAP_KEY_SIG => {
+                impl_psbt_insert_pair! {
+                    self.tap_key_sig <= <raw_key: _>|<raw_value: taproot::Signature>
+                }
+            }
+            PSBT_IN_TAP_SCRIPT_SIG => {
+                impl_psbt_insert_pair! {
+                    self.tap_script_sigs <= <raw_key: (XOnlyPublicKey, TapLeafHash)>|<raw_value: taproot::Signature>
+                }
+            }
+            PSBT_IN_TAP_LEAF_SCRIPT => {
+                impl_psbt_insert_pair! {
+                    self.tap_scripts <= <raw_key: ControlBlock>|< raw_value: (ScriptBuf, LeafVersion)>
+                }
+            }
+            PSBT_IN_TAP_BIP32_DERIVATION => {
+                impl_psbt_insert_pair! {
+                    self.tap_key_origins <= <raw_key: XOnlyPublicKey>|< raw_value: (Vec<TapLeafHash>, KeySource)>
+                }
+            }
+            PSBT_IN_TAP_INTERNAL_KEY => {
+                impl_psbt_insert_pair! {
+                    self.tap_internal_key <= <raw_key: _>|< raw_value: XOnlyPublicKey>
+                }
+            }
+            PSBT_IN_TAP_MERKLE_ROOT => {
+                impl_psbt_insert_pair! {
+                    self.tap_merkle_root <= <raw_key: _>|< raw_value: TapNodeHash>
+                }
+            }
+            PSBT_IN_PROPRIETARY => {
+                let key = raw::ProprietaryKey::try_from(raw_key.clone())?;
+                match self.proprietary.entry(key) {
+                    btree_map::Entry::Vacant(empty_key) => {
+                        empty_key.insert(raw_value);
+                    }
+                    btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key)),
+                }
+            }
+            _ => match self.unknown.entry(raw_key) {
+                btree_map::Entry::Vacant(empty_key) => {
+                    empty_key.insert(raw_value);
+                }
+                btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone())),
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Combines this [`Input`] with `other` `Input` (as described by BIP 174).
+    pub fn combine(&mut self, other: Self) {
+        combine!(non_witness_utxo, self, other);
+
+        if let (&None, Some(witness_utxo)) = (&self.witness_utxo, other.witness_utxo) {
+            self.witness_utxo = Some(witness_utxo);
+            self.non_witness_utxo = None; // Clear out any non-witness UTXO when we set a witness one
+        }
+
+        self.partial_sigs.extend(other.partial_sigs);
+        self.bip32_derivation.extend(other.bip32_derivation);
+        self.ripemd160_preimages.extend(other.ripemd160_preimages);
+        self.sha256_preimages.extend(other.sha256_preimages);
+        self.hash160_preimages.extend(other.hash160_preimages);
+        self.hash256_preimages.extend(other.hash256_preimages);
+        self.tap_script_sigs.extend(other.tap_script_sigs);
+        self.tap_scripts.extend(other.tap_scripts);
+        self.tap_key_origins.extend(other.tap_key_origins);
+        self.proprietary.extend(other.proprietary);
+        self.unknown.extend(other.unknown);
+
+        combine!(redeem_script, self, other);
+        combine!(witness_script, self, other);
+        combine!(final_script_sig, self, other);
+        combine!(final_script_witness, self, other);
+        combine!(tap_key_sig, self, other);
+        combine!(tap_internal_key, self, other);
+        combine!(tap_merkle_root, self, other);
+    }
+}
+
+impl Map for Input {
+    fn get_pairs(&self) -> Vec<raw::Pair> {
+        let mut rv: Vec<raw::Pair> = Default::default();
+
+        impl_psbt_get_pair! {
+            rv.push(self.non_witness_utxo, PSBT_IN_NON_WITNESS_UTXO)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.witness_utxo, PSBT_IN_WITNESS_UTXO)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.partial_sigs, PSBT_IN_PARTIAL_SIG)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.sighash_type, PSBT_IN_SIGHASH_TYPE)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.redeem_script, PSBT_IN_REDEEM_SCRIPT)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.witness_script, PSBT_IN_WITNESS_SCRIPT)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.bip32_derivation, PSBT_IN_BIP32_DERIVATION)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.final_script_sig, PSBT_IN_FINAL_SCRIPTSIG)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.final_script_witness, PSBT_IN_FINAL_SCRIPTWITNESS)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.ripemd160_preimages, PSBT_IN_RIPEMD160)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.sha256_preimages, PSBT_IN_SHA256)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.hash160_preimages, PSBT_IN_HASH160)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.hash256_preimages, PSBT_IN_HASH256)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.tap_key_sig, PSBT_IN_TAP_KEY_SIG)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.tap_script_sigs, PSBT_IN_TAP_SCRIPT_SIG)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.tap_scripts, PSBT_IN_TAP_LEAF_SCRIPT)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.tap_key_origins, PSBT_IN_TAP_BIP32_DERIVATION)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.tap_internal_key, PSBT_IN_TAP_INTERNAL_KEY)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.tap_merkle_root, PSBT_IN_TAP_MERKLE_ROOT)
+        }
+        for (key, value) in self.proprietary.iter() {
+            rv.push(raw::Pair { key: key.to_key(), value: value.clone() });
+        }
+
+        for (key, value) in self.unknown.iter() {
+            rv.push(raw::Pair { key: key.clone(), value: value.clone() });
+        }
+
+        rv
+    }
+}
+
+impl_psbtmap_ser_de_serialize!(Input);
+
+fn psbt_insert_hash_pair<H>(
+    map: &mut BTreeMap<H, Vec<u8>>,
+    raw_key: raw::Key,
+    raw_value: Vec<u8>,
+    hash_type: error::PsbtHash,
+) -> Result<(), Error>
+where
+    H: hashes::Hash + Deserialize,
+{
+    if raw_key.key.is_empty() {
+        return Err(psbt::Error::InvalidKey(raw_key));
+    }
+    let key_val: H = Deserialize::deserialize(&raw_key.key)?;
+    match map.entry(key_val) {
+        btree_map::Entry::Vacant(empty_key) => {
+            let val: Vec<u8> = Deserialize::deserialize(&raw_value)?;
+            if <H as hashes::Hash>::hash(&val) != key_val {
+                return Err(psbt::Error::InvalidPreimageHashPair {
+                    preimage: val.into_boxed_slice(),
+                    hash: Box::from(key_val.borrow()),
+                    hash_type,
+                });
+            }
+            empty_key.insert(val);
+            Ok(())
+        }
+        btree_map::Entry::Occupied(_) => Err(psbt::Error::DuplicateKey(raw_key)),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn psbt_sighash_type_ecdsa() {
+        for ecdsa in &[
+            EcdsaSighashType::All,
+            EcdsaSighashType::None,
+            EcdsaSighashType::Single,
+            EcdsaSighashType::AllPlusAnyoneCanPay,
+            EcdsaSighashType::NonePlusAnyoneCanPay,
+            EcdsaSighashType::SinglePlusAnyoneCanPay,
+        ] {
+            let sighash = PsbtSighashType::from(*ecdsa);
+            let s = format!("{}", sighash);
+            let back = PsbtSighashType::from_str(&s).unwrap();
+            assert_eq!(back, sighash);
+            assert_eq!(back.ecdsa_hash_ty().unwrap(), *ecdsa);
+        }
+    }
+
+    #[test]
+    fn psbt_sighash_type_taproot() {
+        for tap in &[
+            TapSighashType::Default,
+            TapSighashType::All,
+            TapSighashType::None,
+            TapSighashType::Single,
+            TapSighashType::AllPlusAnyoneCanPay,
+            TapSighashType::NonePlusAnyoneCanPay,
+            TapSighashType::SinglePlusAnyoneCanPay,
+        ] {
+            let sighash = PsbtSighashType::from(*tap);
+            let s = format!("{}", sighash);
+            let back = PsbtSighashType::from_str(&s).unwrap();
+            assert_eq!(back, sighash);
+            assert_eq!(back.taproot_hash_ty().unwrap(), *tap);
+        }
+    }
+
+    #[test]
+    fn psbt_sighash_type_notstd() {
+        let nonstd = 0xdddddddd;
+        let sighash = PsbtSighashType { inner: nonstd };
+        let s = format!("{}", sighash);
+        let back = PsbtSighashType::from_str(&s).unwrap();
+
+        assert_eq!(back, sighash);
+        assert_eq!(back.ecdsa_hash_ty(), Err(NonStandardSighashTypeError(nonstd)));
+        assert_eq!(back.taproot_hash_ty(), Err(InvalidSighashTypeError(nonstd)));
+    }
+}

--- a/libs/bitcoin/src/psbt/map/mod.rs
+++ b/libs/bitcoin/src/psbt/map/mod.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: CC0-1.0
+
+mod global;
+mod input;
+mod output;
+
+use crate::prelude::*;
+use crate::psbt::raw;
+use crate::psbt::serialize::Serialize;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    input::{Input, PsbtSighashType},
+    output::Output,
+};
+
+/// A trait that describes a PSBT key-value map.
+pub(super) trait Map {
+    /// Attempt to get all key-value pairs.
+    fn get_pairs(&self) -> Vec<raw::Pair>;
+
+    /// Serialize Psbt binary map data according to BIP-174 specification.
+    ///
+    /// <map> := <keypair>* 0x00
+    ///
+    /// Why is the separator here 0x00 instead of 0xff? The separator here is used to distinguish between each chunk of data.
+    /// A separator of 0x00 would mean that the unserializer can read it as a key length of 0, which would never occur with
+    /// actual keys. It can thus be used as a separator and allow for easier unserializer implementation.
+    fn serialize_map(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for pair in Map::get_pairs(self) {
+            buf.extend(&pair.serialize());
+        }
+        buf.push(0x00_u8);
+        buf
+    }
+}

--- a/libs/bitcoin/src/psbt/map/output.rs
+++ b/libs/bitcoin/src/psbt/map/output.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use secp256k1::XOnlyPublicKey;
+
+use crate::bip32::KeySource;
+use crate::blockdata::script::ScriptBuf;
+use crate::prelude::*;
+use crate::psbt::map::Map;
+use crate::psbt::{raw, Error};
+use crate::taproot::{TapLeafHash, TapTree};
+
+/// Type: Redeem ScriptBuf PSBT_OUT_REDEEM_SCRIPT = 0x00
+const PSBT_OUT_REDEEM_SCRIPT: u8 = 0x00;
+/// Type: Witness ScriptBuf PSBT_OUT_WITNESS_SCRIPT = 0x01
+const PSBT_OUT_WITNESS_SCRIPT: u8 = 0x01;
+/// Type: BIP 32 Derivation Path PSBT_OUT_BIP32_DERIVATION = 0x02
+const PSBT_OUT_BIP32_DERIVATION: u8 = 0x02;
+/// Type: Taproot Internal Key PSBT_OUT_TAP_INTERNAL_KEY = 0x05
+const PSBT_OUT_TAP_INTERNAL_KEY: u8 = 0x05;
+/// Type: Taproot Tree PSBT_OUT_TAP_TREE = 0x06
+const PSBT_OUT_TAP_TREE: u8 = 0x06;
+/// Type: Taproot Key BIP 32 Derivation Path PSBT_OUT_TAP_BIP32_DERIVATION = 0x07
+const PSBT_OUT_TAP_BIP32_DERIVATION: u8 = 0x07;
+/// Type: Proprietary Use Type PSBT_IN_PROPRIETARY = 0xFC
+const PSBT_OUT_PROPRIETARY: u8 = 0xFC;
+
+/// A key-value map for an output of the corresponding index in the unsigned
+/// transaction.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Output {
+    /// The redeem script for this output.
+    pub redeem_script: Option<ScriptBuf>,
+    /// The witness script for this output.
+    pub witness_script: Option<ScriptBuf>,
+    /// A map from public keys needed to spend this output to their
+    /// corresponding master key fingerprints and derivation paths.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
+    pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
+    /// The internal pubkey.
+    pub tap_internal_key: Option<XOnlyPublicKey>,
+    /// Taproot Output tree.
+    pub tap_tree: Option<TapTree>,
+    /// Map of tap root x only keys to origin info and leaf hashes contained in it.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
+    pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
+    /// Proprietary key-value pairs for this output.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
+    pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
+    /// Unknown key-value pairs for this output.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
+    pub unknown: BTreeMap<raw::Key, Vec<u8>>,
+}
+
+impl Output {
+    pub(super) fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), Error> {
+        let raw::Pair { key: raw_key, value: raw_value } = pair;
+
+        match raw_key.type_value {
+            PSBT_OUT_REDEEM_SCRIPT => {
+                impl_psbt_insert_pair! {
+                    self.redeem_script <= <raw_key: _>|<raw_value: ScriptBuf>
+                }
+            }
+            PSBT_OUT_WITNESS_SCRIPT => {
+                impl_psbt_insert_pair! {
+                    self.witness_script <= <raw_key: _>|<raw_value: ScriptBuf>
+                }
+            }
+            PSBT_OUT_BIP32_DERIVATION => {
+                impl_psbt_insert_pair! {
+                    self.bip32_derivation <= <raw_key: secp256k1::PublicKey>|<raw_value: KeySource>
+                }
+            }
+            PSBT_OUT_PROPRIETARY => {
+                let key = raw::ProprietaryKey::try_from(raw_key.clone())?;
+                match self.proprietary.entry(key) {
+                    btree_map::Entry::Vacant(empty_key) => {
+                        empty_key.insert(raw_value);
+                    }
+                    btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key)),
+                }
+            }
+            PSBT_OUT_TAP_INTERNAL_KEY => {
+                impl_psbt_insert_pair! {
+                    self.tap_internal_key <= <raw_key: _>|<raw_value: XOnlyPublicKey>
+                }
+            }
+            PSBT_OUT_TAP_TREE => {
+                impl_psbt_insert_pair! {
+                    self.tap_tree <= <raw_key: _>|<raw_value: TapTree>
+                }
+            }
+            PSBT_OUT_TAP_BIP32_DERIVATION => {
+                impl_psbt_insert_pair! {
+                    self.tap_key_origins <= <raw_key: XOnlyPublicKey>|< raw_value: (Vec<TapLeafHash>, KeySource)>
+                }
+            }
+            _ => match self.unknown.entry(raw_key) {
+                btree_map::Entry::Vacant(empty_key) => {
+                    empty_key.insert(raw_value);
+                }
+                btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone())),
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Combines this [`Output`] with `other` `Output` (as described by BIP 174).
+    pub fn combine(&mut self, other: Self) {
+        self.bip32_derivation.extend(other.bip32_derivation);
+        self.proprietary.extend(other.proprietary);
+        self.unknown.extend(other.unknown);
+        self.tap_key_origins.extend(other.tap_key_origins);
+
+        combine!(redeem_script, self, other);
+        combine!(witness_script, self, other);
+        combine!(tap_internal_key, self, other);
+        combine!(tap_tree, self, other);
+    }
+}
+
+impl Map for Output {
+    fn get_pairs(&self) -> Vec<raw::Pair> {
+        let mut rv: Vec<raw::Pair> = Default::default();
+
+        impl_psbt_get_pair! {
+            rv.push(self.redeem_script, PSBT_OUT_REDEEM_SCRIPT)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.witness_script, PSBT_OUT_WITNESS_SCRIPT)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.bip32_derivation, PSBT_OUT_BIP32_DERIVATION)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.tap_internal_key, PSBT_OUT_TAP_INTERNAL_KEY)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push(self.tap_tree, PSBT_OUT_TAP_TREE)
+        }
+
+        impl_psbt_get_pair! {
+            rv.push_map(self.tap_key_origins, PSBT_OUT_TAP_BIP32_DERIVATION)
+        }
+
+        for (key, value) in self.proprietary.iter() {
+            rv.push(raw::Pair { key: key.to_key(), value: value.clone() });
+        }
+
+        for (key, value) in self.unknown.iter() {
+            rv.push(raw::Pair { key: key.clone(), value: value.clone() });
+        }
+
+        rv
+    }
+}
+
+impl_psbtmap_ser_de_serialize!(Output);

--- a/libs/bitcoin/src/psbt/mod.rs
+++ b/libs/bitcoin/src/psbt/mod.rs
@@ -1,0 +1,2413 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Partially Signed Bitcoin Transactions.
+//!
+//! Implementation of BIP174 Partially Signed Bitcoin Transaction Format as
+//! defined at <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>
+//! except we define PSBTs containing non-standard sighash types as invalid.
+//!
+
+#[macro_use]
+mod macros;
+mod error;
+mod map;
+pub mod raw;
+pub mod serialize;
+
+use core::{cmp, fmt};
+#[cfg(feature = "std")]
+use std::collections::{HashMap, HashSet};
+
+use internals::write_err;
+use secp256k1::{Keypair, Message, Secp256k1, Signing, Verification};
+
+use crate::bip32::{self, KeySource, Xpriv, Xpub};
+use crate::blockdata::transaction::{self, Transaction, TxOut};
+use crate::crypto::key::{PrivateKey, PublicKey};
+use crate::crypto::{ecdsa, taproot};
+use crate::key::{TapTweak, XOnlyPublicKey};
+use crate::prelude::*;
+use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
+use crate::{Amount, FeeRate, TapLeafHash, TapSighashType};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    map::{Input, Output, PsbtSighashType},
+    error::Error,
+};
+
+/// A Partially Signed Transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Psbt {
+    /// The unsigned transaction, scriptSigs and witnesses for each input must be empty.
+    pub unsigned_tx: Transaction,
+    /// The version number of this PSBT. If omitted, the version number is 0.
+    pub version: u32,
+    /// A global map from extended public keys to the used key fingerprint and
+    /// derivation path as defined by BIP 32.
+    pub xpub: BTreeMap<Xpub, KeySource>,
+    /// Global proprietary key-value pairs.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_utils::btreemap_as_seq_byte_values")
+    )]
+    pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
+    /// Unknown global key-value pairs.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_utils::btreemap_as_seq_byte_values")
+    )]
+    pub unknown: BTreeMap<raw::Key, Vec<u8>>,
+
+    /// The corresponding key-value map for each input in the unsigned transaction.
+    pub inputs: Vec<Input>,
+    /// The corresponding key-value map for each output in the unsigned transaction.
+    pub outputs: Vec<Output>,
+}
+
+impl Psbt {
+    /// Returns an iterator for the funding UTXOs of the psbt
+    ///
+    /// For each PSBT input that contains UTXO information `Ok` is returned containing that information.
+    /// The order of returned items is same as the order of inputs.
+    ///
+    /// ## Errors
+    ///
+    /// The function returns error when UTXO information is not present or is invalid.
+    ///
+    /// ## Panics
+    ///
+    /// The function panics if the length of transaction inputs is not equal to the length of PSBT inputs.
+    pub fn iter_funding_utxos(&self) -> impl Iterator<Item = Result<&TxOut, Error>> {
+        assert_eq!(self.inputs.len(), self.unsigned_tx.input.len());
+        self.unsigned_tx
+            .input
+            .iter()
+            .zip(&self.inputs)
+            .map(|(tx_input, psbt_input)| {
+                match (&psbt_input.witness_utxo, &psbt_input.non_witness_utxo) {
+                    (Some(witness_utxo), _) => Ok(witness_utxo),
+                    (None, Some(non_witness_utxo)) => {
+                        let vout = tx_input.previous_output.vout as usize;
+                        non_witness_utxo
+                            .output
+                            .get(vout)
+                            .ok_or(Error::PsbtUtxoOutOfbounds)
+                    }
+                    (None, None) => Err(Error::MissingUtxo),
+                }
+            })
+    }
+
+    /// Checks that unsigned transaction does not have scriptSig's or witness data.
+    fn unsigned_tx_checks(&self) -> Result<(), Error> {
+        for txin in &self.unsigned_tx.input {
+            if !txin.script_sig.is_empty() {
+                return Err(Error::UnsignedTxHasScriptSigs);
+            }
+
+            if !txin.witness.is_empty() {
+                return Err(Error::UnsignedTxHasScriptWitnesses);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Creates a PSBT from an unsigned transaction.
+    ///
+    /// # Errors
+    ///
+    /// If transactions is not unsigned.
+    pub fn from_unsigned_tx(tx: Transaction) -> Result<Self, Error> {
+        let psbt = Psbt {
+            inputs: vec![Default::default(); tx.input.len()],
+            outputs: vec![Default::default(); tx.output.len()],
+
+            unsigned_tx: tx,
+            xpub: Default::default(),
+            version: 0,
+            proprietary: Default::default(),
+            unknown: Default::default(),
+        };
+        psbt.unsigned_tx_checks()?;
+        Ok(psbt)
+    }
+
+    /// The default `max_fee_rate` value used for extracting transactions with [`extract_tx`]
+    ///
+    /// As of 2023, even the biggest overpayers during the highest fee markets only paid around
+    /// 1000 sats/vByte. 25k sats/vByte is obviously a mistake at this point.
+    ///
+    /// [`extract_tx`]: Psbt::extract_tx
+    pub const DEFAULT_MAX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(25_000);
+
+    /// An alias for [`extract_tx_fee_rate_limit`].
+    ///
+    /// [`extract_tx_fee_rate_limit`]: Psbt::extract_tx_fee_rate_limit
+    pub fn extract_tx(self) -> Result<Transaction, ExtractTxError> {
+        self.internal_extract_tx_with_fee_rate_limit(Self::DEFAULT_MAX_FEE_RATE)
+    }
+
+    /// Extracts the [`Transaction`] from a [`Psbt`] by filling in the available signature information.
+    ///
+    /// ## Errors
+    ///
+    /// [`ExtractTxError`] variants will contain either the [`Psbt`] itself or the [`Transaction`]
+    /// that was extracted. These can be extracted from the Errors in order to recover.
+    /// See the error documentation for info on the variants. In general, it covers large fees.
+    pub fn extract_tx_fee_rate_limit(self) -> Result<Transaction, ExtractTxError> {
+        self.internal_extract_tx_with_fee_rate_limit(Self::DEFAULT_MAX_FEE_RATE)
+    }
+
+    /// Extracts the [`Transaction`] from a [`Psbt`] by filling in the available signature information.
+    ///
+    /// ## Errors
+    ///
+    /// See [`extract_tx`].
+    ///
+    /// [`extract_tx`]: Psbt::extract_tx
+    pub fn extract_tx_with_fee_rate_limit(
+        self,
+        max_fee_rate: FeeRate,
+    ) -> Result<Transaction, ExtractTxError> {
+        self.internal_extract_tx_with_fee_rate_limit(max_fee_rate)
+    }
+
+    /// Perform [`extract_tx_fee_rate_limit`] without the fee rate check.
+    ///
+    /// This can result in a transaction with absurdly high fees. Use with caution.
+    ///
+    /// [`extract_tx_fee_rate_limit`]: Psbt::extract_tx_fee_rate_limit
+    pub fn extract_tx_unchecked_fee_rate(self) -> Transaction {
+        self.internal_extract_tx()
+    }
+
+    #[inline]
+    fn internal_extract_tx(self) -> Transaction {
+        let mut tx: Transaction = self.unsigned_tx;
+
+        for (vin, psbtin) in tx.input.iter_mut().zip(self.inputs.into_iter()) {
+            vin.script_sig = psbtin.final_script_sig.unwrap_or_default();
+            vin.witness = psbtin.final_script_witness.unwrap_or_default();
+        }
+
+        tx
+    }
+
+    #[inline]
+    fn internal_extract_tx_with_fee_rate_limit(
+        self,
+        max_fee_rate: FeeRate,
+    ) -> Result<Transaction, ExtractTxError> {
+        let fee = match self.fee() {
+            Ok(fee) => fee,
+            Err(Error::MissingUtxo) => {
+                return Err(ExtractTxError::MissingInputValue {
+                    tx: self.internal_extract_tx(),
+                })
+            }
+            Err(Error::NegativeFee) => return Err(ExtractTxError::SendingTooMuch { psbt: self }),
+            Err(Error::FeeOverflow) => {
+                return Err(ExtractTxError::AbsurdFeeRate {
+                    fee_rate: FeeRate::MAX,
+                    tx: self.internal_extract_tx(),
+                })
+            }
+            _ => unreachable!(),
+        };
+
+        // Note: Move prevents usage of &self from now on.
+        let tx = self.internal_extract_tx();
+
+        // Now that the extracted Transaction is made, decide how to return it.
+        let fee_rate =
+            FeeRate::from_sat_per_kwu(fee.to_sat().saturating_mul(1000) / tx.weight().to_wu());
+        // Prefer to return an AbsurdFeeRate error when both trigger.
+        if fee_rate > max_fee_rate {
+            return Err(ExtractTxError::AbsurdFeeRate { fee_rate, tx });
+        }
+
+        Ok(tx)
+    }
+
+    /// Combines this [`Psbt`] with `other` PSBT as described by BIP 174.
+    ///
+    /// In accordance with BIP 174 this function is commutative i.e., `A.combine(B) == B.combine(A)`
+    pub fn combine(&mut self, other: Self) -> Result<(), Error> {
+        if self.unsigned_tx != other.unsigned_tx {
+            return Err(Error::UnexpectedUnsignedTx {
+                expected: Box::new(self.unsigned_tx.clone()),
+                actual: Box::new(other.unsigned_tx),
+            });
+        }
+
+        // BIP 174: The Combiner must remove any duplicate key-value pairs, in accordance with
+        //          the specification. It can pick arbitrarily when conflicts occur.
+
+        // Keeping the highest version
+        self.version = cmp::max(self.version, other.version);
+
+        // Merging xpubs
+        for (xpub, (fingerprint1, derivation1)) in other.xpub {
+            match self.xpub.entry(xpub) {
+                btree_map::Entry::Vacant(entry) => {
+                    entry.insert((fingerprint1, derivation1));
+                }
+                btree_map::Entry::Occupied(mut entry) => {
+                    // Here in case of the conflict we select the version with algorithm:
+                    // 1) if everything is equal we do nothing
+                    // 2) report an error if
+                    //    - derivation paths are equal and fingerprints are not
+                    //    - derivation paths are of the same length, but not equal
+                    //    - derivation paths has different length, but the shorter one
+                    //      is not the strict suffix of the longer one
+                    // 3) choose longest derivation otherwise
+
+                    let (fingerprint2, derivation2) = entry.get().clone();
+
+                    if (derivation1 == derivation2 && fingerprint1 == fingerprint2)
+                        || (derivation1.len() < derivation2.len()
+                            && derivation1[..]
+                                == derivation2[derivation2.len() - derivation1.len()..])
+                    {
+                        continue;
+                    } else if derivation2[..]
+                        == derivation1[derivation1.len() - derivation2.len()..]
+                    {
+                        entry.insert((fingerprint1, derivation1));
+                        continue;
+                    }
+                    return Err(Error::CombineInconsistentKeySources(Box::new(xpub)));
+                }
+            }
+        }
+
+        self.proprietary.extend(other.proprietary);
+        self.unknown.extend(other.unknown);
+
+        for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs.into_iter()) {
+            self_input.combine(other_input);
+        }
+
+        for (self_output, other_output) in self.outputs.iter_mut().zip(other.outputs.into_iter()) {
+            self_output.combine(other_output);
+        }
+
+        Ok(())
+    }
+
+    /// Attempts to create _all_ the required signatures for this PSBT using `k`.
+    ///
+    /// If you just want to sign an input with one specific key consider using `sighash_ecdsa` or
+    /// `sighash_taproot`. This function does not support scripts that contain `OP_CODESEPARATOR`.
+    ///
+    /// # Returns
+    ///
+    /// A map of input index -> keys used to sign, for Taproot specifics please see [`SigningKeys`].
+    ///
+    /// If an error is returned some signatures may already have been added to the PSBT. Since
+    /// `partial_sigs` is a [`BTreeMap`] it is safe to retry, previous sigs will be overwritten.
+    pub fn sign<C, K>(
+        &mut self,
+        k: &K,
+        secp: &Secp256k1<C>,
+    ) -> Result<SigningKeysMap, (SigningKeysMap, SigningErrors)>
+    where
+        C: Signing + Verification,
+        K: GetKey,
+    {
+        let tx = self.unsigned_tx.clone(); // clone because we need to mutably borrow when signing.
+        let mut cache = SighashCache::new(&tx);
+
+        let mut used = BTreeMap::new();
+        let mut errors = BTreeMap::new();
+
+        for i in 0..self.inputs.len() {
+            match self.signing_algorithm(i) {
+                Ok(SigningAlgorithm::Ecdsa) => {
+                    match self.bip32_sign_ecdsa(k, i, &mut cache, secp) {
+                        Ok(v) => {
+                            used.insert(i, SigningKeys::Ecdsa(v));
+                        }
+                        Err(e) => {
+                            errors.insert(i, e);
+                        }
+                    }
+                }
+                Ok(SigningAlgorithm::Schnorr) => {
+                    match self.bip32_sign_schnorr(k, i, &mut cache, secp) {
+                        Ok(v) => {
+                            used.insert(i, SigningKeys::Schnorr(v));
+                        }
+                        Err(e) => {
+                            errors.insert(i, e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    errors.insert(i, e);
+                }
+            }
+        }
+        if errors.is_empty() {
+            Ok(used)
+        } else {
+            Err((used, errors))
+        }
+    }
+
+    /// Attempts to create all signatures required by this PSBT's `bip32_derivation` field, adding
+    /// them to `partial_sigs`.
+    ///
+    /// # Returns
+    ///
+    /// - Ok: A list of the public keys used in signing.
+    /// - Err: Error encountered trying to calculate the sighash AND we had the signing key.
+    fn bip32_sign_ecdsa<C, K, T>(
+        &mut self,
+        k: &K,
+        input_index: usize,
+        cache: &mut SighashCache<T>,
+        secp: &Secp256k1<C>,
+    ) -> Result<Vec<PublicKey>, SignError>
+    where
+        C: Signing,
+        T: Borrow<Transaction>,
+        K: GetKey,
+    {
+        let msg_sighash_ty_res = self.sighash_ecdsa(input_index, cache);
+
+        let input = &mut self.inputs[input_index]; // Index checked in call to `sighash_ecdsa`.
+
+        let mut used = vec![]; // List of pubkeys used to sign the input.
+
+        for (pk, key_source) in input.bip32_derivation.iter() {
+            let sk = if let Ok(Some(sk)) = k.get_key(KeyRequest::Bip32(key_source.clone()), secp) {
+                sk
+            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(PublicKey::new(*pk)), secp) {
+                sk
+            } else {
+                continue;
+            };
+
+            // Only return the error if we have a secret key to sign this input.
+            let (msg, sighash_ty) = match msg_sighash_ty_res {
+                Err(e) => return Err(e),
+                Ok((msg, sighash_ty)) => (msg, sighash_ty),
+            };
+
+            let sig = ecdsa::Signature {
+                signature: secp.sign_ecdsa(&msg, &sk.inner),
+                sighash_type: sighash_ty,
+            };
+
+            let pk = sk.public_key(secp);
+
+            input.partial_sigs.insert(pk, sig);
+            used.push(pk);
+        }
+
+        Ok(used)
+    }
+
+    /// Attempts to create all signatures required by this PSBT's `tap_key_origins` field, adding
+    /// them to `tap_key_sig` or `tap_script_sigs`.
+    ///
+    /// # Returns
+    ///
+    /// - Ok: A list of the xonly public keys used in signing. When signing a key path spend we
+    ///   return the internal key.
+    /// - Err: Error encountered trying to calculate the sighash AND we had the signing key.
+    fn bip32_sign_schnorr<C, K, T>(
+        &mut self,
+        k: &K,
+        input_index: usize,
+        cache: &mut SighashCache<T>,
+        secp: &Secp256k1<C>,
+    ) -> Result<Vec<XOnlyPublicKey>, SignError>
+    where
+        C: Signing + Verification,
+        T: Borrow<Transaction>,
+        K: GetKey,
+    {
+        let mut input = self.checked_input(input_index)?.clone();
+
+        let mut used = vec![]; // List of pubkeys used to sign the input.
+
+        for (&xonly, (leaf_hashes, key_source)) in input.tap_key_origins.iter() {
+            let sk = if let Ok(Some(secret_key)) =
+                k.get_key(KeyRequest::Bip32(key_source.clone()), secp)
+            {
+                secret_key
+            } else {
+                continue;
+            };
+
+            // Considering the responsibility of the PSBT's finalizer to extract valid signatures,
+            // the goal of this algorithm is to provide signatures to the best of our ability:
+            // 1) If the conditions for key path spend are met, proceed to provide the signature for key path spend
+            // 2) If the conditions for script path spend are met, proceed to provide the signature for script path spend
+
+            // key path spend
+            if let Some(internal_key) = input.tap_internal_key {
+                // BIP 371: The internal key does not have leaf hashes, so can be indicated with a hashes len of 0.
+
+                // Based on input.tap_internal_key.is_some() alone, it is not sufficient to determine whether it is a key path spend.
+                // According to BIP 371, we also need to consider the condition leaf_hashes.is_empty() for a more accurate determination.
+                if internal_key == xonly && leaf_hashes.is_empty() && input.tap_key_sig.is_none() {
+                    let (msg, sighash_type) = self.sighash_taproot(input_index, cache, None)?;
+                    let key_pair = Keypair::from_secret_key(secp, &sk.inner)
+                        .tap_tweak(secp, input.tap_merkle_root)
+                        .to_inner();
+
+                    #[cfg(feature = "rand-std")]
+                    let signature = secp.sign_schnorr(&msg, &key_pair);
+                    #[cfg(not(feature = "rand-std"))]
+                    let signature = secp.sign_schnorr_no_aux_rand(&msg, &key_pair);
+
+                    let signature = taproot::Signature {
+                        signature,
+                        sighash_type,
+                    };
+                    input.tap_key_sig = Some(signature);
+
+                    used.push(internal_key);
+                }
+            }
+
+            // script path spend
+            if let Some((leaf_hashes, _)) = input.tap_key_origins.get(&xonly) {
+                let leaf_hashes = leaf_hashes
+                    .iter()
+                    .filter(|lh| !input.tap_script_sigs.contains_key(&(xonly, **lh)))
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                if !leaf_hashes.is_empty() {
+                    let key_pair = Keypair::from_secret_key(secp, &sk.inner);
+
+                    for lh in leaf_hashes {
+                        let (msg, sighash_type) =
+                            self.sighash_taproot(input_index, cache, Some(lh))?;
+
+                        #[cfg(feature = "rand-std")]
+                        let signature = secp.sign_schnorr(&msg, &key_pair);
+                        #[cfg(not(feature = "rand-std"))]
+                        let signature = secp.sign_schnorr_no_aux_rand(&msg, &key_pair);
+
+                        let signature = taproot::Signature {
+                            signature,
+                            sighash_type,
+                        };
+                        input.tap_script_sigs.insert((xonly, lh), signature);
+                    }
+
+                    used.push(sk.public_key(secp).into());
+                }
+            }
+        }
+
+        self.inputs[input_index] = input; // input_index is checked above.
+
+        Ok(used)
+    }
+
+    /// Returns the sighash message to sign an ECDSA input along with the sighash type.
+    ///
+    /// Uses the [`EcdsaSighashType`] from this input if one is specified. If no sighash type is
+    /// specified uses [`EcdsaSighashType::All`]. This function does not support scripts that
+    /// contain `OP_CODESEPARATOR`.
+    pub fn sighash_ecdsa<T: Borrow<Transaction>>(
+        &self,
+        input_index: usize,
+        cache: &mut SighashCache<T>,
+    ) -> Result<(Message, EcdsaSighashType), SignError> {
+        use OutputType::*;
+
+        if self.signing_algorithm(input_index)? != SigningAlgorithm::Ecdsa {
+            return Err(SignError::WrongSigningAlgorithm);
+        }
+
+        let input = self.checked_input(input_index)?;
+        let utxo = self.spend_utxo(input_index)?;
+        let spk = &utxo.script_pubkey; // scriptPubkey for input spend utxo.
+
+        let hash_ty = input
+            .ecdsa_hash_ty()
+            .map_err(|_| SignError::InvalidSighashType)?; // Only support standard sighash types.
+
+        match self.output_type(input_index)? {
+            Bare => {
+                let sighash = cache
+                    .legacy_signature_hash(input_index, spk, hash_ty.to_u32())
+                    .expect("input checked above");
+                Ok((Message::from(sighash), hash_ty))
+            }
+            Sh => {
+                let script_code = input
+                    .redeem_script
+                    .as_ref()
+                    .ok_or(SignError::MissingRedeemScript)?;
+                let sighash = cache
+                    .legacy_signature_hash(input_index, script_code, hash_ty.to_u32())
+                    .expect("input checked above");
+                Ok((Message::from(sighash), hash_ty))
+            }
+            Wpkh => {
+                let sighash = cache.p2wpkh_signature_hash(input_index, spk, utxo.value, hash_ty)?;
+                Ok((Message::from(sighash), hash_ty))
+            }
+            ShWpkh => {
+                let redeem_script = input.redeem_script.as_ref().expect("checked above");
+                let sighash =
+                    cache.p2wpkh_signature_hash(input_index, redeem_script, utxo.value, hash_ty)?;
+                Ok((Message::from(sighash), hash_ty))
+            }
+            Wsh | ShWsh => {
+                let witness_script = input
+                    .witness_script
+                    .as_ref()
+                    .ok_or(SignError::MissingWitnessScript)?;
+                let sighash = cache
+                    .p2wsh_signature_hash(input_index, witness_script, utxo.value, hash_ty)
+                    .map_err(SignError::SegwitV0Sighash)?;
+                Ok((Message::from(sighash), hash_ty))
+            }
+            Tr => {
+                // This PSBT signing API is WIP, taproot to come shortly.
+                Err(SignError::Unsupported)
+            }
+        }
+    }
+
+    /// Returns the sighash message to sign an SCHNORR input along with the sighash type.
+    ///
+    /// Uses the [`TapSighashType`] from this input if one is specified. If no sighash type is
+    /// specified uses [`TapSighashType::Default`].
+    fn sighash_taproot<T: Borrow<Transaction>>(
+        &self,
+        input_index: usize,
+        cache: &mut SighashCache<T>,
+        leaf_hash: Option<TapLeafHash>,
+    ) -> Result<(Message, TapSighashType), SignError> {
+        use OutputType::*;
+
+        if self.signing_algorithm(input_index)? != SigningAlgorithm::Schnorr {
+            return Err(SignError::WrongSigningAlgorithm);
+        }
+
+        let input = self.checked_input(input_index)?;
+
+        match self.output_type(input_index)? {
+            Tr => {
+                let hash_ty = input
+                    .sighash_type
+                    .unwrap_or_else(|| TapSighashType::Default.into())
+                    .taproot_hash_ty()
+                    .map_err(|_| SignError::InvalidSighashType)?;
+
+                let spend_utxos = (0..self.inputs.len())
+                    .map(|i| self.spend_utxo(i).ok())
+                    .collect::<Vec<_>>();
+                let all_spend_utxos;
+
+                let is_anyone_can_pay = PsbtSighashType::from(hash_ty).to_u32() & 0x80 != 0;
+
+                let prev_outs = if is_anyone_can_pay {
+                    Prevouts::One(
+                        input_index,
+                        spend_utxos[input_index].ok_or(SignError::MissingSpendUtxo)?,
+                    )
+                } else if spend_utxos.iter().all(Option::is_some) {
+                    all_spend_utxos = spend_utxos.iter().filter_map(|x| *x).collect::<Vec<_>>();
+                    Prevouts::All(&all_spend_utxos)
+                } else {
+                    return Err(SignError::MissingSpendUtxo);
+                };
+
+                let sighash = if let Some(leaf_hash) = leaf_hash {
+                    cache.taproot_script_spend_signature_hash(
+                        input_index,
+                        &prev_outs,
+                        leaf_hash,
+                        hash_ty,
+                    )?
+                } else {
+                    cache.taproot_key_spend_signature_hash(input_index, &prev_outs, hash_ty)?
+                };
+                Ok((Message::from(sighash), hash_ty))
+            }
+            _ => Err(SignError::Unsupported),
+        }
+    }
+
+    /// Returns the spending utxo for this PSBT's input at `input_index`.
+    pub fn spend_utxo(&self, input_index: usize) -> Result<&TxOut, SignError> {
+        let input = self.checked_input(input_index)?;
+        let utxo = if let Some(witness_utxo) = &input.witness_utxo {
+            witness_utxo
+        } else if let Some(non_witness_utxo) = &input.non_witness_utxo {
+            let vout = self.unsigned_tx.input[input_index].previous_output.vout;
+            &non_witness_utxo.output[vout as usize]
+        } else {
+            return Err(SignError::MissingSpendUtxo);
+        };
+        Ok(utxo)
+    }
+
+    /// Gets the input at `input_index` after checking that it is a valid index.
+    fn checked_input(&self, input_index: usize) -> Result<&Input, IndexOutOfBoundsError> {
+        self.check_index_is_within_bounds(input_index)?;
+        Ok(&self.inputs[input_index])
+    }
+
+    /// Checks `input_index` is within bounds for the PSBT `inputs` array and
+    /// for the PSBT `unsigned_tx` `input` array.
+    fn check_index_is_within_bounds(
+        &self,
+        input_index: usize,
+    ) -> Result<(), IndexOutOfBoundsError> {
+        if input_index >= self.inputs.len() {
+            return Err(IndexOutOfBoundsError::Inputs {
+                index: input_index,
+                length: self.inputs.len(),
+            });
+        }
+
+        if input_index >= self.unsigned_tx.input.len() {
+            return Err(IndexOutOfBoundsError::TxInput {
+                index: input_index,
+                length: self.unsigned_tx.input.len(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Returns the algorithm used to sign this PSBT's input at `input_index`.
+    fn signing_algorithm(&self, input_index: usize) -> Result<SigningAlgorithm, SignError> {
+        let output_type = self.output_type(input_index)?;
+        Ok(output_type.signing_algorithm())
+    }
+
+    /// Returns the [`OutputType`] of the spend utxo for this PBST's input at `input_index`.
+    fn output_type(&self, input_index: usize) -> Result<OutputType, SignError> {
+        let input = self.checked_input(input_index)?;
+        let utxo = self.spend_utxo(input_index)?;
+        let spk = utxo.script_pubkey.clone();
+
+        // Anything that is not segwit and is not p2sh is `Bare`.
+        if !(spk.is_witness_program() || spk.is_p2sh()) {
+            return Ok(OutputType::Bare);
+        }
+
+        if spk.is_p2wpkh() {
+            return Ok(OutputType::Wpkh);
+        }
+
+        if spk.is_p2wsh() {
+            return Ok(OutputType::Wsh);
+        }
+
+        if spk.is_p2sh() {
+            if input
+                .redeem_script
+                .as_ref()
+                .map(|s| s.is_p2wpkh())
+                .unwrap_or(false)
+            {
+                return Ok(OutputType::ShWpkh);
+            }
+            if input
+                .redeem_script
+                .as_ref()
+                .map(|x| x.is_p2wsh())
+                .unwrap_or(false)
+            {
+                return Ok(OutputType::ShWsh);
+            }
+            return Ok(OutputType::Sh);
+        }
+
+        if spk.is_p2tr() {
+            return Ok(OutputType::Tr);
+        }
+
+        // Something is wrong with the input scriptPubkey or we do not know how to sign
+        // because there has been a new softfork that we do not yet support.
+        Err(SignError::UnknownOutputType)
+    }
+
+    /// Calculates transaction fee.
+    ///
+    /// 'Fee' being the amount that will be paid for mining a transaction with the current inputs
+    /// and outputs i.e., the difference in value of the total inputs and the total outputs.
+    ///
+    /// ## Errors
+    ///
+    /// - [`Error::MissingUtxo`] when UTXO information for any input is not present or is invalid.
+    /// - [`Error::NegativeFee`] if calculated value is negative.
+    /// - [`Error::FeeOverflow`] if an integer overflow occurs.
+    pub fn fee(&self) -> Result<Amount, Error> {
+        let mut inputs: u64 = 0;
+        for utxo in self.iter_funding_utxos() {
+            inputs = inputs
+                .checked_add(utxo?.value.to_sat())
+                .ok_or(Error::FeeOverflow)?;
+        }
+        let mut outputs: u64 = 0;
+        for out in &self.unsigned_tx.output {
+            outputs = outputs
+                .checked_add(out.value.to_sat())
+                .ok_or(Error::FeeOverflow)?;
+        }
+        inputs
+            .checked_sub(outputs)
+            .map(Amount::from_sat)
+            .ok_or(Error::NegativeFee)
+    }
+}
+
+/// Data required to call [`GetKey`] to get the private key to sign an input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KeyRequest {
+    /// Request a private key using the associated public key.
+    Pubkey(PublicKey),
+    /// Request a private key using BIP-32 fingerprint and derivation path.
+    Bip32(KeySource),
+}
+
+/// Trait to get a private key from a key request, key is then used to sign an input.
+pub trait GetKey {
+    /// An error occurred while getting the key.
+    type Error: core::fmt::Debug;
+
+    /// Attempts to get the private key for `key_request`.
+    ///
+    /// # Returns
+    /// - `Some(key)` if the key is found.
+    /// - `None` if the key was not found but no error was encountered.
+    /// - `Err` if an error was encountered while looking for the key.
+    fn get_key<C: Signing>(
+        &self,
+        key_request: KeyRequest,
+        secp: &Secp256k1<C>,
+    ) -> Result<Option<PrivateKey>, Self::Error>;
+}
+
+impl GetKey for Xpriv {
+    type Error = GetKeyError;
+
+    fn get_key<C: Signing>(
+        &self,
+        key_request: KeyRequest,
+        secp: &Secp256k1<C>,
+    ) -> Result<Option<PrivateKey>, Self::Error> {
+        match key_request {
+            KeyRequest::Pubkey(_) => Err(GetKeyError::NotSupported),
+            KeyRequest::Bip32((fingerprint, path)) => {
+                let key = if self.fingerprint(secp) == fingerprint {
+                    let k = self.derive_priv(secp, &path)?;
+                    Some(k.to_priv())
+                } else {
+                    None
+                };
+                Ok(key)
+            }
+        }
+    }
+}
+
+/// Map of input index -> signing key for that input (see [`SigningKeys`]).
+pub type SigningKeysMap = BTreeMap<usize, SigningKeys>;
+
+/// A list of keys used to sign an input.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SigningKeys {
+    /// Keys used to sign an ECDSA input.
+    Ecdsa(Vec<PublicKey>),
+    /// Keys used to sign a Taproot input.
+    ///
+    /// - Key path spend: This is the internal key.
+    /// - Script path spend: This is the pubkey associated with the secret key that signed.
+    Schnorr(Vec<XOnlyPublicKey>),
+}
+
+/// Map of input index -> the error encountered while attempting to sign that input.
+pub type SigningErrors = BTreeMap<usize, SignError>;
+
+#[rustfmt::skip]
+macro_rules! impl_get_key_for_set {
+    ($set:ident) => {
+
+impl GetKey for $set<Xpriv> {
+    type Error = GetKeyError;
+
+    fn get_key<C: Signing>(
+        &self,
+        key_request: KeyRequest,
+        secp: &Secp256k1<C>
+    ) -> Result<Option<PrivateKey>, Self::Error> {
+        match key_request {
+            KeyRequest::Pubkey(_) => Err(GetKeyError::NotSupported),
+            KeyRequest::Bip32((fingerprint, path)) => {
+                for xpriv in self.iter() {
+                    if xpriv.parent_fingerprint == fingerprint {
+                        let k = xpriv.derive_priv(secp, &path)?;
+                        return Ok(Some(k.to_priv()));
+                    }
+                }
+                Ok(None)
+            }
+        }
+    }
+}}}
+impl_get_key_for_set!(BTreeSet);
+#[cfg(feature = "std")]
+impl_get_key_for_set!(HashSet);
+
+#[rustfmt::skip]
+macro_rules! impl_get_key_for_map {
+    ($map:ident) => {
+
+impl GetKey for $map<PublicKey, PrivateKey> {
+    type Error = GetKeyError;
+
+    fn get_key<C: Signing>(
+        &self,
+        key_request: KeyRequest,
+        _: &Secp256k1<C>,
+    ) -> Result<Option<PrivateKey>, Self::Error> {
+        match key_request {
+            KeyRequest::Pubkey(pk) => Ok(self.get(&pk).cloned()),
+            KeyRequest::Bip32(_) => Err(GetKeyError::NotSupported),
+        }
+    }
+}}}
+impl_get_key_for_map!(BTreeMap);
+#[cfg(feature = "std")]
+impl_get_key_for_map!(HashMap);
+
+/// Errors when getting a key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GetKeyError {
+    /// A bip32 error.
+    Bip32(bip32::Error),
+    /// The GetKey operation is not supported for this key request.
+    NotSupported,
+}
+
+internals::impl_from_infallible!(GetKeyError);
+
+impl fmt::Display for GetKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GetKeyError::*;
+
+        match *self {
+            Bip32(ref e) => write_err!(f, "a bip23 error"; e),
+            NotSupported => {
+                f.write_str("the GetKey operation is not supported for this key request")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GetKeyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GetKeyError::*;
+
+        match *self {
+            NotSupported => None,
+            Bip32(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<bip32::Error> for GetKeyError {
+    fn from(e: bip32::Error) -> Self {
+        GetKeyError::Bip32(e)
+    }
+}
+
+/// The various output types supported by the Bitcoin network.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum OutputType {
+    /// An output of type: pay-to-pubkey or pay-to-pubkey-hash.
+    Bare,
+    /// A pay-to-witness-pubkey-hash output (P2WPKH).
+    Wpkh,
+    /// A pay-to-witness-script-hash output (P2WSH).
+    Wsh,
+    /// A nested segwit output, pay-to-witness-pubkey-hash nested in a pay-to-script-hash.
+    ShWpkh,
+    /// A nested segwit output, pay-to-witness-script-hash nested in a pay-to-script-hash.
+    ShWsh,
+    /// A pay-to-script-hash output excluding wrapped segwit (P2SH).
+    Sh,
+    /// A taproot output (P2TR).
+    Tr,
+}
+
+impl OutputType {
+    /// The signing algorithm used to sign this output type.
+    pub fn signing_algorithm(&self) -> SigningAlgorithm {
+        use OutputType::*;
+
+        match self {
+            Bare | Wpkh | Wsh | ShWpkh | ShWsh | Sh => SigningAlgorithm::Ecdsa,
+            Tr => SigningAlgorithm::Schnorr,
+        }
+    }
+}
+
+/// Signing algorithms supported by the Bitcoin network.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SigningAlgorithm {
+    /// The Elliptic Curve Digital Signature Algorithm (see [wikipedia]).
+    ///
+    /// [wikipedia]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+    Ecdsa,
+    /// The Schnorr signature algorithm (see [wikipedia]).
+    ///
+    /// [wikipedia]: https://en.wikipedia.org/wiki/Schnorr_signature
+    Schnorr,
+}
+
+/// Errors encountered while calculating the sighash message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SignError {
+    /// Input index out of bounds.
+    IndexOutOfBounds(IndexOutOfBoundsError),
+    /// Invalid Sighash type.
+    InvalidSighashType,
+    /// Missing input utxo.
+    MissingInputUtxo,
+    /// Missing Redeem script.
+    MissingRedeemScript,
+    /// Missing spending utxo.
+    MissingSpendUtxo,
+    /// Missing witness script.
+    MissingWitnessScript,
+    /// Signing algorithm and key type does not match.
+    MismatchedAlgoKey,
+    /// Attempted to ECDSA sign an non-ECDSA input.
+    NotEcdsa,
+    /// The `scriptPubkey` is not a P2WPKH script.
+    NotWpkh,
+    /// Sighash computation error (segwit v0 input).
+    SegwitV0Sighash(transaction::InputsIndexError),
+    /// Sighash computation error (p2wpkh input).
+    P2wpkhSighash(sighash::P2wpkhError),
+    /// Sighash computation error (taproot input).
+    TaprootError(sighash::TaprootError),
+    /// Unable to determine the output type.
+    UnknownOutputType,
+    /// Unable to find key.
+    KeyNotFound,
+    /// Attempt to sign an input with the wrong signing algorithm.
+    WrongSigningAlgorithm,
+    /// Signing request currently unsupported.
+    Unsupported,
+}
+
+internals::impl_from_infallible!(SignError);
+
+impl fmt::Display for SignError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use SignError::*;
+
+        match *self {
+            IndexOutOfBounds(ref e) => write_err!(f, "index out of bounds"; e),
+            InvalidSighashType => write!(f, "invalid sighash type"),
+            MissingInputUtxo => write!(f, "missing input utxo in PBST"),
+            MissingRedeemScript => write!(f, "missing redeem script"),
+            MissingSpendUtxo => write!(f, "missing spend utxo in PSBT"),
+            MissingWitnessScript => write!(f, "missing witness script"),
+            MismatchedAlgoKey => write!(f, "signing algorithm and key type does not match"),
+            NotEcdsa => write!(f, "attempted to ECDSA sign an non-ECDSA input"),
+            NotWpkh => write!(f, "the scriptPubkey is not a P2WPKH script"),
+            SegwitV0Sighash(ref e) => write_err!(f, "segwit v0 sighash"; e),
+            P2wpkhSighash(ref e) => write_err!(f, "p2wpkh sighash"; e),
+            TaprootError(ref e) => write_err!(f, "taproot sighash"; e),
+            UnknownOutputType => write!(f, "unable to determine the output type"),
+            KeyNotFound => write!(f, "unable to find key"),
+            WrongSigningAlgorithm => write!(
+                f,
+                "attempt to sign an input with the wrong signing algorithm"
+            ),
+            Unsupported => write!(f, "signing request currently unsupported"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SignError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use SignError::*;
+
+        match *self {
+            SegwitV0Sighash(ref e) => Some(e),
+            P2wpkhSighash(ref e) => Some(e),
+            TaprootError(ref e) => Some(e),
+            IndexOutOfBounds(ref e) => Some(e),
+            InvalidSighashType
+            | MissingInputUtxo
+            | MissingRedeemScript
+            | MissingSpendUtxo
+            | MissingWitnessScript
+            | MismatchedAlgoKey
+            | NotEcdsa
+            | NotWpkh
+            | UnknownOutputType
+            | KeyNotFound
+            | WrongSigningAlgorithm
+            | Unsupported => None,
+        }
+    }
+}
+
+impl From<sighash::P2wpkhError> for SignError {
+    fn from(e: sighash::P2wpkhError) -> Self {
+        Self::P2wpkhSighash(e)
+    }
+}
+
+impl From<IndexOutOfBoundsError> for SignError {
+    fn from(e: IndexOutOfBoundsError) -> Self {
+        SignError::IndexOutOfBounds(e)
+    }
+}
+
+impl From<sighash::TaprootError> for SignError {
+    fn from(e: sighash::TaprootError) -> Self {
+        SignError::TaprootError(e)
+    }
+}
+
+/// This error is returned when extracting a [`Transaction`] from a [`Psbt`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExtractTxError {
+    /// The [`FeeRate`] is too high
+    AbsurdFeeRate {
+        /// The [`FeeRate`]
+        fee_rate: FeeRate,
+        /// The extracted [`Transaction`] (use this to ignore the error)
+        tx: Transaction,
+    },
+    /// One or more of the inputs lacks value information (witness_utxo or non_witness_utxo)
+    MissingInputValue {
+        /// The extracted [`Transaction`] (use this to ignore the error)
+        tx: Transaction,
+    },
+    /// Input value is less than Output Value, and the [`Transaction`] would be invalid.
+    SendingTooMuch {
+        /// The original [`Psbt`] is returned untouched.
+        psbt: Psbt,
+    },
+}
+
+internals::impl_from_infallible!(ExtractTxError);
+
+impl fmt::Display for ExtractTxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ExtractTxError::*;
+
+        match *self {
+            AbsurdFeeRate { fee_rate, .. } => {
+                write!(f, "An absurdly high fee rate of {}", fee_rate)
+            }
+            MissingInputValue { .. } => write!(
+                f,
+                "One of the inputs lacked value information (witness_utxo or non_witness_utxo)"
+            ),
+            SendingTooMuch { .. } => write!(
+                f,
+                "Transaction would be invalid due to output value being greater than input value."
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ExtractTxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ExtractTxError::*;
+
+        match *self {
+            AbsurdFeeRate { .. } | MissingInputValue { .. } | SendingTooMuch { .. } => None,
+        }
+    }
+}
+
+/// Input index out of bounds (actual index, maximum index allowed).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IndexOutOfBoundsError {
+    /// The index is out of bounds for the `psbt.inputs` vector.
+    Inputs {
+        /// Attempted index access.
+        index: usize,
+        /// Length of the PBST inputs vector.
+        length: usize,
+    },
+    /// The index is out of bounds for the `psbt.unsigned_tx.input` vector.
+    TxInput {
+        /// Attempted index access.
+        index: usize,
+        /// Length of the PBST's unsigned transaction input vector.
+        length: usize,
+    },
+}
+
+internals::impl_from_infallible!(IndexOutOfBoundsError);
+
+impl fmt::Display for IndexOutOfBoundsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use IndexOutOfBoundsError::*;
+
+        match *self {
+            Inputs {
+                ref index,
+                ref length,
+            } => write!(
+                f,
+                "index {} is out-of-bounds for PSBT inputs vector length {}",
+                index, length
+            ),
+            TxInput {
+                ref index,
+                ref length,
+            } => write!(
+                f,
+                "index {} is out-of-bounds for PSBT unsigned tx input vector length {}",
+                index, length
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IndexOutOfBoundsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use IndexOutOfBoundsError::*;
+
+        match *self {
+            Inputs { .. } | TxInput { .. } => None,
+        }
+    }
+}
+
+#[cfg(feature = "base64")]
+mod display_from_str {
+    use core::fmt::{self, Display, Formatter};
+    use core::str::FromStr;
+
+    use base64::display::Base64Display;
+    use base64::prelude::{Engine as _, BASE64_STANDARD};
+    use internals::write_err;
+
+    use super::{Error, Psbt};
+
+    /// Error encountered during PSBT decoding from Base64 string.
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub enum PsbtParseError {
+        /// Error in internal PSBT data structure.
+        PsbtEncoding(Error),
+        /// Error in PSBT Base64 encoding.
+        Base64Encoding(::base64::DecodeError),
+    }
+
+    internals::impl_from_infallible!(PsbtParseError);
+
+    impl Display for PsbtParseError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            use self::PsbtParseError::*;
+
+            match *self {
+                PsbtEncoding(ref e) => write_err!(f, "error in internal PSBT data structure"; e),
+                Base64Encoding(ref e) => write_err!(f, "error in PSBT base64 encoding"; e),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for PsbtParseError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            use self::PsbtParseError::*;
+
+            match self {
+                PsbtEncoding(e) => Some(e),
+                Base64Encoding(e) => Some(e),
+            }
+        }
+    }
+
+    impl Display for Psbt {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "{}",
+                Base64Display::new(&self.serialize(), &BASE64_STANDARD)
+            )
+        }
+    }
+
+    impl FromStr for Psbt {
+        type Err = PsbtParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let data = BASE64_STANDARD
+                .decode(s)
+                .map_err(PsbtParseError::Base64Encoding)?;
+            Psbt::deserialize(&data).map_err(PsbtParseError::PsbtEncoding)
+        }
+    }
+}
+#[cfg(feature = "base64")]
+pub use self::display_from_str::PsbtParseError;
+
+#[cfg(test)]
+mod tests {
+    use hashes::{hash160, ripemd160, sha256, Hash};
+    use hex::{test_hex_unwrap as hex, FromHex};
+    #[cfg(feature = "rand-std")]
+    use secp256k1::{All, SecretKey};
+
+    use super::*;
+    use crate::bip32::ChildNumber;
+    use crate::blockdata::locktime::absolute;
+    use crate::blockdata::script::ScriptBuf;
+    use crate::blockdata::transaction::{self, OutPoint, Sequence, TxIn};
+    use crate::blockdata::witness::Witness;
+    use crate::network::NetworkKind;
+    use crate::psbt::serialize::{Deserialize, Serialize};
+
+    #[track_caller]
+    pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {
+        let r = Vec::from_hex(s);
+        match r {
+            Err(_e) => panic!("unable to parse hex string {}", s),
+            Ok(v) => Psbt::deserialize(&v),
+        }
+    }
+
+    #[track_caller]
+    fn psbt_with_values(input: u64, output: u64) -> Psbt {
+        Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: OutPoint {
+                        txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126"
+                            .parse()
+                            .unwrap(),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                    witness: Witness::default(),
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(output),
+                    script_pubkey: ScriptBuf::from_hex(
+                        "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787",
+                    )
+                    .unwrap(),
+                }],
+            },
+            xpub: Default::default(),
+            version: 0,
+            proprietary: BTreeMap::new(),
+            unknown: BTreeMap::new(),
+
+            inputs: vec![Input {
+                witness_utxo: Some(TxOut {
+                    value: Amount::from_sat(input),
+                    script_pubkey: ScriptBuf::from_hex(
+                        "a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587",
+                    )
+                    .unwrap(),
+                }),
+                ..Default::default()
+            }],
+            outputs: vec![],
+        }
+    }
+
+    #[test]
+    fn trivial_psbt() {
+        let psbt = Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![],
+                output: vec![],
+            },
+            xpub: Default::default(),
+            version: 0,
+            proprietary: BTreeMap::new(),
+            unknown: BTreeMap::new(),
+
+            inputs: vec![],
+            outputs: vec![],
+        };
+        assert_eq!(
+            psbt.serialize_hex(),
+            "70736274ff01000a0200000000000000000000"
+        );
+    }
+
+    #[test]
+    fn psbt_uncompressed_key() {
+        let psbt: Psbt = hex_psbt("70736274ff01003302000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff000000000000420204bb0d5d0cca36e7b9c80f63bc04c1240babb83bcd2803ef7ac8b6e2af594291daec281e856c98d210c5ab14dfd5828761f8ee7d5f45ca21ad3e4c4b41b747a3a047304402204f67e2afb76142d44fae58a2495d33a3419daa26cd0db8d04f3452b63289ac0f022010762a9fb67e94cc5cad9026f6dc99ff7f070f4278d30fbc7d0c869dd38c7fe70100").unwrap();
+        assert!(psbt.inputs[0].partial_sigs.len() == 1);
+        let pk = psbt.inputs[0].partial_sigs.iter().next().unwrap().0;
+        assert!(!pk.compressed);
+    }
+
+    #[test]
+    fn psbt_high_fee_checks() {
+        let psbt = psbt_with_values(5_000_000_000_000, 1000);
+        assert_eq!(
+            psbt.clone().extract_tx().map_err(|e| match e {
+                ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
+                _ => panic!(""),
+            }),
+            Err(FeeRate::from_sat_per_kwu(15060240960843))
+        );
+        assert_eq!(
+            psbt.clone()
+                .extract_tx_fee_rate_limit()
+                .map_err(|e| match e {
+                    ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
+                    _ => panic!(""),
+                }),
+            Err(FeeRate::from_sat_per_kwu(15060240960843))
+        );
+        assert_eq!(
+            psbt.clone()
+                .extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_kwu(15060240960842))
+                .map_err(|e| match e {
+                    ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
+                    _ => panic!(""),
+                }),
+            Err(FeeRate::from_sat_per_kwu(15060240960843))
+        );
+        assert!(psbt
+            .extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_kwu(15060240960843))
+            .is_ok());
+
+        // Testing that extract_tx will error at 25k sat/vbyte (6250000 sat/kwu)
+        assert_eq!(
+            psbt_with_values(2076001, 1000)
+                .extract_tx()
+                .map_err(|e| match e {
+                    ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
+                    _ => panic!(""),
+                }),
+            Err(FeeRate::from_sat_per_kwu(6250003)) // 6250000 is 25k sat/vbyte
+        );
+
+        // Lowering the input satoshis by 1 lowers the sat/kwu by 3
+        // Putting it exactly at 25k sat/vbyte
+        assert!(psbt_with_values(2076000, 1000).extract_tx().is_ok());
+    }
+
+    #[test]
+    fn serialize_then_deserialize_output() {
+        let secp = &Secp256k1::new();
+        let seed = hex!("000102030405060708090a0b0c0d0e0f");
+
+        let mut hd_keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = Default::default();
+
+        let mut sk: Xpriv = Xpriv::new_master(NetworkKind::Main, &seed).unwrap();
+
+        let fprint = sk.fingerprint(secp);
+
+        let dpath: Vec<ChildNumber> = vec![
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(1).unwrap(),
+            ChildNumber::from_normal_idx(2).unwrap(),
+            ChildNumber::from_normal_idx(4).unwrap(),
+            ChildNumber::from_normal_idx(42).unwrap(),
+            ChildNumber::from_hardened_idx(69).unwrap(),
+            ChildNumber::from_normal_idx(420).unwrap(),
+            ChildNumber::from_normal_idx(31337).unwrap(),
+        ];
+
+        sk = sk.derive_priv(secp, &dpath).unwrap();
+
+        let pk = Xpub::from_priv(secp, &sk);
+
+        hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
+
+        let expected: Output = Output {
+            redeem_script: Some(
+                ScriptBuf::from_hex("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac").unwrap(),
+            ),
+            witness_script: Some(
+                ScriptBuf::from_hex("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787").unwrap(),
+            ),
+            bip32_derivation: hd_keypaths,
+            ..Default::default()
+        };
+
+        let actual = Output::deserialize(&expected.serialize()).unwrap();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn serialize_then_deserialize_global() {
+        let expected = Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::from_consensus(1257139),
+                input: vec![TxIn {
+                    previous_output: OutPoint {
+                        txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126"
+                            .parse()
+                            .unwrap(),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                    witness: Witness::default(),
+                }],
+                output: vec![
+                    TxOut {
+                        value: Amount::from_sat(99_999_699),
+                        script_pubkey: ScriptBuf::from_hex(
+                            "76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac",
+                        )
+                        .unwrap(),
+                    },
+                    TxOut {
+                        value: Amount::from_sat(100_000_000),
+                        script_pubkey: ScriptBuf::from_hex(
+                            "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787",
+                        )
+                        .unwrap(),
+                    },
+                ],
+            },
+            xpub: Default::default(),
+            version: 0,
+            proprietary: Default::default(),
+            unknown: Default::default(),
+            inputs: vec![Input::default()],
+            outputs: vec![Output::default(), Output::default()],
+        };
+
+        let actual: Psbt = Psbt::deserialize(&expected.serialize()).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn serialize_then_deserialize_psbtkvpair() {
+        let expected = raw::Pair {
+            key: raw::Key {
+                type_value: 0u8,
+                key: vec![42u8, 69u8],
+            },
+            value: vec![69u8, 42u8, 4u8],
+        };
+
+        let actual = raw::Pair::deserialize(&expected.serialize()).unwrap();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn deserialize_and_serialize_psbt_with_two_partial_sigs() {
+        let hex = "70736274ff0100890200000001207ae985d787dfe6143d5c58fad79cc7105e0e799fcf033b7f2ba17e62d7b3200000000000ffffffff02563d03000000000022002019899534b9a011043c0dd57c3ff9a381c3522c5f27c6a42319085b56ca543a1d6adc020000000000220020618b47a07ebecca4e156edb1b9ea7c24bdee0139fc049237965ffdaf56d5ee73000000000001012b801a0600000000002200201148e93e9315e37dbed2121be5239257af35adc03ffdfc5d914b083afa44dab82202025fe7371376d53cf8a2783917c28bf30bd690b0a4d4a207690093ca2b920ee076473044022007e06b362e89912abd4661f47945430739b006a85d1b2a16c01dc1a4bd07acab022061576d7aa834988b7ab94ef21d8eebd996ea59ea20529a19b15f0c9cebe3d8ac01220202b3fe93530020a8294f0e527e33fbdff184f047eb6b5a1558a352f62c29972f8a473044022002787f926d6817504431ee281183b8119b6845bfaa6befae45e13b6d430c9d2f02202859f149a6cd26ae2f03a107e7f33c7d91730dade305fe077bae677b5d44952a01010547522102b3fe93530020a8294f0e527e33fbdff184f047eb6b5a1558a352f62c29972f8a21025fe7371376d53cf8a2783917c28bf30bd690b0a4d4a207690093ca2b920ee07652ae0001014752210283ef76537f2d58ae3aa3a4bd8ae41c3f230ccadffb1a0bd3ca504d871cff05e7210353d79cc0cb1396f4ce278d005f16d948e02a6aec9ed1109f13747ecb1507b37b52ae00010147522102b3937241777b6665e0d694e52f9c1b188433641df852da6fc42187b5d8a368a321034cdd474f01cc5aa7ff834ad8bcc882a87e854affc775486bc2a9f62e8f49bd7852ae00";
+        let psbt: Psbt = hex_psbt(hex).unwrap();
+        assert_eq!(hex, psbt.serialize_hex());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_psbt() {
+        //! Create a full PSBT value with various fields filled and make sure it can be JSONized.
+        use hashes::sha256d;
+
+        use crate::psbt::map::Input;
+
+        // create some values to use in the PSBT
+        let tx = Transaction {
+            version: transaction::Version::ONE,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389"
+                        .parse()
+                        .unwrap(),
+                    vout: 1,
+                },
+                script_sig: ScriptBuf::from_hex("160014be18d152a9b012039daf3da7de4f53349eecb985")
+                    .unwrap(),
+                sequence: Sequence::MAX,
+                witness: Witness::from_slice(&[hex!(
+                    "03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105"
+                )]),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(190_303_501_938),
+                script_pubkey: ScriptBuf::from_hex(
+                    "a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587",
+                )
+                .unwrap(),
+            }],
+        };
+        let unknown: BTreeMap<raw::Key, Vec<u8>> = vec![(
+            raw::Key {
+                type_value: 1,
+                key: vec![0, 1],
+            },
+            vec![3, 4, 5],
+        )]
+        .into_iter()
+        .collect();
+        let key_source = ("deadbeef".parse().unwrap(), "0'/1".parse().unwrap());
+        let keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = vec![(
+            "0339880dc92394b7355e3d0439fa283c31de7590812ea011c4245c0674a685e883"
+                .parse()
+                .unwrap(),
+            key_source.clone(),
+        )]
+        .into_iter()
+        .collect();
+
+        let proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>> = vec![(
+            raw::ProprietaryKey {
+                prefix: "prefx".as_bytes().to_vec(),
+                subtype: 42,
+                key: "test_key".as_bytes().to_vec(),
+            },
+            vec![5, 6, 7],
+        )]
+        .into_iter()
+        .collect();
+
+        let psbt = Psbt {
+            version: 0,
+            xpub: {
+                let xpub: Xpub =
+                    "xpub661MyMwAqRbcGoRVtwfvzZsq2VBJR1LAHfQstHUoxqDorV89vRoMxUZ27kLrraAj6MPi\
+                    QfrDb27gigC1VS1dBXi5jGpxmMeBXEkKkcXUTg4".parse().unwrap();
+                vec![(xpub, key_source)].into_iter().collect()
+            },
+            unsigned_tx: {
+                let mut unsigned = tx.clone();
+                unsigned.input[0].script_sig = ScriptBuf::new();
+                unsigned.input[0].witness = Witness::default();
+                unsigned
+            },
+            proprietary: proprietary.clone(),
+            unknown: unknown.clone(),
+
+            inputs: vec![
+                Input {
+                    non_witness_utxo: Some(tx),
+                    witness_utxo: Some(TxOut {
+                        value: Amount::from_sat(190_303_501_938),
+                        script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
+                    }),
+                    sighash_type: Some("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY".parse::<PsbtSighashType>().unwrap()),
+                    redeem_script: Some(vec![0x51].into()),
+                    witness_script: None,
+                    partial_sigs: vec![(
+                        "0339880dc92394b7355e3d0439fa283c31de7590812ea011c4245c0674a685e883".parse().unwrap(),
+                        "304402204f67e2afb76142d44fae58a2495d33a3419daa26cd0db8d04f3452b63289ac0f022010762a9fb67e94cc5cad9026f6dc99ff7f070f4278d30fbc7d0c869dd38c7fe701".parse().unwrap(),
+                    )].into_iter().collect(),
+                    bip32_derivation: keypaths.clone(),
+                    final_script_witness: Some(Witness::from_slice(&[vec![1, 3], vec![5]])),
+                    ripemd160_preimages: vec![(ripemd160::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),
+                    sha256_preimages: vec![(sha256::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),
+                    hash160_preimages: vec![(hash160::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),
+                    hash256_preimages: vec![(sha256d::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),
+                    proprietary: proprietary.clone(),
+                    unknown: unknown.clone(),
+                    ..Default::default()
+                }
+            ],
+            outputs: vec![
+                Output {
+                    bip32_derivation: keypaths,
+                    proprietary,
+                    unknown,
+                    ..Default::default()
+                }
+            ],
+        };
+        let encoded = serde_json::to_string(&psbt).unwrap();
+        let decoded: Psbt = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(psbt, decoded);
+    }
+
+    mod bip_vectors {
+        #[cfg(feature = "base64")]
+        use std::str::FromStr;
+
+        use super::*;
+        use crate::psbt::map::Map;
+
+        #[test]
+        #[should_panic(expected = "InvalidMagic")]
+        fn invalid_vector_1() {
+            hex_psbt("0200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf6000000006a473044022070b2245123e6bf474d60c5b50c043d4c691a5d2435f09a34a7662a9dc251790a022001329ca9dacf280bdf30740ec0390422422c81cb45839457aeb76fc12edd95b3012102657d118d3357b8e0f4c2cd46db7b39f6d9c38d9a70abcb9b2de5dc8dbfe4ce31feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300").unwrap();
+        }
+
+        #[cfg(feature = "base64")]
+        #[test]
+        #[should_panic(expected = "InvalidMagic")]
+        fn invalid_vector_1_base64() {
+            Psbt::from_str("AgAAAAEmgXE3Ht/yhek3re6ks3t4AAwFZsuzrWRkFxPKQhcb9gAAAABqRzBEAiBwsiRRI+a/R01gxbUMBD1MaRpdJDXwmjSnZiqdwlF5CgIgATKcqdrPKAvfMHQOwDkEIkIsgctFg5RXrrdvwS7dlbMBIQJlfRGNM1e44PTCzUbbezn22cONmnCry5st5dyNv+TOMf7///8C09/1BQAAAAAZdqkU0MWZA8W6woaHYOkP1SGkZlqnZSCIrADh9QUAAAAAF6kUNUXm4zuDLEcFDyTT7rk8nAOUi8eHsy4TAA==").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "ConsensusEncoding")]
+        fn invalid_vector_2() {
+            hex_psbt("70736274ff0100750200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf60000000000feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000100fda5010100000000010289a3c71eab4d20e0371bbba4cc698fa295c9463afa2e397f8533ccb62f9567e50100000017160014be18d152a9b012039daf3da7de4f53349eecb985ffffffff86f8aa43a71dff1448893a530a7237ef6b4608bbb2dd2d0171e63aec6a4890b40100000017160014fe3e9ef1a745e974d902c4355943abcb34bd5353ffffffff0200c2eb0b000000001976a91485cff1097fd9e008bb34af709c62197b38978a4888ac72fef84e2c00000017a914339725ba21efd62ac753a9bcd067d6c7a6a39d05870247304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c012103d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f210502483045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01210223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab30000000000")
+                .unwrap();
+        }
+
+        #[cfg(feature = "base64")]
+        #[test]
+        #[should_panic(expected = "ConsensusEncoding")]
+        fn invalid_vector_2_base64() {
+            Psbt::from_str("cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==")
+                .unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsignedTxHasScriptSigs")]
+        fn invalid_vector_3() {
+            hex_psbt("70736274ff0100fd0a010200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be4000000006a47304402204759661797c01b036b25928948686218347d89864b719e1f7fcf57d1e511658702205309eabf56aa4d8891ffd111fdf1336f3a29da866d7f8486d75546ceedaf93190121035cdc61fc7ba971c0b501a646a2a83b102cb43881217ca682dc86e2d73fa88292feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac00000000000001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb82308000000").unwrap();
+        }
+
+        #[cfg(feature = "base64")]
+        #[test]
+        #[should_panic(expected = "UnsignedTxHasScriptSigs")]
+        fn invalid_vector_3_base64() {
+            Psbt::from_str("cHNidP8BAP0KAQIAAAACqwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QAAAAAakcwRAIgR1lmF5fAGwNrJZKJSGhiGDR9iYZLcZ4ff89X0eURZYcCIFMJ6r9Wqk2Ikf/REf3xM286KdqGbX+EhtdVRs7tr5MZASEDXNxh/HupccC1AaZGoqg7ECy0OIEhfKaC3Ibi1z+ogpL+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAABASAA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHhwEEFgAUhdE1N/LiZUBaNNuvqePdoB+4IwgAAAA=").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "MustHaveUnsignedTx")]
+        fn invalid_vector_4() {
+            hex_psbt("70736274ff000100fda5010100000000010289a3c71eab4d20e0371bbba4cc698fa295c9463afa2e397f8533ccb62f9567e50100000017160014be18d152a9b012039daf3da7de4f53349eecb985ffffffff86f8aa43a71dff1448893a530a7237ef6b4608bbb2dd2d0171e63aec6a4890b40100000017160014fe3e9ef1a745e974d902c4355943abcb34bd5353ffffffff0200c2eb0b000000001976a91485cff1097fd9e008bb34af709c62197b38978a4888ac72fef84e2c00000017a914339725ba21efd62ac753a9bcd067d6c7a6a39d05870247304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c012103d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f210502483045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01210223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab30000000000").unwrap();
+        }
+
+        #[cfg(feature = "base64")]
+        #[test]
+        #[should_panic(expected = "MustHaveUnsignedTx")]
+        fn invalid_vector_4_base64() {
+            Psbt::from_str("cHNidP8AAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key: [] })")]
+        fn invalid_vector_5() {
+            hex_psbt("70736274ff0100750200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf60000000000feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000100fda5010100000000010289a3c71eab4d20e0371bbba4cc698fa295c9463afa2e397f8533ccb62f9567e50100000017160014be18d152a9b012039daf3da7de4f53349eecb985ffffffff86f8aa43a71dff1448893a530a7237ef6b4608bbb2dd2d0171e63aec6a4890b40100000017160014fe3e9ef1a745e974d902c4355943abcb34bd5353ffffffff0200c2eb0b000000001976a91485cff1097fd9e008bb34af709c62197b38978a4888ac72fef84e2c00000017a914339725ba21efd62ac753a9bcd067d6c7a6a39d05870247304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c012103d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f210502483045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01210223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab30000000001003f0200000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff010000000000000000036a010000000000000000").unwrap();
+        }
+
+        #[cfg(feature = "base64")]
+        #[test]
+        #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key: [] })")]
+        fn invalid_vector_5_base64() {
+            Psbt::from_str("cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAQA/AgAAAAH//////////////////////////////////////////wAAAAAA/////wEAAAAAAAAAAANqAQAAAAAAAAAA").unwrap();
+        }
+
+        #[test]
+        fn valid_vector_1() {
+            let unserialized = Psbt {
+                unsigned_tx: Transaction {
+                    version: transaction::Version::TWO,
+                    lock_time: absolute::LockTime::from_consensus(1257139),
+                    input: vec![
+                        TxIn {
+                            previous_output: OutPoint {
+                                txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126".parse().unwrap(),
+                                vout: 0,
+                            },
+                            script_sig: ScriptBuf::new(),
+                            sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                            witness: Witness::default(),
+                        }
+                    ],
+                    output: vec![
+                        TxOut {
+                            value: Amount::from_sat(99_999_699),
+                            script_pubkey: ScriptBuf::from_hex("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac").unwrap(),
+                        },
+                        TxOut {
+                            value: Amount::from_sat(100_000_000),
+                            script_pubkey: ScriptBuf::from_hex("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787").unwrap(),
+                        },
+                    ],
+                },
+                xpub: Default::default(),
+                version: 0,
+                proprietary: BTreeMap::new(),
+                unknown: BTreeMap::new(),
+
+                inputs: vec![
+                    Input {
+                        non_witness_utxo: Some(Transaction {
+                            version: transaction::Version::ONE,
+                            lock_time: absolute::LockTime::ZERO,
+                            input: vec![
+                                TxIn {
+                                    previous_output: OutPoint {
+                                        txid: "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389".parse().unwrap(),
+                                        vout: 1,
+                                    },
+                                    script_sig: ScriptBuf::from_hex("160014be18d152a9b012039daf3da7de4f53349eecb985").unwrap(),
+                                    sequence: Sequence::MAX,
+                                    witness: Witness::from_slice(&[
+                                        hex!("304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c01"),
+                                        hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105"),
+                                    ]),
+                                },
+                                TxIn {
+                                    previous_output: OutPoint {
+                                        txid: "b490486aec3ae671012dddb2bb08466bef37720a533a894814ff1da743aaf886".parse().unwrap(),
+                                        vout: 1,
+                                    },
+                                    script_sig: ScriptBuf::from_hex("160014fe3e9ef1a745e974d902c4355943abcb34bd5353").unwrap(),
+                                    sequence: Sequence::MAX,
+                                    witness: Witness::from_slice(&[
+                                        hex!("3045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01"),
+                                        hex!("0223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab3"),
+                                    ]),
+                                }
+                            ],
+                            output: vec![
+                                TxOut {
+                                    value: Amount::from_sat(200_000_000),
+                                    script_pubkey: ScriptBuf::from_hex("76a91485cff1097fd9e008bb34af709c62197b38978a4888ac").unwrap(),
+                                },
+                                TxOut {
+                                    value: Amount::from_sat(190_303_501_938),
+                                    script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
+                                },
+                            ],
+                        }),
+                        ..Default::default()
+                    },
+                ],
+                outputs: vec![
+                    Output {
+                        ..Default::default()
+                    },
+                    Output {
+                        ..Default::default()
+                    },
+                ],
+            };
+
+            let base16str = "70736274ff0100750200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf60000000000feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000100fda5010100000000010289a3c71eab4d20e0371bbba4cc698fa295c9463afa2e397f8533ccb62f9567e50100000017160014be18d152a9b012039daf3da7de4f53349eecb985ffffffff86f8aa43a71dff1448893a530a7237ef6b4608bbb2dd2d0171e63aec6a4890b40100000017160014fe3e9ef1a745e974d902c4355943abcb34bd5353ffffffff0200c2eb0b000000001976a91485cff1097fd9e008bb34af709c62197b38978a4888ac72fef84e2c00000017a914339725ba21efd62ac753a9bcd067d6c7a6a39d05870247304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c012103d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f210502483045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01210223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab300000000000000";
+
+            assert_eq!(unserialized.serialize_hex(), base16str);
+            assert_eq!(unserialized, hex_psbt(base16str).unwrap());
+
+            #[cfg(feature = "base64")]
+            {
+                let base64str = "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA";
+                assert_eq!(Psbt::from_str(base64str).unwrap(), unserialized);
+                assert_eq!(base64str, unserialized.to_string());
+                assert_eq!(
+                    Psbt::from_str(base64str).unwrap(),
+                    hex_psbt(base16str).unwrap()
+                );
+            }
+        }
+
+        #[test]
+        fn valid_vector_2() {
+            let psbt: Psbt = hex_psbt("70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac000000000001076a47304402204759661797c01b036b25928948686218347d89864b719e1f7fcf57d1e511658702205309eabf56aa4d8891ffd111fdf1336f3a29da866d7f8486d75546ceedaf93190121035cdc61fc7ba971c0b501a646a2a83b102cb43881217ca682dc86e2d73fa882920001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb82308000000").unwrap();
+
+            assert_eq!(psbt.inputs.len(), 2);
+            assert_eq!(psbt.outputs.len(), 2);
+
+            assert!(&psbt.inputs[0].final_script_sig.is_some());
+
+            let redeem_script = psbt.inputs[1].redeem_script.as_ref().unwrap();
+            let expected_out =
+                ScriptBuf::from_hex("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787").unwrap();
+
+            assert!(redeem_script.is_p2wpkh());
+            assert_eq!(
+                redeem_script.to_p2sh(),
+                psbt.inputs[1].witness_utxo.as_ref().unwrap().script_pubkey
+            );
+            assert_eq!(redeem_script.to_p2sh(), expected_out);
+
+            for output in psbt.outputs {
+                assert_eq!(output.get_pairs().len(), 0)
+            }
+        }
+
+        #[test]
+        fn valid_vector_3() {
+            let psbt: Psbt = hex_psbt("70736274ff0100750200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf60000000000feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000100fda5010100000000010289a3c71eab4d20e0371bbba4cc698fa295c9463afa2e397f8533ccb62f9567e50100000017160014be18d152a9b012039daf3da7de4f53349eecb985ffffffff86f8aa43a71dff1448893a530a7237ef6b4608bbb2dd2d0171e63aec6a4890b40100000017160014fe3e9ef1a745e974d902c4355943abcb34bd5353ffffffff0200c2eb0b000000001976a91485cff1097fd9e008bb34af709c62197b38978a4888ac72fef84e2c00000017a914339725ba21efd62ac753a9bcd067d6c7a6a39d05870247304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c012103d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f210502483045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01210223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab30000000001030401000000000000").unwrap();
+
+            assert_eq!(psbt.inputs.len(), 1);
+            assert_eq!(psbt.outputs.len(), 2);
+
+            let tx_input = &psbt.unsigned_tx.input[0];
+            let psbt_non_witness_utxo = psbt.inputs[0].non_witness_utxo.as_ref().unwrap();
+
+            assert_eq!(
+                tx_input.previous_output.txid,
+                psbt_non_witness_utxo.compute_txid()
+            );
+            assert!(
+                psbt_non_witness_utxo.output[tx_input.previous_output.vout as usize]
+                    .script_pubkey
+                    .is_p2pkh()
+            );
+            assert_eq!(
+                psbt.inputs[0]
+                    .sighash_type
+                    .as_ref()
+                    .unwrap()
+                    .ecdsa_hash_ty()
+                    .unwrap(),
+                EcdsaSighashType::All
+            );
+        }
+
+        #[test]
+        fn valid_vector_4() {
+            let psbt: Psbt = hex_psbt("70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac00000000000100df0200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf6000000006a473044022070b2245123e6bf474d60c5b50c043d4c691a5d2435f09a34a7662a9dc251790a022001329ca9dacf280bdf30740ec0390422422c81cb45839457aeb76fc12edd95b3012102657d118d3357b8e0f4c2cd46db7b39f6d9c38d9a70abcb9b2de5dc8dbfe4ce31feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e13000001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb8230800220202ead596687ca806043edc3de116cdf29d5e9257c196cd055cf698c8d02bf24e9910b4a6ba670000008000000080020000800022020394f62be9df19952c5587768aeb7698061ad2c4a25c894f47d8c162b4d7213d0510b4a6ba6700000080010000800200008000").unwrap();
+
+            assert_eq!(psbt.inputs.len(), 2);
+            assert_eq!(psbt.outputs.len(), 2);
+
+            assert!(&psbt.inputs[0].final_script_sig.is_none());
+            assert!(&psbt.inputs[1].final_script_sig.is_none());
+
+            let redeem_script = psbt.inputs[1].redeem_script.as_ref().unwrap();
+            let expected_out =
+                ScriptBuf::from_hex("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787").unwrap();
+
+            assert!(redeem_script.is_p2wpkh());
+            assert_eq!(
+                redeem_script.to_p2sh(),
+                psbt.inputs[1].witness_utxo.as_ref().unwrap().script_pubkey
+            );
+            assert_eq!(redeem_script.to_p2sh(), expected_out);
+
+            for output in psbt.outputs {
+                assert!(!output.get_pairs().is_empty())
+            }
+        }
+
+        #[test]
+        fn valid_vector_5() {
+            let psbt: Psbt = hex_psbt("70736274ff0100550200000001279a2323a5dfb51fc45f220fa58b0fc13e1e3342792a85d7e36cd6333b5cbc390000000000ffffffff01a05aea0b000000001976a914ffe9c0061097cc3b636f2cb0460fa4fc427d2b4588ac0000000000010120955eea0b0000000017a9146345200f68d189e1adc0df1c4d16ea8f14c0dbeb87220203b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd4646304302200424b58effaaa694e1559ea5c93bbfd4a89064224055cdf070b6771469442d07021f5c8eb0fea6516d60b8acb33ad64ede60e8785bfb3aa94b99bdf86151db9a9a010104220020771fd18ad459666dd49f3d564e3dbc42f4c84774e360ada16816a8ed488d5681010547522103b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd462103de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd52ae220603b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd4610b4a6ba67000000800000008004000080220603de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd10b4a6ba670000008000000080050000800000").unwrap();
+
+            assert_eq!(psbt.inputs.len(), 1);
+            assert_eq!(psbt.outputs.len(), 1);
+
+            assert!(&psbt.inputs[0].final_script_sig.is_none());
+
+            let redeem_script = psbt.inputs[0].redeem_script.as_ref().unwrap();
+            let expected_out =
+                ScriptBuf::from_hex("a9146345200f68d189e1adc0df1c4d16ea8f14c0dbeb87").unwrap();
+
+            assert!(redeem_script.is_p2wsh());
+            assert_eq!(
+                redeem_script.to_p2sh(),
+                psbt.inputs[0].witness_utxo.as_ref().unwrap().script_pubkey
+            );
+
+            assert_eq!(redeem_script.to_p2sh(), expected_out);
+        }
+
+        #[test]
+        fn valid_vector_6() {
+            let psbt: Psbt = hex_psbt("70736274ff01003f0200000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff010000000000000000036a010000000000000a0f0102030405060708090f0102030405060708090a0b0c0d0e0f0000").unwrap();
+
+            assert_eq!(psbt.inputs.len(), 1);
+            assert_eq!(psbt.outputs.len(), 1);
+
+            let tx = &psbt.unsigned_tx;
+            assert_eq!(
+                tx.compute_txid(),
+                "75c5c9665a570569ad77dd1279e6fd4628a093c4dcbf8d41532614044c14c115"
+                    .parse()
+                    .unwrap(),
+            );
+
+            let mut unknown: BTreeMap<raw::Key, Vec<u8>> = BTreeMap::new();
+            let key: raw::Key = raw::Key {
+                type_value: 0x0fu8,
+                key: hex!("010203040506070809"),
+            };
+            let value: Vec<u8> = hex!("0102030405060708090a0b0c0d0e0f");
+
+            unknown.insert(key, value);
+
+            assert_eq!(psbt.inputs[0].unknown, unknown)
+        }
+    }
+
+    mod bip_371_vectors {
+        use super::*;
+
+        #[test]
+        fn invalid_vectors() {
+            let err = hex_psbt("70736274ff010071020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff02787c01000000000016001483a7e34bd99ff03a4962ef8a1a101bb295461ece606b042a010000001600147ac369df1b20e033d6116623957b0ac49f3c52e8000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a075701172102fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa232000000").unwrap_err();
+            assert_eq!(err.to_string(), "invalid xonly public key");
+            let err = hex_psbt("70736274ff010071020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff02787c01000000000016001483a7e34bd99ff03a4962ef8a1a101bb295461ece606b042a010000001600147ac369df1b20e033d6116623957b0ac49f3c52e8000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a0757011342173bb3d36c074afb716fec6307a069a2e450b995f3c82785945ab8df0e24260dcd703b0cbf34de399184a9481ac2b3586db6601f026a77f7e4938481bc34751701aa000000").unwrap_err();
+            #[cfg(feature = "std")]
+            assert_eq!(err.to_string(), "invalid taproot signature");
+            #[cfg(not(feature = "std"))]
+            assert_eq!(
+                err.to_string(),
+                "invalid taproot signature: invalid taproot signature size: 66"
+            );
+            let err = hex_psbt("70736274ff010071020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff02787c01000000000016001483a7e34bd99ff03a4962ef8a1a101bb295461ece606b042a010000001600147ac369df1b20e033d6116623957b0ac49f3c52e8000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a0757221602fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2321900772b2da75600008001000080000000800100000000000000000000").unwrap_err();
+            assert_eq!(err.to_string(), "invalid xonly public key");
+            let err = hex_psbt("70736274ff01007d020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff02887b0100000000001600142382871c7e8421a00093f754d91281e675874b9f606b042a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a0757000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a0757000001052102fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa23200").unwrap_err();
+            assert_eq!(err.to_string(), "invalid xonly public key");
+            let err = hex_psbt("70736274ff01007d020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff02887b0100000000001600142382871c7e8421a00093f754d91281e675874b9f606b042a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a0757000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a07570000220702fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2321900772b2da7560000800100008000000080010000000000000000").unwrap_err();
+            assert_eq!(err.to_string(), "invalid xonly public key");
+            let err = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b6924214022cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b094089756aa3739ccc689ec0fcf3a360be32cc0b59b16e93a1e8bb4605726b2ca7a3ff706c4176649632b2cc68e1f912b8a578e3719ce7710885c7a966f49bcd43cb0000").unwrap_err();
+            #[cfg(feature = "std")]
+            assert_eq!(err.to_string(), "invalid hash when parsing slice");
+            #[cfg(not(feature = "std"))]
+            assert_eq!(
+                err.to_string(),
+                "invalid hash when parsing slice: invalid slice length 33 (expected 32)"
+            );
+            let err = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b69241142cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b094289756aa3739ccc689ec0fcf3a360be32cc0b59b16e93a1e8bb4605726b2ca7a3ff706c4176649632b2cc68e1f912b8a578e3719ce7710885c7a966f49bcd43cb01010000").unwrap_err();
+            #[cfg(feature = "std")]
+            assert_eq!(err.to_string(), "invalid taproot signature");
+            #[cfg(not(feature = "std"))]
+            assert_eq!(
+                err.to_string(),
+                "invalid taproot signature: invalid taproot signature size: 66"
+            );
+            let err = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b69241142cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b093989756aa3739ccc689ec0fcf3a360be32cc0b59b16e93a1e8bb4605726b2ca7a3ff706c4176649632b2cc68e1f912b8a578e3719ce7710885c7a966f49bcd43cb0000").unwrap_err();
+            #[cfg(feature = "std")]
+            assert_eq!(err.to_string(), "invalid taproot signature");
+            #[cfg(not(feature = "std"))]
+            assert_eq!(
+                err.to_string(),
+                "invalid taproot signature: invalid taproot signature size: 57"
+            );
+            let err = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b6926315c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae970115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f80023202cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2acc00000").unwrap_err();
+            assert_eq!(err.to_string(), "invalid control block");
+            let err = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b6926115c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae970115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e123202cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2acc00000").unwrap_err();
+            assert_eq!(err.to_string(), "invalid control block");
+        }
+
+        fn rtt_psbt(psbt: Psbt) {
+            let enc = Psbt::serialize(&psbt);
+            let psbt2 = Psbt::deserialize(&enc).unwrap();
+            assert_eq!(psbt, psbt2);
+        }
+
+        #[test]
+        fn valid_psbt_vectors() {
+            let psbt = hex_psbt("70736274ff010052020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff0148e6052a01000000160014768e1eeb4cf420866033f80aceff0f9720744969000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a07572116fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2321900772b2da75600008001000080000000800100000000000000011720fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa232002202036b772a6db74d8753c98a827958de6c78ab3312109f37d3e0304484242ece73d818772b2da7540000800100008000000080000000000000000000").unwrap();
+            let internal_key = psbt.inputs[0].tap_internal_key.unwrap();
+            assert!(psbt.inputs[0].tap_key_origins.contains_key(&internal_key));
+            rtt_psbt(psbt);
+
+            // vector 2
+            let psbt = hex_psbt("70736274ff010052020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff0148e6052a01000000160014768e1eeb4cf420866033f80aceff0f9720744969000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a0757011340bb53ec917bad9d906af1ba87181c48b86ace5aae2b53605a725ca74625631476fc6f5baedaf4f2ee0f477f36f58f3970d5b8273b7e497b97af2e3f125c97af342116fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2321900772b2da75600008001000080000000800100000000000000011720fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa232002202036b772a6db74d8753c98a827958de6c78ab3312109f37d3e0304484242ece73d818772b2da7540000800100008000000080000000000000000000").unwrap();
+            let internal_key = psbt.inputs[0].tap_internal_key.unwrap();
+            assert!(psbt.inputs[0].tap_key_origins.contains_key(&internal_key));
+            assert!(psbt.inputs[0].tap_key_sig.is_some());
+            rtt_psbt(psbt);
+
+            // vector 3
+            let psbt = hex_psbt("70736274ff01005e020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff0148e6052a0100000022512083698e458c6664e1595d75da2597de1e22ee97d798e706c4c0a4b5a9823cd743000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a07572116fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2321900772b2da75600008001000080000000800100000000000000011720fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa232000105201124da7aec92ccd06c954562647f437b138b95721a84be2bf2276bbddab3e67121071124da7aec92ccd06c954562647f437b138b95721a84be2bf2276bbddab3e6711900772b2da7560000800100008000000080000000000500000000").unwrap();
+            let internal_key = psbt.outputs[0].tap_internal_key.unwrap();
+            assert!(psbt.outputs[0].tap_key_origins.contains_key(&internal_key));
+            rtt_psbt(psbt);
+
+            // vector 4
+            let psbt = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a0100000022512083698e458c6664e1595d75da2597de1e22ee97d798e706c4c0a4b5a9823cd743000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b6926215c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae970115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f823202cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2acc04215c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac097c6e6fea5ff714ff5724499990810e406e98aa10f5bf7e5f6784bc1d0a9a6ce23204320b0bf16f011b53ea7be615924aa7f27e5d29ad20ea1155d848676c3bad1b2acc06215c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b09115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f82320fa0f7a3cef3b1d0c0a6ce7d26e17ada0b2e5c92d19efad48b41859cb8a451ca9acc021162cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d23901cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b09772b2da7560000800100008002000080000000000000000021164320b0bf16f011b53ea7be615924aa7f27e5d29ad20ea1155d848676c3bad1b23901115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f8772b2da75600008001000080010000800000000000000000211650929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac005007c461e5d2116fa0f7a3cef3b1d0c0a6ce7d26e17ada0b2e5c92d19efad48b41859cb8a451ca939016f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae970772b2da7560000800100008003000080000000000000000001172050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0011820f0362e2f75a6f420a5bde3eb221d96ae6720cf25f81890c95b1d775acb515e65000105201124da7aec92ccd06c954562647f437b138b95721a84be2bf2276bbddab3e67121071124da7aec92ccd06c954562647f437b138b95721a84be2bf2276bbddab3e6711900772b2da7560000800100008000000080000000000500000000").unwrap();
+            assert!(psbt.inputs[0].tap_internal_key.is_some());
+            assert!(psbt.inputs[0].tap_merkle_root.is_some());
+            assert!(!psbt.inputs[0].tap_key_origins.is_empty());
+            assert!(!psbt.inputs[0].tap_scripts.is_empty());
+            rtt_psbt(psbt);
+
+            // vector 5
+            let psbt = hex_psbt("70736274ff01005e020000000127744ababf3027fe0d6cf23a96eee2efb188ef52301954585883e69b6624b2420000000000ffffffff0148e6052a010000002251200a8cbdc86de1ce1c0f9caeb22d6df7ced3683fe423e05d1e402a879341d6f6f5000000000001012b00f2052a010000002251205a2c2cf5b52cf31f83ad2e8da63ff03183ecd8f609c7510ae8a48e03910a07572116fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2321900772b2da75600008001000080000000800100000000000000011720fe349064c98d6e2a853fa3c9b12bd8b304a19c195c60efa7ee2393046d3fa2320001052050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac001066f02c02220736e572900fe1252589a2143c8f3c79f71a0412d2353af755e9701c782694a02ac02c02220631c5f3b5832b8fbdebfb19704ceeb323c21f40f7a24f43d68ef0cc26b125969ac01c0222044faa49a0338de488c8dfffecdfb6f329f380bd566ef20c8df6d813eab1c4273ac210744faa49a0338de488c8dfffecdfb6f329f380bd566ef20c8df6d813eab1c42733901f06b798b92a10ed9a9d0bbfd3af173a53b1617da3a4159ca008216cd856b2e0e772b2da75600008001000080010000800000000003000000210750929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac005007c461e5d2107631c5f3b5832b8fbdebfb19704ceeb323c21f40f7a24f43d68ef0cc26b125969390118ace409889785e0ea70ceebb8e1ca892a7a78eaede0f2e296cf435961a8f4ca772b2da756000080010000800200008000000000030000002107736e572900fe1252589a2143c8f3c79f71a0412d2353af755e9701c782694a02390129a5b4915090162d759afd3fe0f93fa3326056d0b4088cb933cae7826cb8d82c772b2da7560000800100008003000080000000000300000000").unwrap();
+            assert!(psbt.outputs[0].tap_internal_key.is_some());
+            assert!(!psbt.outputs[0].tap_key_origins.is_empty());
+            assert!(psbt.outputs[0].tap_tree.is_some());
+            rtt_psbt(psbt);
+
+            // vector 6
+            let psbt = hex_psbt("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a0100000022512083698e458c6664e1595d75da2597de1e22ee97d798e706c4c0a4b5a9823cd743000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b69241142cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b0940bf818d9757d6ffeb538ba057fb4c1fc4e0f5ef186e765beb564791e02af5fd3d5e2551d4e34e33d86f276b82c99c79aed3f0395a081efcd2cc2c65dd7e693d7941144320b0bf16f011b53ea7be615924aa7f27e5d29ad20ea1155d848676c3bad1b2115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f840e1f1ab6fabfa26b236f21833719dc1d428ab768d80f91f9988d8abef47bfb863bb1f2a529f768c15f00ce34ec283cdc07e88f8428be28f6ef64043c32911811a4114fa0f7a3cef3b1d0c0a6ce7d26e17ada0b2e5c92d19efad48b41859cb8a451ca96f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae97040ec1f0379206461c83342285423326708ab031f0da4a253ee45aafa5b8c92034d8b605490f8cd13e00f989989b97e215faa36f12dee3693d2daccf3781c1757f66215c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae970115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f823202cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2acc04215c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac097c6e6fea5ff714ff5724499990810e406e98aa10f5bf7e5f6784bc1d0a9a6ce23204320b0bf16f011b53ea7be615924aa7f27e5d29ad20ea1155d848676c3bad1b2acc06215c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b09115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f82320fa0f7a3cef3b1d0c0a6ce7d26e17ada0b2e5c92d19efad48b41859cb8a451ca9acc021162cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d23901cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b09772b2da7560000800100008002000080000000000000000021164320b0bf16f011b53ea7be615924aa7f27e5d29ad20ea1155d848676c3bad1b23901115f2e490af7cc45c4f78511f36057ce5c5a5c56325a29fb44dfc203f356e1f8772b2da75600008001000080010000800000000000000000211650929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac005007c461e5d2116fa0f7a3cef3b1d0c0a6ce7d26e17ada0b2e5c92d19efad48b41859cb8a451ca939016f7d62059e9497a1a4a267569d9876da60101aff38e3529b9b939ce7f91ae970772b2da7560000800100008003000080000000000000000001172050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0011820f0362e2f75a6f420a5bde3eb221d96ae6720cf25f81890c95b1d775acb515e65000105201124da7aec92ccd06c954562647f437b138b95721a84be2bf2276bbddab3e67121071124da7aec92ccd06c954562647f437b138b95721a84be2bf2276bbddab3e6711900772b2da7560000800100008000000080000000000500000000").unwrap();
+            assert!(psbt.inputs[0].tap_internal_key.is_some());
+            assert!(psbt.inputs[0].tap_merkle_root.is_some());
+            assert!(!psbt.inputs[0].tap_scripts.is_empty());
+            assert!(!psbt.inputs[0].tap_script_sigs.is_empty());
+            assert!(!psbt.inputs[0].tap_key_origins.is_empty());
+            rtt_psbt(psbt);
+        }
+    }
+
+    #[test]
+    fn serialize_and_deserialize_preimage_psbt() {
+        // create a sha preimage map
+        let mut sha256_preimages = BTreeMap::new();
+        sha256_preimages.insert(sha256::Hash::hash(&[1u8, 2u8]), vec![1u8, 2u8]);
+        sha256_preimages.insert(sha256::Hash::hash(&[1u8]), vec![1u8]);
+
+        // same for hash160
+        let mut hash160_preimages = BTreeMap::new();
+        hash160_preimages.insert(hash160::Hash::hash(&[1u8, 2u8]), vec![1u8, 2u8]);
+        hash160_preimages.insert(hash160::Hash::hash(&[1u8]), vec![1u8]);
+
+        // same vector as valid_vector_1 from BIPs with added
+        let mut unserialized = Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::from_consensus(1257139),
+                input: vec![
+                    TxIn {
+                        previous_output: OutPoint {
+                            txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126".parse().unwrap(),
+                            vout: 0,
+                        },
+                        script_sig: ScriptBuf::new(),
+                        sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                        witness: Witness::default(),
+                    }
+                ],
+                output: vec![
+                    TxOut {
+                        value: Amount::from_sat(99_999_699),
+                        script_pubkey: ScriptBuf::from_hex("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac").unwrap(),
+                    },
+                    TxOut {
+                        value: Amount::from_sat(100_000_000),
+                        script_pubkey: ScriptBuf::from_hex("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787").unwrap(),
+                    },
+                ],
+            },
+            version: 0,
+            xpub: Default::default(),
+            proprietary: Default::default(),
+            unknown: BTreeMap::new(),
+
+            inputs: vec![
+                Input {
+                    non_witness_utxo: Some(Transaction {
+                        version: transaction::Version::ONE,
+                        lock_time: absolute::LockTime::ZERO,
+                        input: vec![
+                            TxIn {
+                                previous_output: OutPoint {
+                                    txid: "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389".parse().unwrap(),
+                                    vout: 1,
+                                },
+                                script_sig: ScriptBuf::from_hex("160014be18d152a9b012039daf3da7de4f53349eecb985").unwrap(),
+                                sequence: Sequence::MAX,
+                                witness: Witness::from_slice(&[
+                                    hex!("304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c01"),
+                                    hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105"),
+                                ]),
+                            },
+                            TxIn {
+                                previous_output: OutPoint {
+                                    txid: "b490486aec3ae671012dddb2bb08466bef37720a533a894814ff1da743aaf886".parse().unwrap(),
+                                    vout: 1,
+                                },
+                                script_sig: ScriptBuf::from_hex("160014fe3e9ef1a745e974d902c4355943abcb34bd5353").unwrap(),
+                                sequence: Sequence::MAX,
+                                witness: Witness::from_slice(&[
+                                    hex!("3045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01"),
+                                    hex!("0223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab3"),
+                                ]),
+                            }
+                        ],
+                        output: vec![
+                            TxOut {
+                                value: Amount::from_sat(200_000_000),
+                                script_pubkey: ScriptBuf::from_hex("76a91485cff1097fd9e008bb34af709c62197b38978a4888ac").unwrap(),
+                            },
+                            TxOut {
+                                value: Amount::from_sat(190_303_501_938),
+                                script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            ],
+            outputs: vec![
+                Output {
+                    ..Default::default()
+                },
+                Output {
+                    ..Default::default()
+                },
+            ],
+        };
+        unserialized.inputs[0].hash160_preimages = hash160_preimages;
+        unserialized.inputs[0].sha256_preimages = sha256_preimages;
+
+        let rtt: Psbt = hex_psbt(&unserialized.serialize_hex()).unwrap();
+        assert_eq!(rtt, unserialized);
+
+        // Now add an ripemd160 with incorrect preimage
+        let mut ripemd160_preimages = BTreeMap::new();
+        ripemd160_preimages.insert(ripemd160::Hash::hash(&[17u8]), vec![18u8]);
+        unserialized.inputs[0].ripemd160_preimages = ripemd160_preimages;
+
+        // Now the roundtrip should fail as the preimage is incorrect.
+        let rtt: Result<Psbt, _> = hex_psbt(&unserialized.serialize_hex());
+        assert!(rtt.is_err());
+    }
+
+    #[test]
+    fn serialize_and_deserialize_proprietary() {
+        let mut psbt: Psbt = hex_psbt("70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac000000000001076a47304402204759661797c01b036b25928948686218347d89864b719e1f7fcf57d1e511658702205309eabf56aa4d8891ffd111fdf1336f3a29da866d7f8486d75546ceedaf93190121035cdc61fc7ba971c0b501a646a2a83b102cb43881217ca682dc86e2d73fa882920001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb82308000000").unwrap();
+        psbt.proprietary.insert(
+            raw::ProprietaryKey {
+                prefix: b"test".to_vec(),
+                subtype: 0u8,
+                key: b"test".to_vec(),
+            },
+            b"test".to_vec(),
+        );
+        assert!(!psbt.proprietary.is_empty());
+        let rtt: Psbt = hex_psbt(&psbt.serialize_hex()).unwrap();
+        assert!(!rtt.proprietary.is_empty());
+    }
+
+    // // PSBTs taken from BIP 174 test vectors.
+    // #[test]
+    // fn combine_psbts() {
+    //     let mut psbt1 = hex_psbt(include_str!("../../tests/data/psbt1.hex")).unwrap();
+    //     let psbt2 = hex_psbt(include_str!("../../tests/data/psbt2.hex")).unwrap();
+    //     let psbt_combined = hex_psbt(include_str!("../../tests/data/psbt2.hex")).unwrap();
+
+    //     psbt1.combine(psbt2).expect("psbt combine to succeed");
+    //     assert_eq!(psbt1, psbt_combined);
+    // }
+
+    // #[test]
+    // fn combine_psbts_commutative() {
+    //     let mut psbt1 = hex_psbt(include_str!("../../tests/data/psbt1.hex")).unwrap();
+    //     let mut psbt2 = hex_psbt(include_str!("../../tests/data/psbt2.hex")).unwrap();
+
+    //     let psbt1_clone = psbt1.clone();
+    //     let psbt2_clone = psbt2.clone();
+
+    //     psbt1.combine(psbt2_clone).expect("psbt1 combine to succeed");
+    //     psbt2.combine(psbt1_clone).expect("psbt2 combine to succeed");
+
+    //     assert_eq!(psbt1, psbt2);
+    // }
+
+    #[cfg(feature = "rand-std")]
+    fn gen_keys() -> (PrivateKey, PublicKey, Secp256k1<All>) {
+        use secp256k1::rand::thread_rng;
+
+        let secp = Secp256k1::new();
+
+        let sk = SecretKey::new(&mut thread_rng());
+        let priv_key = PrivateKey::new(sk, NetworkKind::Test);
+        let pk = PublicKey::from_private_key(&secp, &priv_key);
+
+        (priv_key, pk, secp)
+    }
+
+    #[test]
+    #[cfg(feature = "rand-std")]
+    fn get_key_btree_map() {
+        let (priv_key, pk, secp) = gen_keys();
+
+        let mut key_map = BTreeMap::new();
+        key_map.insert(pk, priv_key);
+
+        let got = key_map
+            .get_key(KeyRequest::Pubkey(pk), &secp)
+            .expect("failed to get key");
+        assert_eq!(got.unwrap(), priv_key)
+    }
+
+    #[test]
+    fn test_fee() {
+        let output_0_val = Amount::from_sat(99_999_699);
+        let output_1_val = Amount::from_sat(100_000_000);
+        let prev_output_val = Amount::from_sat(200_000_000);
+
+        let mut t = Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::from_consensus(1257139),
+                input: vec![
+                    TxIn {
+                        previous_output: OutPoint {
+                            txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126".parse().unwrap(),
+                            vout: 0,
+                        },
+                        sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                        ..Default::default()
+                    }
+                ],
+                output: vec![
+                    TxOut {
+                        value: output_0_val,
+                        script_pubkey:  ScriptBuf::new()
+                    },
+                    TxOut {
+                        value: output_1_val,
+                        script_pubkey:  ScriptBuf::new()
+                    },
+                ],
+            },
+            xpub: Default::default(),
+            version: 0,
+            proprietary: BTreeMap::new(),
+            unknown: BTreeMap::new(),
+
+            inputs: vec![
+                Input {
+                    non_witness_utxo: Some(Transaction {
+                        version: transaction::Version::ONE,
+                        lock_time: absolute::LockTime::ZERO,
+                        input: vec![
+                            TxIn {
+                                previous_output: OutPoint {
+                                    txid: "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389".parse().unwrap(),
+                                    vout: 1,
+                                },
+                                sequence: Sequence::MAX,
+                                ..Default::default()
+                            },
+                            TxIn {
+                                previous_output: OutPoint {
+                                    txid: "b490486aec3ae671012dddb2bb08466bef37720a533a894814ff1da743aaf886".parse().unwrap(),
+                                    vout: 1,
+                                },
+                                sequence: Sequence::MAX,
+                                ..Default::default()
+                            }
+                        ],
+                        output: vec![
+                            TxOut {
+                                value: prev_output_val,
+                                script_pubkey:  ScriptBuf::new()
+                            },
+                            TxOut {
+                                value: Amount::from_sat(190_303_501_938),
+                                script_pubkey:  ScriptBuf::new()
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            ],
+            outputs: vec![
+                Output {
+                    ..Default::default()
+                },
+                Output {
+                    ..Default::default()
+                },
+            ],
+        };
+        assert_eq!(
+            t.fee().expect("fee calculation"),
+            prev_output_val - (output_0_val + output_1_val)
+        );
+        // no previous output
+        let mut t2 = t.clone();
+        t2.inputs[0].non_witness_utxo = None;
+        match t2.fee().unwrap_err() {
+            Error::MissingUtxo => {}
+            e => panic!("unexpected error: {:?}", e),
+        }
+        //  negative fee
+        let mut t3 = t.clone();
+        t3.unsigned_tx.output[0].value = prev_output_val;
+        match t3.fee().unwrap_err() {
+            Error::NegativeFee => {}
+            e => panic!("unexpected error: {:?}", e),
+        }
+        // overflow
+        t.unsigned_tx.output[0].value = Amount::MAX;
+        t.unsigned_tx.output[1].value = Amount::MAX;
+        match t.fee().unwrap_err() {
+            Error::FeeOverflow => {}
+            e => panic!("unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "rand-std")]
+    fn sign_psbt() {
+        use crate::bip32::{DerivationPath, Fingerprint};
+        use crate::witness_version::WitnessVersion;
+        use crate::{WPubkeyHash, WitnessProgram};
+
+        let unsigned_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default(), TxIn::default()],
+            output: vec![TxOut::NULL],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+
+        let (priv_key, pk, secp) = gen_keys();
+
+        // key_map implements `GetKey` using KeyRequest::Pubkey. A pubkey key request does not use
+        // keysource so we use default `KeySource` (fingreprint and derivation path) below.
+        let mut key_map = BTreeMap::new();
+        key_map.insert(pk, priv_key);
+
+        // First input we can spend. See comment above on key_map for why we use defaults here.
+        let txout_wpkh = TxOut {
+            value: Amount::from_sat(10),
+            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::hash(&pk.to_bytes())),
+        };
+        psbt.inputs[0].witness_utxo = Some(txout_wpkh);
+
+        let mut map = BTreeMap::new();
+        map.insert(
+            pk.inner,
+            (Fingerprint::default(), DerivationPath::default()),
+        );
+        psbt.inputs[0].bip32_derivation = map;
+
+        // Second input is unspendable by us e.g., from another wallet that supports future upgrades.
+        let unknown_prog = WitnessProgram::new(WitnessVersion::V4, &[0xaa; 34]).unwrap();
+        let txout_unknown_future = TxOut {
+            value: Amount::from_sat(10),
+            script_pubkey: ScriptBuf::new_witness_program(&unknown_prog),
+        };
+        psbt.inputs[1].witness_utxo = Some(txout_unknown_future);
+
+        let (signing_keys, _) = psbt.sign(&key_map, &secp).unwrap_err();
+
+        assert_eq!(signing_keys.len(), 1);
+        assert_eq!(signing_keys[&0], SigningKeys::Ecdsa(vec![pk]));
+    }
+}

--- a/libs/bitcoin/src/psbt/raw.rs
+++ b/libs/bitcoin/src/psbt/raw.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Raw PSBT key-value pairs.
+//!
+//! Raw PSBT key-value pairs as defined at
+//! <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>.
+//!
+
+use core::fmt;
+
+use io::{Read, Write};
+
+use super::serialize::{Deserialize, Serialize};
+use crate::consensus::encode::{
+    self, deserialize, serialize, Decodable, Encodable, ReadExt, VarInt, WriteExt, MAX_VEC_SIZE,
+};
+use crate::prelude::*;
+use crate::psbt::Error;
+
+/// A PSBT key in its raw byte form.
+#[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Key {
+    /// The type of this PSBT key.
+    pub type_value: u8,
+    /// The key itself in raw byte form.
+    /// `<key> := <keylen> <keytype> <keydata>`
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
+    pub key: Vec<u8>,
+}
+
+/// A PSBT key-value pair in its raw byte form.
+/// `<keypair> := <key> <value>`
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Pair {
+    /// The key of this key-value pair.
+    pub key: Key,
+    /// The value data of this key-value pair in raw byte form.
+    /// `<value> := <valuelen> <valuedata>`
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
+    pub value: Vec<u8>,
+}
+
+/// Default implementation for proprietary key subtyping
+pub type ProprietaryType = u8;
+
+/// Proprietary keys (i.e. keys starting with 0xFC byte) with their internal
+/// structure according to BIP 174.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct ProprietaryKey<Subtype = ProprietaryType>
+where
+    Subtype: Copy + From<u8> + Into<u8>,
+{
+    /// Proprietary type prefix used for grouping together keys under some
+    /// application and avoid namespace collision
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
+    pub prefix: Vec<u8>,
+    /// Custom proprietary subtype
+    pub subtype: Subtype,
+    /// Additional key bytes (like serialized public key data etc)
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
+    pub key: Vec<u8>,
+}
+
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "type: {:#x}, key: {:x}", self.type_value, self.key.as_hex())
+    }
+}
+
+impl Key {
+    pub(crate) fn decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        let VarInt(byte_size): VarInt = Decodable::consensus_decode(r)?;
+
+        if byte_size == 0 {
+            return Err(Error::NoMorePairs);
+        }
+
+        let key_byte_size: u64 = byte_size - 1;
+
+        if key_byte_size > MAX_VEC_SIZE as u64 {
+            return Err(encode::Error::OversizedVectorAllocation {
+                requested: key_byte_size as usize,
+                max: MAX_VEC_SIZE,
+            }
+            .into());
+        }
+
+        let type_value: u8 = Decodable::consensus_decode(r)?;
+
+        let mut key = Vec::with_capacity(key_byte_size as usize);
+        for _ in 0..key_byte_size {
+            key.push(Decodable::consensus_decode(r)?);
+        }
+
+        Ok(Key { type_value, key })
+    }
+}
+
+impl Serialize for Key {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        VarInt::from(self.key.len() + 1)
+            .consensus_encode(&mut buf)
+            .expect("in-memory writers don't error");
+
+        self.type_value.consensus_encode(&mut buf).expect("in-memory writers don't error");
+
+        for key in &self.key {
+            key.consensus_encode(&mut buf).expect("in-memory writers don't error");
+        }
+
+        buf
+    }
+}
+
+impl Serialize for Pair {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend(self.key.serialize());
+        // <value> := <valuelen> <valuedata>
+        self.value.consensus_encode(&mut buf).unwrap();
+        buf
+    }
+}
+
+impl Deserialize for Pair {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        let mut decoder = bytes;
+        Pair::decode(&mut decoder)
+    }
+}
+
+impl Pair {
+    pub(crate) fn decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        Ok(Pair { key: Key::decode(r)?, value: Decodable::consensus_decode(r)? })
+    }
+}
+
+impl<Subtype> Encodable for ProprietaryKey<Subtype>
+where
+    Subtype: Copy + From<u8> + Into<u8>,
+{
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.prefix.consensus_encode(w)? + 1;
+        w.emit_u8(self.subtype.into())?;
+        w.write_all(&self.key)?;
+        len += self.key.len();
+        Ok(len)
+    }
+}
+
+impl<Subtype> Decodable for ProprietaryKey<Subtype>
+where
+    Subtype: Copy + From<u8> + Into<u8>,
+{
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let prefix = Vec::<u8>::consensus_decode(r)?;
+        let subtype = Subtype::from(r.read_u8()?);
+
+        // The limit is a DOS protection mechanism the exact value is not
+        // important, 1024 bytes is bigger than any key should be.
+        let mut key = vec![];
+        let _ = r.read_to_limit(&mut key, 1024)?;
+
+        Ok(ProprietaryKey { prefix, subtype, key })
+    }
+}
+
+impl<Subtype> ProprietaryKey<Subtype>
+where
+    Subtype: Copy + From<u8> + Into<u8>,
+{
+    /// Constructs full [Key] corresponding to this proprietary key type
+    pub fn to_key(&self) -> Key { Key { type_value: 0xFC, key: serialize(self) } }
+}
+
+impl<Subtype> TryFrom<Key> for ProprietaryKey<Subtype>
+where
+    Subtype: Copy + From<u8> + Into<u8>,
+{
+    type Error = Error;
+
+    /// Constructs a [`ProprietaryKey`] from a [`Key`].
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidProprietaryKey`] if `key` does not start with `0xFC` byte.
+    fn try_from(key: Key) -> Result<Self, Self::Error> {
+        if key.type_value != 0xFC {
+            return Err(Error::InvalidProprietaryKey);
+        }
+
+        Ok(deserialize(&key.key)?)
+    }
+}

--- a/libs/bitcoin/src/psbt/serialize.rs
+++ b/libs/bitcoin/src/psbt/serialize.rs
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! PSBT serialization.
+//!
+//! Traits to serialize PSBT values to and from raw bytes
+//! according to the BIP-174 specification.
+//!
+
+use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use hex::DisplayHex;
+use secp256k1::XOnlyPublicKey;
+
+use super::map::{Input, Map, Output, PsbtSighashType};
+use crate::bip32::{ChildNumber, Fingerprint, KeySource};
+use crate::blockdata::script::ScriptBuf;
+use crate::blockdata::transaction::{Transaction, TxOut};
+use crate::blockdata::witness::Witness;
+use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
+use crate::crypto::key::PublicKey;
+use crate::crypto::{ecdsa, taproot};
+use crate::io::Write;
+use crate::prelude::{String, Vec};
+use crate::psbt::{Error, Psbt};
+use crate::taproot::{
+    ControlBlock, LeafVersion, TapLeafHash, TapNodeHash, TapTree, TaprootBuilder,
+};
+use crate::VarInt;
+/// A trait for serializing a value as raw data for insertion into PSBT
+/// key-value maps.
+pub(crate) trait Serialize {
+    /// Serialize a value as raw data.
+    fn serialize(&self) -> Vec<u8>;
+}
+
+/// A trait for deserializing a value from raw data in PSBT key-value maps.
+pub(crate) trait Deserialize: Sized {
+    /// Deserialize a value from raw data.
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error>;
+}
+
+impl Psbt {
+    /// Serialize a value as bytes in hex.
+    pub fn serialize_hex(&self) -> String { self.serialize().to_lower_hex_string() }
+
+    /// Serialize as raw binary data
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        self.serialize_to_writer(&mut buf).expect("Writing to Vec can't fail");
+        buf
+    }
+
+    /// Serialize the PSBT into a writer.
+    pub fn serialize_to_writer(&self, w: &mut impl Write) -> io::Result<usize> {
+        let mut written_len = 0;
+
+        fn write_all(w: &mut impl Write, data: &[u8]) -> io::Result<usize> {
+            w.write_all(data).map(|_| data.len())
+        }
+
+        // magic
+        written_len += write_all(w, b"psbt")?;
+        // separator
+        written_len += write_all(w, &[0xff])?;
+
+        written_len += write_all(w, &self.serialize_map())?;
+
+        for i in &self.inputs {
+            written_len += write_all(w, &i.serialize_map())?;
+        }
+
+        for i in &self.outputs {
+            written_len += write_all(w, &i.serialize_map())?;
+        }
+
+        Ok(written_len)
+    }
+
+    /// Deserialize a value from raw binary data.
+    pub fn deserialize(mut bytes: &[u8]) -> Result<Self, Error> {
+        Self::deserialize_from_reader(&mut bytes)
+    }
+
+    /// Deserialize a value from raw binary data read from a `BufRead` object.
+    pub fn deserialize_from_reader<R: io::BufRead>(r: &mut R) -> Result<Self, Error> {
+        const MAGIC_BYTES: &[u8] = b"psbt";
+
+        let magic: [u8; 4] = Decodable::consensus_decode(r)?;
+        if magic != MAGIC_BYTES {
+            return Err(Error::InvalidMagic);
+        }
+
+        const PSBT_SERPARATOR: u8 = 0xff_u8;
+        let separator: u8 = Decodable::consensus_decode(r)?;
+        if separator != PSBT_SERPARATOR {
+            return Err(Error::InvalidSeparator);
+        }
+
+        let mut global = Psbt::decode_global(r)?;
+        global.unsigned_tx_checks()?;
+
+        let inputs: Vec<Input> = {
+            let inputs_len: usize = (global.unsigned_tx.input).len();
+
+            let mut inputs: Vec<Input> = Vec::with_capacity(inputs_len);
+
+            for _ in 0..inputs_len {
+                inputs.push(Input::decode(r)?);
+            }
+
+            inputs
+        };
+
+        let outputs: Vec<Output> = {
+            let outputs_len: usize = (global.unsigned_tx.output).len();
+
+            let mut outputs: Vec<Output> = Vec::with_capacity(outputs_len);
+
+            for _ in 0..outputs_len {
+                outputs.push(Output::decode(r)?);
+            }
+
+            outputs
+        };
+
+        global.inputs = inputs;
+        global.outputs = outputs;
+        Ok(global)
+    }
+}
+impl_psbt_de_serialize!(Transaction);
+impl_psbt_de_serialize!(TxOut);
+impl_psbt_de_serialize!(Witness);
+impl_psbt_hash_de_serialize!(ripemd160::Hash);
+impl_psbt_hash_de_serialize!(sha256::Hash);
+impl_psbt_hash_de_serialize!(TapLeafHash);
+impl_psbt_hash_de_serialize!(TapNodeHash);
+impl_psbt_hash_de_serialize!(hash160::Hash);
+impl_psbt_hash_de_serialize!(sha256d::Hash);
+
+// taproot
+impl_psbt_de_serialize!(Vec<TapLeafHash>);
+
+impl Serialize for ScriptBuf {
+    fn serialize(&self) -> Vec<u8> { self.to_bytes() }
+}
+
+impl Deserialize for ScriptBuf {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> { Ok(Self::from(bytes.to_vec())) }
+}
+
+impl Serialize for PublicKey {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.write_into(&mut buf).expect("vecs don't error");
+        buf
+    }
+}
+
+impl Deserialize for PublicKey {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        PublicKey::from_slice(bytes).map_err(Error::InvalidPublicKey)
+    }
+}
+
+impl Serialize for secp256k1::PublicKey {
+    fn serialize(&self) -> Vec<u8> { self.serialize().to_vec() }
+}
+
+impl Deserialize for secp256k1::PublicKey {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        secp256k1::PublicKey::from_slice(bytes).map_err(Error::InvalidSecp256k1PublicKey)
+    }
+}
+
+impl Serialize for ecdsa::Signature {
+    fn serialize(&self) -> Vec<u8> { self.to_vec() }
+}
+
+impl Deserialize for ecdsa::Signature {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        // NB: Since BIP-174 says "the signature as would be pushed to the stack from
+        // a scriptSig or witness" we should ideally use a consensus deserialization and do
+        // not error on a non-standard values. However,
+        //
+        // 1) the current implementation of from_u32_consensus(`flag`) does not preserve
+        // the sighash byte `flag` mapping all unknown values to EcdsaSighashType::All or
+        // EcdsaSighashType::AllPlusAnyOneCanPay. Therefore, break the invariant
+        // EcdsaSig::from_slice(&sl[..]).to_vec = sl.
+        //
+        // 2) This would cause to have invalid signatures because the sighash message
+        // also has a field sighash_u32 (See BIP141). For example, when signing with non-standard
+        // 0x05, the sighash message would have the last field as 0x05u32 while, the verification
+        // would use check the signature assuming sighash_u32 as `0x01`.
+        ecdsa::Signature::from_slice(bytes).map_err(|e| match e {
+            ecdsa::Error::EmptySignature => Error::InvalidEcdsaSignature(e),
+            ecdsa::Error::SighashType(err) => Error::NonStandardSighashType(err.0),
+            ecdsa::Error::Secp256k1(..) => Error::InvalidEcdsaSignature(e),
+            ecdsa::Error::Hex(..) => unreachable!("Decoding from slice, not hex"),
+        })
+    }
+}
+
+impl Serialize for KeySource {
+    fn serialize(&self) -> Vec<u8> {
+        let mut rv: Vec<u8> = Vec::with_capacity(key_source_len(self));
+
+        rv.append(&mut self.0.to_bytes().to_vec());
+
+        for cnum in self.1.into_iter() {
+            rv.append(&mut serialize(&u32::from(*cnum)))
+        }
+
+        rv
+    }
+}
+
+impl Deserialize for KeySource {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() < 4 {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
+        }
+
+        let fprint: Fingerprint = bytes[0..4].try_into().expect("4 is the fingerprint length");
+        let mut dpath: Vec<ChildNumber> = Default::default();
+
+        let mut d = &bytes[4..];
+        while !d.is_empty() {
+            match u32::consensus_decode(&mut d) {
+                Ok(index) => dpath.push(index.into()),
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        Ok((fprint, dpath.into()))
+    }
+}
+
+// partial sigs
+impl Serialize for Vec<u8> {
+    fn serialize(&self) -> Vec<u8> { self.clone() }
+}
+
+impl Deserialize for Vec<u8> {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> { Ok(bytes.to_vec()) }
+}
+
+impl Serialize for PsbtSighashType {
+    fn serialize(&self) -> Vec<u8> { serialize(&self.to_u32()) }
+}
+
+impl Deserialize for PsbtSighashType {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        let raw: u32 = encode::deserialize(bytes)?;
+        Ok(PsbtSighashType { inner: raw })
+    }
+}
+
+// Taproot related ser/deser
+impl Serialize for XOnlyPublicKey {
+    fn serialize(&self) -> Vec<u8> { XOnlyPublicKey::serialize(self).to_vec() }
+}
+
+impl Deserialize for XOnlyPublicKey {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        XOnlyPublicKey::from_slice(bytes).map_err(|_| Error::InvalidXOnlyPublicKey)
+    }
+}
+
+impl Serialize for taproot::Signature {
+    fn serialize(&self) -> Vec<u8> { self.to_vec() }
+}
+
+impl Deserialize for taproot::Signature {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        use taproot::SigFromSliceError::*;
+
+        taproot::Signature::from_slice(bytes).map_err(|e| match e {
+            SighashType(err) => Error::NonStandardSighashType(err.0),
+            InvalidSignatureSize(_) => Error::InvalidTaprootSignature(e),
+            Secp256k1(..) => Error::InvalidTaprootSignature(e),
+        })
+    }
+}
+
+impl Serialize for (XOnlyPublicKey, TapLeafHash) {
+    fn serialize(&self) -> Vec<u8> {
+        let ser_pk = self.0.serialize();
+        let mut buf = Vec::with_capacity(ser_pk.len() + self.1.as_byte_array().len());
+        buf.extend(&ser_pk);
+        buf.extend(self.1.as_byte_array());
+        buf
+    }
+}
+
+impl Deserialize for (XOnlyPublicKey, TapLeafHash) {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() < 32 {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
+        }
+        let a: XOnlyPublicKey = Deserialize::deserialize(&bytes[..32])?;
+        let b: TapLeafHash = Deserialize::deserialize(&bytes[32..])?;
+        Ok((a, b))
+    }
+}
+
+impl Serialize for ControlBlock {
+    fn serialize(&self) -> Vec<u8> { ControlBlock::serialize(self) }
+}
+
+impl Deserialize for ControlBlock {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        Self::decode(bytes).map_err(|_| Error::InvalidControlBlock)
+    }
+}
+
+// Versioned ScriptBuf
+impl Serialize for (ScriptBuf, LeafVersion) {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.0.len() + 1);
+        buf.extend(self.0.as_bytes());
+        buf.push(self.1.to_consensus());
+        buf
+    }
+}
+
+impl Deserialize for (ScriptBuf, LeafVersion) {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.is_empty() {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
+        }
+        // The last byte is LeafVersion.
+        let script = ScriptBuf::deserialize(&bytes[..bytes.len() - 1])?;
+        let leaf_ver = LeafVersion::from_consensus(bytes[bytes.len() - 1])
+            .map_err(|_| Error::InvalidLeafVersion)?;
+        Ok((script, leaf_ver))
+    }
+}
+
+impl Serialize for (Vec<TapLeafHash>, KeySource) {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(32 * self.0.len() + key_source_len(&self.1));
+        self.0.consensus_encode(&mut buf).expect("Vecs don't error allocation");
+        buf.extend(self.1.serialize());
+        buf
+    }
+}
+
+impl Deserialize for (Vec<TapLeafHash>, KeySource) {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        let (leafhash_vec, consumed) = deserialize_partial::<Vec<TapLeafHash>>(bytes)?;
+        let key_source = KeySource::deserialize(&bytes[consumed..])?;
+        Ok((leafhash_vec, key_source))
+    }
+}
+
+impl Serialize for TapTree {
+    fn serialize(&self) -> Vec<u8> {
+        let capacity = self
+            .script_leaves()
+            .map(|l| {
+                l.script().len() + VarInt::from(l.script().len()).size() // script version
+            + 1 // merkle branch
+            + 1 // leaf version
+            })
+            .sum::<usize>();
+        let mut buf = Vec::with_capacity(capacity);
+        for leaf_info in self.script_leaves() {
+            // # Cast Safety:
+            //
+            // TaprootMerkleBranch can only have len atmost 128(TAPROOT_CONTROL_MAX_NODE_COUNT).
+            // safe to cast from usize to u8
+            buf.push(leaf_info.merkle_branch().len() as u8);
+            buf.push(leaf_info.version().to_consensus());
+            leaf_info.script().consensus_encode(&mut buf).expect("Vecs dont err");
+        }
+        buf
+    }
+}
+
+impl Deserialize for TapTree {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        let mut builder = TaprootBuilder::new();
+        let mut bytes_iter = bytes.iter();
+        while let Some(depth) = bytes_iter.next() {
+            let version = bytes_iter.next().ok_or(Error::Taproot("Invalid Taproot Builder"))?;
+            let (script, consumed) = deserialize_partial::<ScriptBuf>(bytes_iter.as_slice())?;
+            if consumed > 0 {
+                bytes_iter.nth(consumed - 1);
+            }
+            let leaf_version =
+                LeafVersion::from_consensus(*version).map_err(|_| Error::InvalidLeafVersion)?;
+            builder = builder
+                .add_leaf_with_ver(*depth, script, leaf_version)
+                .map_err(|_| Error::Taproot("Tree not in DFS order"))?;
+        }
+        TapTree::try_from(builder).map_err(Error::TapTree)
+    }
+}
+
+// Helper function to compute key source len
+fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).as_ref().len() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Composes tree matching a given depth map, filled with dumb script leafs,
+    // each of which consists of a single push-int op code, with int value
+    // increased for each consecutive leaf.
+    pub fn compose_taproot_builder<'map>(
+        opcode: u8,
+        depth_map: impl IntoIterator<Item = &'map u8>,
+    ) -> TaprootBuilder {
+        let mut val = opcode;
+        let mut builder = TaprootBuilder::new();
+        for depth in depth_map {
+            let script = ScriptBuf::from_hex(&format!("{:02x}", val)).unwrap();
+            builder = builder.add_leaf(*depth, script).unwrap();
+            let (new_val, _) = val.overflowing_add(1);
+            val = new_val;
+        }
+        builder
+    }
+
+    #[test]
+    fn taptree_hidden() {
+        let mut builder = compose_taproot_builder(0x51, &[2, 2, 2]);
+        builder = builder
+            .add_leaf_with_ver(
+                3,
+                ScriptBuf::from_hex("b9").unwrap(),
+                LeafVersion::from_consensus(0xC2).unwrap(),
+            )
+            .unwrap();
+        builder = builder.add_hidden_node(3, TapNodeHash::all_zeros()).unwrap();
+        assert!(TapTree::try_from(builder).is_err());
+    }
+
+    #[test]
+    fn taptree_roundtrip() {
+        let mut builder = compose_taproot_builder(0x51, &[2, 2, 2, 3]);
+        builder = builder
+            .add_leaf_with_ver(
+                3,
+                ScriptBuf::from_hex("b9").unwrap(),
+                LeafVersion::from_consensus(0xC2).unwrap(),
+            )
+            .unwrap();
+        let tree = TapTree::try_from(builder).unwrap();
+        let tree_prime = TapTree::deserialize(&tree.serialize()).unwrap();
+        assert_eq!(tree, tree_prime);
+    }
+
+    #[test]
+    fn can_deserialize_non_standard_psbt_sighash_type() {
+        let non_standard_sighash = [222u8, 0u8, 0u8, 0u8]; // 32 byte value.
+        let sighash = PsbtSighashType::deserialize(&non_standard_sighash);
+        assert!(sighash.is_ok())
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidMagic")]
+    fn invalid_vector_1() {
+        let hex_psbt = b"0200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf6000000006a473044022070b2245123e6bf474d60c5b50c043d4c691a5d2435f09a34a7662a9dc251790a022001329ca9dacf280bdf30740ec0390422422c81cb45839457aeb76fc12edd95b3012102657d118d3357b8e0f4c2cd46db7b39f6d9c38d9a70abcb9b2de5dc8dbfe4ce31feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300";
+        Psbt::deserialize(hex_psbt).unwrap();
+    }
+}

--- a/libs/bitcoin/src/taproot/merkle_branch.rs
+++ b/libs/bitcoin/src/taproot/merkle_branch.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Contains `TaprootMerkleBranch` and its associated types.
+
+use hashes::Hash;
+
+use super::{
+    TapNodeHash, TaprootBuilderError, TaprootError, TAPROOT_CONTROL_MAX_NODE_COUNT,
+    TAPROOT_CONTROL_NODE_SIZE,
+};
+use crate::prelude::*;
+
+/// The merkle proof for inclusion of a tree in a taptree hash.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(into = "Vec<TapNodeHash>"))]
+#[cfg_attr(feature = "serde", serde(try_from = "Vec<TapNodeHash>"))]
+pub struct TaprootMerkleBranch(Vec<TapNodeHash>);
+
+impl TaprootMerkleBranch {
+    /// Returns a reference to the slice of hashes.
+    #[deprecated(since = "0.32.0", note = "Use `as_slice` instead")]
+    #[inline]
+    pub fn as_inner(&self) -> &[TapNodeHash] { &self.0 }
+
+    /// Returns a reference to the slice of hashes.
+    #[inline]
+    pub fn as_slice(&self) -> &[TapNodeHash] { &self.0 }
+
+    /// Returns the number of nodes in this merkle proof.
+    #[inline]
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Checks if this merkle proof is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Decodes bytes from control block.
+    ///
+    /// This reads the branch as encoded in the control block: the concatenated 32B byte chunks -
+    /// one for each hash.
+    ///
+    /// # Errors
+    ///
+    /// The function returns an error if the number of bytes is not an integer multiple of 32 or
+    /// if the number of hashes exceeds 128.
+    pub fn decode(sl: &[u8]) -> Result<Self, TaprootError> {
+        if sl.len() % TAPROOT_CONTROL_NODE_SIZE != 0 {
+            Err(TaprootError::InvalidMerkleBranchSize(sl.len()))
+        } else if sl.len() > TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT {
+            Err(TaprootError::InvalidMerkleTreeDepth(sl.len() / TAPROOT_CONTROL_NODE_SIZE))
+        } else {
+            let inner = sl
+                .chunks_exact(TAPROOT_CONTROL_NODE_SIZE)
+                .map(|chunk| {
+                    TapNodeHash::from_slice(chunk)
+                        .expect("chunks_exact always returns the correct size")
+                })
+                .collect();
+
+            Ok(TaprootMerkleBranch(inner))
+        }
+    }
+
+    /// Creates a merkle proof from list of hashes.
+    ///
+    /// # Errors
+    /// If inner proof length is more than [`TAPROOT_CONTROL_MAX_NODE_COUNT`] (128).
+    #[inline]
+    fn from_collection<T: AsRef<[TapNodeHash]> + Into<Vec<TapNodeHash>>>(
+        collection: T,
+    ) -> Result<Self, TaprootError> {
+        if collection.as_ref().len() > TAPROOT_CONTROL_MAX_NODE_COUNT {
+            Err(TaprootError::InvalidMerkleTreeDepth(collection.as_ref().len()))
+        } else {
+            Ok(TaprootMerkleBranch(collection.into()))
+        }
+    }
+
+    /// Serializes to a writer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written to the writer.
+    pub fn encode<Write: io::Write + ?Sized>(&self, writer: &mut Write) -> io::Result<usize> {
+        for hash in self {
+            writer.write_all(hash.as_ref())?;
+        }
+        Ok(self.len() * TapNodeHash::LEN)
+    }
+
+    /// Serializes `self` as bytes.
+    pub fn serialize(&self) -> Vec<u8> {
+        self.iter().flat_map(|e| e.as_byte_array()).copied().collect::<Vec<u8>>()
+    }
+
+    /// Appends elements to proof.
+    pub(super) fn push(&mut self, h: TapNodeHash) -> Result<(), TaprootBuilderError> {
+        if self.len() >= TAPROOT_CONTROL_MAX_NODE_COUNT {
+            Err(TaprootBuilderError::InvalidMerkleTreeDepth(self.0.len()))
+        } else {
+            self.0.push(h);
+            Ok(())
+        }
+    }
+
+    /// Returns the inner list of hashes.
+    #[deprecated(since = "0.32.0", note = "Use `into_vec` instead")]
+    #[inline]
+    pub fn into_inner(self) -> Vec<TapNodeHash> { self.0 }
+
+    /// Returns the list of hashes stored in a `Vec`.
+    #[inline]
+    pub fn into_vec(self) -> Vec<TapNodeHash> { self.0 }
+}
+
+macro_rules! impl_try_from {
+    ($from:ty) => {
+        impl TryFrom<$from> for TaprootMerkleBranch {
+            type Error = TaprootError;
+
+            /// Creates a merkle proof from list of hashes.
+            ///
+            /// # Errors
+            /// If inner proof length is more than [`TAPROOT_CONTROL_MAX_NODE_COUNT`] (128).
+            #[inline]
+            fn try_from(v: $from) -> Result<Self, Self::Error> {
+                TaprootMerkleBranch::from_collection(v)
+            }
+        }
+    };
+}
+impl_try_from!(&[TapNodeHash]);
+impl_try_from!(Vec<TapNodeHash>);
+impl_try_from!(Box<[TapNodeHash]>);
+
+macro_rules! impl_try_from_array {
+    ($($len:expr),* $(,)?) => {
+        $(
+            impl From<[TapNodeHash; $len]> for TaprootMerkleBranch {
+                #[inline]
+                fn from(a: [TapNodeHash; $len]) -> Self {
+                    Self(a.to_vec())
+                }
+            }
+        )*
+    }
+}
+// Implement for all values [0, 128] inclusive.
+//
+// The reason zero is included is that `TaprootMerkleBranch` doesn't contain the hash of the node
+// that's being proven - it's not needed because the script is already right before control block.
+impl_try_from_array!(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+    74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+    98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+    117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128
+);
+
+impl From<TaprootMerkleBranch> for Vec<TapNodeHash> {
+    #[inline]
+    fn from(branch: TaprootMerkleBranch) -> Self { branch.0 }
+}
+
+impl IntoIterator for TaprootMerkleBranch {
+    type IntoIter = IntoIter;
+    type Item = TapNodeHash;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { IntoIter(self.0.into_iter()) }
+}
+
+impl<'a> IntoIterator for &'a TaprootMerkleBranch {
+    type IntoIter = core::slice::Iter<'a, TapNodeHash>;
+    type Item = &'a TapNodeHash;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { self.0.iter() }
+}
+
+impl<'a> IntoIterator for &'a mut TaprootMerkleBranch {
+    type IntoIter = core::slice::IterMut<'a, TapNodeHash>;
+    type Item = &'a mut TapNodeHash;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { self.0.iter_mut() }
+}
+
+impl core::ops::Deref for TaprootMerkleBranch {
+    type Target = [TapNodeHash];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl core::ops::DerefMut for TaprootMerkleBranch {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+}
+
+impl AsRef<[TapNodeHash]> for TaprootMerkleBranch {
+    #[inline]
+    fn as_ref(&self) -> &[TapNodeHash] { &self.0 }
+}
+
+impl AsMut<[TapNodeHash]> for TaprootMerkleBranch {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [TapNodeHash] { &mut self.0 }
+}
+
+impl Borrow<[TapNodeHash]> for TaprootMerkleBranch {
+    #[inline]
+    fn borrow(&self) -> &[TapNodeHash] { &self.0 }
+}
+
+impl BorrowMut<[TapNodeHash]> for TaprootMerkleBranch {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [TapNodeHash] { &mut self.0 }
+}
+
+/// Iterator over node hashes within Taproot merkle branch.
+///
+/// This is created by `into_iter` method on `TaprootMerkleBranch` (via `IntoIterator` trait).
+#[derive(Clone, Debug)]
+pub struct IntoIter(alloc::vec::IntoIter<TapNodeHash>);
+
+impl IntoIter {
+    /// Returns the remaining items of this iterator as a slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[TapNodeHash] { self.0.as_slice() }
+
+    /// Returns the remaining items of this iterator as a mutable slice.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [TapNodeHash] { self.0.as_mut_slice() }
+}
+
+impl Iterator for IntoIter {
+    type Item = TapNodeHash;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) { self.0.size_hint() }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> { self.0.nth(n) }
+
+    #[inline]
+    fn last(self) -> Option<Self::Item> { self.0.last() }
+
+    #[inline]
+    fn count(self) -> usize { self.0.count() }
+}
+
+impl DoubleEndedIterator for IntoIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> { self.0.next_back() }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> { self.0.nth_back(n) }
+}
+
+impl ExactSizeIterator for IntoIter {}
+
+impl core::iter::FusedIterator for IntoIter {}

--- a/libs/bitcoin/src/taproot/mod.rs
+++ b/libs/bitcoin/src/taproot/mod.rs
@@ -1,0 +1,2022 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin Taproot.
+//!
+//! This module provides support for taproot tagged hashes.
+//!
+
+pub mod merkle_branch;
+pub mod serialized_signature;
+
+use core::cmp::Reverse;
+use core::fmt;
+use core::iter::FusedIterator;
+
+use hashes::{sha256t_hash_newtype, Hash, HashEngine};
+use internals::write_err;
+use io::Write;
+use secp256k1::{Scalar, Secp256k1};
+
+use crate::consensus::Encodable;
+use crate::crypto::key::{TapTweak, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey};
+use crate::prelude::*;
+use crate::{Script, ScriptBuf};
+
+// Re-export these so downstream only has to use one `taproot` module.
+#[rustfmt::skip]
+#[doc(inline)]
+pub use crate::crypto::taproot::{SigFromSliceError, Signature};
+#[doc(inline)]
+pub use merkle_branch::TaprootMerkleBranch;
+
+// Taproot test vectors from BIP-341 state the hashes without any reversing
+sha256t_hash_newtype! {
+    pub struct TapLeafTag = hash_str("TapLeaf");
+
+    /// Taproot-tagged hash with tag \"TapLeaf\".
+    ///
+    /// This is used for computing tapscript script spend hash.
+    #[hash_newtype(forward)]
+    pub struct TapLeafHash(_);
+
+    pub struct TapBranchTag = hash_str("TapBranch");
+
+    /// Tagged hash used in taproot trees.
+    ///
+    /// See BIP-340 for tagging rules.
+    #[hash_newtype(forward)]
+    pub struct TapNodeHash(_);
+
+    pub struct TapTweakTag = hash_str("TapTweak");
+
+    /// Taproot-tagged hash with tag \"TapTweak\".
+    ///
+    /// This hash type is used while computing the tweaked public key.
+    #[hash_newtype(forward)]
+    pub struct TapTweakHash(_);
+}
+
+impl TapTweakHash {
+    /// Creates a new BIP341 [`TapTweakHash`] from key and tweak. Produces `H_taptweak(P||R)` where
+    /// `P` is the internal key and `R` is the merkle root.
+    pub fn from_key_and_tweak(
+        internal_key: UntweakedPublicKey,
+        merkle_root: Option<TapNodeHash>,
+    ) -> TapTweakHash {
+        let mut eng = TapTweakHash::engine();
+        // always hash the key
+        eng.input(&internal_key.serialize());
+        if let Some(h) = merkle_root {
+            eng.input(h.as_ref());
+        } else {
+            // nothing to hash
+        }
+        TapTweakHash::from_engine(eng)
+    }
+
+    /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
+    pub fn to_scalar(self) -> Scalar {
+        // This is statistically extremely unlikely to panic.
+        Scalar::from_be_bytes(self.to_byte_array()).expect("hash value greater than curve order")
+    }
+}
+
+impl TapLeafHash {
+    /// Computes the leaf hash from components.
+    pub fn from_script(script: &Script, ver: LeafVersion) -> TapLeafHash {
+        let mut eng = TapLeafHash::engine();
+        ver.to_consensus()
+            .consensus_encode(&mut eng)
+            .expect("engines don't error");
+        script
+            .consensus_encode(&mut eng)
+            .expect("engines don't error");
+        TapLeafHash::from_engine(eng)
+    }
+}
+
+impl From<LeafNode> for TapNodeHash {
+    fn from(leaf: LeafNode) -> TapNodeHash {
+        leaf.node_hash()
+    }
+}
+
+impl From<&LeafNode> for TapNodeHash {
+    fn from(leaf: &LeafNode) -> TapNodeHash {
+        leaf.node_hash()
+    }
+}
+
+impl TapNodeHash {
+    /// Computes branch hash given two hashes of the nodes underneath it.
+    pub fn from_node_hashes(a: TapNodeHash, b: TapNodeHash) -> TapNodeHash {
+        Self::combine_node_hashes(a, b).0
+    }
+
+    /// Computes branch hash given two hashes of the nodes underneath it and returns
+    /// whether the left node was the one hashed first.
+    fn combine_node_hashes(a: TapNodeHash, b: TapNodeHash) -> (TapNodeHash, bool) {
+        let mut eng = TapNodeHash::engine();
+        if a < b {
+            eng.input(a.as_ref());
+            eng.input(b.as_ref());
+        } else {
+            eng.input(b.as_ref());
+            eng.input(a.as_ref());
+        };
+        (TapNodeHash::from_engine(eng), a < b)
+    }
+
+    /// Assumes the given 32 byte array as hidden [`TapNodeHash`].
+    ///
+    /// Similar to [`TapLeafHash::from_byte_array`], but explicitly conveys that the
+    /// hash is constructed from a hidden node. This also has better ergonomics
+    /// because it does not require the caller to import the Hash trait.
+    pub fn assume_hidden(hash: [u8; 32]) -> TapNodeHash {
+        TapNodeHash::from_byte_array(hash)
+    }
+
+    /// Computes the [`TapNodeHash`] from a script and a leaf version.
+    pub fn from_script(script: &Script, ver: LeafVersion) -> TapNodeHash {
+        TapNodeHash::from(TapLeafHash::from_script(script, ver))
+    }
+}
+
+impl From<TapLeafHash> for TapNodeHash {
+    fn from(leaf: TapLeafHash) -> TapNodeHash {
+        TapNodeHash::from_byte_array(leaf.to_byte_array())
+    }
+}
+
+/// Maximum depth of a taproot tree script spend path.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L229
+pub const TAPROOT_CONTROL_MAX_NODE_COUNT: usize = 128;
+/// Size of a taproot control node.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L228
+pub const TAPROOT_CONTROL_NODE_SIZE: usize = 32;
+/// Tapleaf mask for getting the leaf version from first byte of control block.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L225
+pub const TAPROOT_LEAF_MASK: u8 = 0xfe;
+/// Tapscript leaf version.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L226
+pub const TAPROOT_LEAF_TAPSCRIPT: u8 = 0xc0;
+/// Taproot annex prefix.
+pub const TAPROOT_ANNEX_PREFIX: u8 = 0x50;
+/// Tapscript control base size.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L227
+pub const TAPROOT_CONTROL_BASE_SIZE: usize = 33;
+/// Tapscript control max size.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L230
+pub const TAPROOT_CONTROL_MAX_SIZE: usize =
+    TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
+
+// type alias for versioned tap script corresponding merkle proof
+type ScriptMerkleProofMap = BTreeMap<(ScriptBuf, LeafVersion), BTreeSet<TaprootMerkleBranch>>;
+
+/// Represents taproot spending information.
+///
+/// Taproot output corresponds to a combination of a single public key condition (known as the
+/// internal key), and zero or more general conditions encoded in scripts organized in the form of a
+/// binary tree.
+///
+/// Taproot can be spent by either:
+/// - Spending using the key path i.e., with secret key corresponding to the tweaked `output_key`.
+/// - By satisfying any of the scripts in the script spend path. Each script can be satisfied by
+///   providing a witness stack consisting of the script's inputs, plus the script itself and the
+///   control block.
+///
+/// If one or more of the spending conditions consist of just a single key (after aggregation), the
+/// most likely key should be made the internal key.
+/// See [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) for more details on
+/// choosing internal keys for a taproot application.
+///
+/// Note: This library currently does not support
+/// [annex](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-5).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TaprootSpendInfo {
+    /// The BIP341 internal key.
+    internal_key: UntweakedPublicKey,
+    /// The merkle root of the script tree (None if there are no scripts).
+    merkle_root: Option<TapNodeHash>,
+    /// The sign final output pubkey as per BIP 341.
+    output_key_parity: secp256k1::Parity,
+    /// The tweaked output key.
+    output_key: TweakedPublicKey,
+    /// Map from (script, leaf_version) to (sets of) [`TaprootMerkleBranch`]. More than one control
+    /// block for a given script is only possible if it appears in multiple branches of the tree. In
+    /// all cases, keeping one should be enough for spending funds, but we keep all of the paths so
+    /// that a full tree can be constructed again from spending data if required.
+    script_map: ScriptMerkleProofMap,
+}
+
+impl TaprootSpendInfo {
+    /// Creates a new [`TaprootSpendInfo`] from a list of scripts (with default script version) and
+    /// weights of satisfaction for that script.
+    ///
+    /// See [`TaprootBuilder::with_huffman_tree`] for more detailed documentation.
+    pub fn with_huffman_tree<C, I>(
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+        script_weights: I,
+    ) -> Result<Self, TaprootBuilderError>
+    where
+        I: IntoIterator<Item = (u32, ScriptBuf)>,
+        C: secp256k1::Verification,
+    {
+        let builder = TaprootBuilder::with_huffman_tree(script_weights)?;
+        Ok(builder
+            .finalize(secp, internal_key)
+            .expect("Huffman Tree is always complete"))
+    }
+
+    /// Creates a new key spend with `internal_key` and `merkle_root`. Provide [`None`] for
+    /// the `merkle_root` if there is no script path.
+    ///
+    /// *Note*: As per BIP341
+    ///
+    /// When the merkle root is [`None`], the output key commits to an unspendable script path
+    /// instead of having no script path. This is achieved by computing the output key point as
+    /// `Q = P + int(hashTapTweak(bytes(P)))G`. See also [`TaprootSpendInfo::tap_tweak`].
+    ///
+    /// Refer to BIP 341 footnote ('Why should the output key always have a taproot commitment, even
+    /// if there is no script path?') for more details.
+    pub fn new_key_spend<C: secp256k1::Verification>(
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let (output_key, parity) = internal_key.tap_tweak(secp, merkle_root);
+        Self {
+            internal_key,
+            merkle_root,
+            output_key_parity: parity,
+            output_key,
+            script_map: BTreeMap::new(),
+        }
+    }
+
+    /// Returns the `TapTweakHash` for this [`TaprootSpendInfo`] i.e., the tweak using `internal_key`
+    /// and `merkle_root`.
+    pub fn tap_tweak(&self) -> TapTweakHash {
+        TapTweakHash::from_key_and_tweak(self.internal_key, self.merkle_root)
+    }
+
+    /// Returns the internal key for this [`TaprootSpendInfo`].
+    pub fn internal_key(&self) -> UntweakedPublicKey {
+        self.internal_key
+    }
+
+    /// Returns the merkle root for this [`TaprootSpendInfo`].
+    pub fn merkle_root(&self) -> Option<TapNodeHash> {
+        self.merkle_root
+    }
+
+    /// Returns the output key (the key used in script pubkey) for this [`TaprootSpendInfo`].
+    pub fn output_key(&self) -> TweakedPublicKey {
+        self.output_key
+    }
+
+    /// Returns the parity of the output key. See also [`TaprootSpendInfo::output_key`].
+    pub fn output_key_parity(&self) -> secp256k1::Parity {
+        self.output_key_parity
+    }
+
+    /// Returns a reference to the internal script map.
+    pub fn script_map(&self) -> &ScriptMerkleProofMap {
+        &self.script_map
+    }
+
+    /// Computes the [`TaprootSpendInfo`] from `internal_key` and `node`.
+    ///
+    /// This is useful when you want to manually build a taproot tree without using
+    /// [`TaprootBuilder`].
+    pub fn from_node_info<C: secp256k1::Verification>(
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+        node: NodeInfo,
+    ) -> TaprootSpendInfo {
+        // Create as if it is a key spend path with the given merkle root
+        let root_hash = Some(node.hash);
+        let mut info = TaprootSpendInfo::new_key_spend(secp, internal_key, root_hash);
+
+        for leaves in node.leaves {
+            match leaves.leaf {
+                TapLeaf::Hidden(_) => {
+                    // We don't store any information about hidden nodes in TaprootSpendInfo.
+                }
+                TapLeaf::Script(script, ver) => {
+                    let key = (script, ver);
+                    let value = leaves.merkle_branch;
+                    match info.script_map.get_mut(&key) {
+                        None => {
+                            let mut set = BTreeSet::new();
+                            set.insert(value);
+                            info.script_map.insert(key, set);
+                        }
+                        Some(set) => {
+                            set.insert(value);
+                        }
+                    }
+                }
+            }
+        }
+        info
+    }
+
+    /// Constructs a [`ControlBlock`] for particular script with the given version.
+    ///
+    /// # Returns
+    ///
+    /// - If there are multiple control blocks possible, returns the shortest one.
+    /// - If the script is not contained in the [`TaprootSpendInfo`], returns `None`.
+    pub fn control_block(&self, script_ver: &(ScriptBuf, LeafVersion)) -> Option<ControlBlock> {
+        let merkle_branch_set = self.script_map.get(script_ver)?;
+        // Choose the smallest one amongst the multiple script maps
+        let smallest = merkle_branch_set
+            .iter()
+            .min_by(|x, y| x.len().cmp(&y.len()))
+            .expect("Invariant: ScriptBuf map key must contain non-empty set value");
+        Some(ControlBlock {
+            internal_key: self.internal_key,
+            output_key_parity: self.output_key_parity,
+            leaf_version: script_ver.1,
+            merkle_branch: smallest.clone(),
+        })
+    }
+}
+
+impl From<TaprootSpendInfo> for TapTweakHash {
+    fn from(spend_info: TaprootSpendInfo) -> TapTweakHash {
+        spend_info.tap_tweak()
+    }
+}
+
+impl From<&TaprootSpendInfo> for TapTweakHash {
+    fn from(spend_info: &TaprootSpendInfo) -> TapTweakHash {
+        spend_info.tap_tweak()
+    }
+}
+
+/// Builder for building taproot iteratively. Users can specify tap leaf or omitted/hidden branches
+/// in a depth-first search (DFS) walk order to construct this tree.
+///
+/// See Wikipedia for more details on [DFS](https://en.wikipedia.org/wiki/Depth-first_search).
+// Similar to Taproot Builder in Bitcoin Core.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TaprootBuilder {
+    // The following doc-comment is from Bitcoin Core, but modified for Rust. It describes the
+    // current state of the builder for a given tree.
+    //
+    // For each level in the tree, one NodeInfo object may be present. Branch at index 0 is
+    // information about the root; further values are for deeper subtrees being explored.
+    //
+    // During the construction of Taptree, for every right branch taken to reach the position we're
+    // currently working on, there will be a `(Some(_))` entry in branch corresponding to the left
+    // branch at that level.
+    //
+    // For example, imagine this tree:     - N0 -
+    //                                    /      \
+    //                                   N1      N2
+    //                                  /  \    /  \
+    //                                 A    B  C   N3
+    //                                            /  \
+    //                                           D    E
+    //
+    // Initially, branch is empty. After processing leaf A, it would become {None, None, A}. When
+    // processing leaf B, an entry at level 2 already exists, and it would thus be combined with it
+    // to produce a level 1 entry, resulting in {None, N1}. Adding C and D takes us to {None, N1, C}
+    // and {None, N1, C, D} respectively. When E is processed, it is combined with D, and then C,
+    // and then N1, to produce the root, resulting in {N0}.
+    //
+    // This structure allows processing with just O(log n) overhead if the leaves are computed on
+    // the fly.
+    //
+    // As an invariant, there can never be None entries at the end. There can also not be more than
+    // 128 entries (as that would mean more than 128 levels in the tree). The depth of newly added
+    // entries will always be at least equal to the current size of branch (otherwise it does not
+    // correspond to a depth-first traversal of a tree). A branch is only empty if no entries have
+    // ever be processed. A branch having length 1 corresponds to being done.
+    branch: Vec<Option<NodeInfo>>,
+}
+
+impl TaprootBuilder {
+    /// Creates a new instance of [`TaprootBuilder`].
+    pub fn new() -> Self {
+        TaprootBuilder { branch: vec![] }
+    }
+
+    /// Creates a new instance of [`TaprootBuilder`] with a capacity hint for `size` elements.
+    ///
+    /// The size here should be maximum depth of the tree.
+    pub fn with_capacity(size: usize) -> Self {
+        TaprootBuilder {
+            branch: Vec::with_capacity(size),
+        }
+    }
+
+    /// Creates a new [`TaprootSpendInfo`] from a list of scripts (with default script version) and
+    /// weights of satisfaction for that script.
+    ///
+    /// The weights represent the probability of each branch being taken. If probabilities/weights
+    /// for each condition are known, constructing the tree as a Huffman Tree is the optimal way to
+    /// minimize average case satisfaction cost. This function takes as input an iterator of
+    /// `tuple(u32, ScriptBuf)` where `u32` represents the satisfaction weights of the branch. For
+    /// example, [(3, S1), (2, S2), (5, S3)] would construct a [`TapTree`] that has optimal
+    /// satisfaction weight when probability for S1 is 30%, S2 is 20% and S3 is 50%.
+    ///
+    /// # Errors:
+    ///
+    /// - When the optimal Huffman Tree has a depth more than 128.
+    /// - If the provided list of script weights is empty.
+    ///
+    /// # Edge Cases:
+    ///
+    /// If the script weight calculations overflow, a sub-optimal tree may be generated. This should
+    /// not happen unless you are dealing with billions of branches with weights close to 2^32.
+    ///
+    /// [`TapTree`]: crate::taproot::TapTree
+    pub fn with_huffman_tree<I>(script_weights: I) -> Result<Self, TaprootBuilderError>
+    where
+        I: IntoIterator<Item = (u32, ScriptBuf)>,
+    {
+        let mut node_weights = BinaryHeap::<(Reverse<u32>, NodeInfo)>::new();
+        for (p, leaf) in script_weights {
+            node_weights.push((
+                Reverse(p),
+                NodeInfo::new_leaf_with_ver(leaf, LeafVersion::TapScript),
+            ));
+        }
+        if node_weights.is_empty() {
+            return Err(TaprootBuilderError::EmptyTree);
+        }
+        while node_weights.len() > 1 {
+            // Combine the last two elements and insert a new node
+            let (p1, s1) = node_weights.pop().expect("len must be at least two");
+            let (p2, s2) = node_weights.pop().expect("len must be at least two");
+            // Insert the sum of first two in the tree as a new node
+            // N.B.: p1 + p2 can not practically saturate as you would need to have 2**32 max u32s
+            // from the input to overflow. However, saturating is a reasonable behavior here as
+            // huffman tree construction would treat all such elements as "very likely".
+            let p = Reverse(p1.0.saturating_add(p2.0));
+            node_weights.push((p, NodeInfo::combine(s1, s2)?));
+        }
+        // Every iteration of the loop reduces the node_weights.len() by exactly 1
+        // Therefore, the loop will eventually terminate with exactly 1 element
+        debug_assert_eq!(node_weights.len(), 1);
+        let node = node_weights
+            .pop()
+            .expect("huffman tree algorithm is broken")
+            .1;
+        Ok(TaprootBuilder {
+            branch: vec![Some(node)],
+        })
+    }
+
+    /// Adds a leaf script at `depth` to the builder with script version `ver`. Errors if the leaves
+    /// are not provided in DFS walk order. The depth of the root node is 0.
+    pub fn add_leaf_with_ver(
+        self,
+        depth: u8,
+        script: ScriptBuf,
+        ver: LeafVersion,
+    ) -> Result<Self, TaprootBuilderError> {
+        let leaf = NodeInfo::new_leaf_with_ver(script, ver);
+        self.insert(leaf, depth)
+    }
+
+    /// Adds a leaf script at `depth` to the builder with default script version. Errors if the
+    /// leaves are not provided in DFS walk order. The depth of the root node is 0.
+    ///
+    /// See [`TaprootBuilder::add_leaf_with_ver`] for adding a leaf with specific version.
+    pub fn add_leaf(self, depth: u8, script: ScriptBuf) -> Result<Self, TaprootBuilderError> {
+        self.add_leaf_with_ver(depth, script, LeafVersion::TapScript)
+    }
+
+    /// Adds a hidden/omitted node at `depth` to the builder. Errors if the leaves are not provided
+    /// in DFS walk order. The depth of the root node is 0.
+    pub fn add_hidden_node(
+        self,
+        depth: u8,
+        hash: TapNodeHash,
+    ) -> Result<Self, TaprootBuilderError> {
+        let node = NodeInfo::new_hidden_node(hash);
+        self.insert(node, depth)
+    }
+
+    /// Checks if the builder has finalized building a tree.
+    pub fn is_finalizable(&self) -> bool {
+        self.branch.len() == 1 && self.branch[0].is_some()
+    }
+
+    /// Converts the builder into a [`NodeInfo`] if the builder is a full tree with possibly
+    /// hidden nodes
+    ///
+    /// # Errors:
+    ///
+    /// [`IncompleteBuilderError::NotFinalized`] if the builder is not finalized. The builder
+    /// can be restored by calling [`IncompleteBuilderError::into_builder`]
+    pub fn try_into_node_info(mut self) -> Result<NodeInfo, IncompleteBuilderError> {
+        if self.branch().len() != 1 {
+            return Err(IncompleteBuilderError::NotFinalized(self));
+        }
+        Ok(self
+            .branch
+            .pop()
+            .expect("length checked above")
+            .expect("invariant guarantees node info exists"))
+    }
+
+    /// Converts the builder into a [`TapTree`] if the builder is a full tree and
+    /// does not contain any hidden nodes
+    pub fn try_into_taptree(self) -> Result<TapTree, IncompleteBuilderError> {
+        let node = self.try_into_node_info()?;
+        if node.has_hidden_nodes {
+            // Reconstruct the builder as it was if it has hidden nodes
+            return Err(IncompleteBuilderError::HiddenParts(TaprootBuilder {
+                branch: vec![Some(node)],
+            }));
+        }
+        Ok(TapTree(node))
+    }
+
+    /// Checks if the builder has hidden nodes.
+    pub fn has_hidden_nodes(&self) -> bool {
+        self.branch
+            .iter()
+            .flatten()
+            .any(|node| node.has_hidden_nodes)
+    }
+
+    /// Creates a [`TaprootSpendInfo`] with the given internal key.
+    ///
+    /// Returns the unmodified builder as Err if the builder is not finalizable.
+    /// See also [`TaprootBuilder::is_finalizable`]
+    pub fn finalize<C: secp256k1::Verification>(
+        mut self,
+        secp: &Secp256k1<C>,
+        internal_key: UntweakedPublicKey,
+    ) -> Result<TaprootSpendInfo, TaprootBuilder> {
+        match self.branch.len() {
+            0 => Ok(TaprootSpendInfo::new_key_spend(secp, internal_key, None)),
+            1 => {
+                if let Some(Some(node)) = self.branch.pop() {
+                    Ok(TaprootSpendInfo::from_node_info(secp, internal_key, node))
+                } else {
+                    unreachable!("Size checked above. Builder guarantees the last element is Some")
+                }
+            }
+            _ => Err(self),
+        }
+    }
+
+    pub(crate) fn branch(&self) -> &[Option<NodeInfo>] {
+        &self.branch
+    }
+
+    /// Inserts a leaf at `depth`.
+    fn insert(mut self, mut node: NodeInfo, mut depth: u8) -> Result<Self, TaprootBuilderError> {
+        // early error on invalid depth. Though this will be checked later
+        // while constructing TaprootMerkelBranch
+        if depth as usize > TAPROOT_CONTROL_MAX_NODE_COUNT {
+            return Err(TaprootBuilderError::InvalidMerkleTreeDepth(depth as usize));
+        }
+        // We cannot insert a leaf at a lower depth while a deeper branch is unfinished. Doing
+        // so would mean the add_leaf/add_hidden invocations do not correspond to a DFS traversal of a
+        // binary tree.
+        if (depth as usize + 1) < self.branch.len() {
+            return Err(TaprootBuilderError::NodeNotInDfsOrder);
+        }
+
+        while self.branch.len() == depth as usize + 1 {
+            let child = match self.branch.pop() {
+                None => unreachable!("Len of branch checked to be >= 1"),
+                Some(Some(child)) => child,
+                // Needs an explicit push to add the None that we just popped.
+                // Cannot use .last() because of borrow checker issues.
+                Some(None) => {
+                    self.branch.push(None);
+                    break;
+                } // Cannot combine further
+            };
+            if depth == 0 {
+                // We are trying to combine two nodes at root level.
+                // Can't propagate further up than the root
+                return Err(TaprootBuilderError::OverCompleteTree);
+            }
+            node = NodeInfo::combine(node, child)?;
+            // Propagate to combine nodes at a lower depth
+            depth -= 1;
+        }
+
+        if self.branch.len() < depth as usize + 1 {
+            // add enough nodes so that we can insert node at depth `depth`
+            let num_extra_nodes = depth as usize + 1 - self.branch.len();
+            self.branch.extend((0..num_extra_nodes).map(|_| None));
+        }
+        // Push the last node to the branch
+        self.branch[depth as usize] = Some(node);
+        Ok(self)
+    }
+}
+
+impl Default for TaprootBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error happening when [`TapTree`] is constructed from a [`TaprootBuilder`]
+/// having hidden branches or not being finalized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IncompleteBuilderError {
+    /// Indicates an attempt to construct a tap tree from a builder containing incomplete branches.
+    NotFinalized(TaprootBuilder),
+    /// Indicates an attempt to construct a tap tree from a builder containing hidden parts.
+    HiddenParts(TaprootBuilder),
+}
+
+internals::impl_from_infallible!(IncompleteBuilderError);
+
+impl IncompleteBuilderError {
+    /// Converts error into the original incomplete [`TaprootBuilder`] instance.
+    pub fn into_builder(self) -> TaprootBuilder {
+        use IncompleteBuilderError::*;
+
+        match self {
+            NotFinalized(builder) | HiddenParts(builder) => builder,
+        }
+    }
+}
+
+impl core::fmt::Display for IncompleteBuilderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use IncompleteBuilderError::*;
+
+        f.write_str(match self {
+            NotFinalized(_) => {
+                "an attempt to construct a tap tree from a builder containing incomplete branches."
+            }
+            HiddenParts(_) => {
+                "an attempt to construct a tap tree from a builder containing hidden parts."
+            }
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IncompleteBuilderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use IncompleteBuilderError::*;
+
+        match *self {
+            NotFinalized(_) | HiddenParts(_) => None,
+        }
+    }
+}
+
+/// Error happening when [`TapTree`] is constructed from a [`NodeInfo`]
+/// having hidden branches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HiddenNodesError {
+    /// Indicates an attempt to construct a tap tree from a builder containing hidden parts.
+    HiddenParts(NodeInfo),
+}
+
+internals::impl_from_infallible!(HiddenNodesError);
+
+impl HiddenNodesError {
+    /// Converts error into the original incomplete [`NodeInfo`] instance.
+    pub fn into_node_info(self) -> NodeInfo {
+        use HiddenNodesError::*;
+
+        match self {
+            HiddenParts(node_info) => node_info,
+        }
+    }
+}
+
+impl core::fmt::Display for HiddenNodesError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use HiddenNodesError::*;
+
+        f.write_str(match self {
+            HiddenParts(_) => {
+                "an attempt to construct a tap tree from a node_info containing hidden parts."
+            }
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HiddenNodesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use HiddenNodesError::*;
+
+        match self {
+            HiddenParts(_) => None,
+        }
+    }
+}
+
+/// Taproot Tree representing a complete binary tree without any hidden nodes.
+///
+/// This is in contrast to [`NodeInfo`], which allows hidden nodes.
+/// The implementations for Eq, PartialEq and Hash compare the merkle root of the tree
+//
+// This is a bug in BIP370 that does not specify how to share trees with hidden nodes,
+// for which we need a separate type.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(into = "NodeInfo"))]
+#[cfg_attr(feature = "serde", serde(try_from = "NodeInfo"))]
+pub struct TapTree(NodeInfo);
+
+impl From<TapTree> for NodeInfo {
+    #[inline]
+    fn from(tree: TapTree) -> Self {
+        tree.into_node_info()
+    }
+}
+
+impl TapTree {
+    /// Gets the reference to inner [`NodeInfo`] of this tree root.
+    pub fn node_info(&self) -> &NodeInfo {
+        &self.0
+    }
+
+    /// Gets the inner [`NodeInfo`] of this tree root.
+    pub fn into_node_info(self) -> NodeInfo {
+        self.0
+    }
+
+    /// Returns [`TapTreeIter<'_>`] iterator for a taproot script tree, operating in DFS order over
+    /// tree [`ScriptLeaf`]s.
+    pub fn script_leaves(&self) -> ScriptLeaves {
+        ScriptLeaves {
+            leaf_iter: self.0.leaf_nodes(),
+        }
+    }
+
+    /// Returns the root [`TapNodeHash`] of this tree.
+    pub fn root_hash(&self) -> TapNodeHash {
+        self.0.hash
+    }
+}
+
+impl TryFrom<TaprootBuilder> for TapTree {
+    type Error = IncompleteBuilderError;
+
+    /// Constructs [`TapTree`] from a [`TaprootBuilder`] if it is complete binary tree.
+    ///
+    /// # Returns
+    ///
+    /// A [`TapTree`] iff the `builder` is complete, otherwise return [`IncompleteBuilderError`]
+    /// error with the content of incomplete `builder` instance.
+    fn try_from(builder: TaprootBuilder) -> Result<Self, Self::Error> {
+        builder.try_into_taptree()
+    }
+}
+
+impl TryFrom<NodeInfo> for TapTree {
+    type Error = HiddenNodesError;
+
+    /// Constructs [`TapTree`] from a [`NodeInfo`] if it is complete binary tree.
+    ///
+    /// # Returns
+    ///
+    /// A [`TapTree`] iff the [`NodeInfo`] has no hidden nodes, otherwise return
+    /// [`HiddenNodesError`] error with the content of incomplete [`NodeInfo`] instance.
+    fn try_from(node_info: NodeInfo) -> Result<Self, Self::Error> {
+        if node_info.has_hidden_nodes {
+            Err(HiddenNodesError::HiddenParts(node_info))
+        } else {
+            Ok(TapTree(node_info))
+        }
+    }
+}
+
+/// Iterator for a taproot script tree, operating in DFS order yielding [`ScriptLeaf`].
+///
+/// Returned by [`TapTree::script_leaves`]. [`TapTree`] does not allow hidden nodes,
+/// so this iterator is guaranteed to yield all known leaves.
+pub struct ScriptLeaves<'tree> {
+    leaf_iter: LeafNodes<'tree>,
+}
+
+impl<'tree> Iterator for ScriptLeaves<'tree> {
+    type Item = ScriptLeaf<'tree>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        ScriptLeaf::from_leaf_node(self.leaf_iter.next()?)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.leaf_iter.size_hint()
+    }
+}
+
+impl<'tree> ExactSizeIterator for ScriptLeaves<'tree> {}
+
+impl<'tree> FusedIterator for ScriptLeaves<'tree> {}
+
+impl<'tree> DoubleEndedIterator for ScriptLeaves<'tree> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        ScriptLeaf::from_leaf_node(self.leaf_iter.next_back()?)
+    }
+}
+/// Iterator for a taproot script tree, operating in DFS order yielding [`LeafNode`].
+///
+/// Returned by [`NodeInfo::leaf_nodes`]. This can potentially yield hidden nodes.
+pub struct LeafNodes<'a> {
+    leaf_iter: core::slice::Iter<'a, LeafNode>,
+}
+
+impl<'a> Iterator for LeafNodes<'a> {
+    type Item = &'a LeafNode;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.leaf_iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.leaf_iter.size_hint()
+    }
+}
+
+impl<'tree> ExactSizeIterator for LeafNodes<'tree> {}
+
+impl<'tree> FusedIterator for LeafNodes<'tree> {}
+
+impl<'tree> DoubleEndedIterator for LeafNodes<'tree> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.leaf_iter.next_back()
+    }
+}
+/// Represents the node information in taproot tree. In contrast to [`TapTree`], this
+/// is allowed to have hidden leaves as children.
+///
+/// Helper type used in merkle tree construction allowing one to build sparse merkle trees. The node
+/// represents part of the tree that has information about all of its descendants.
+/// See how [`TaprootBuilder`] works for more details.
+///
+/// You can use [`TaprootSpendInfo::from_node_info`] to a get a [`TaprootSpendInfo`] from the merkle
+/// root [`NodeInfo`].
+#[derive(Debug, Clone, PartialOrd, Ord)]
+pub struct NodeInfo {
+    /// Merkle hash for this node.
+    pub(crate) hash: TapNodeHash,
+    /// Information about leaves inside this node.
+    pub(crate) leaves: Vec<LeafNode>,
+    /// Tracks information on hidden nodes below this node.
+    pub(crate) has_hidden_nodes: bool,
+}
+
+impl PartialEq for NodeInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash.eq(&other.hash)
+    }
+}
+
+impl core::hash::Hash for NodeInfo {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.hash.hash(state)
+    }
+}
+
+impl Eq for NodeInfo {}
+
+impl NodeInfo {
+    /// Creates a new [`NodeInfo`] with omitted/hidden info.
+    pub fn new_hidden_node(hash: TapNodeHash) -> Self {
+        Self {
+            hash,
+            leaves: vec![],
+            has_hidden_nodes: true,
+        }
+    }
+
+    /// Creates a new leaf [`NodeInfo`] with given [`ScriptBuf`] and [`LeafVersion`].
+    pub fn new_leaf_with_ver(script: ScriptBuf, ver: LeafVersion) -> Self {
+        Self {
+            hash: TapNodeHash::from_script(&script, ver),
+            leaves: vec![LeafNode::new_script(script, ver)],
+            has_hidden_nodes: false,
+        }
+    }
+
+    /// Combines two [`NodeInfo`] to create a new parent.
+    pub fn combine(a: Self, b: Self) -> Result<Self, TaprootBuilderError> {
+        let mut all_leaves = Vec::with_capacity(a.leaves.len() + b.leaves.len());
+        let (hash, left_first) = TapNodeHash::combine_node_hashes(a.hash, b.hash);
+        let (a, b) = if left_first { (a, b) } else { (b, a) };
+        for mut a_leaf in a.leaves {
+            a_leaf.merkle_branch.push(b.hash)?; // add hashing partner
+            all_leaves.push(a_leaf);
+        }
+        for mut b_leaf in b.leaves {
+            b_leaf.merkle_branch.push(a.hash)?; // add hashing partner
+            all_leaves.push(b_leaf);
+        }
+        Ok(Self {
+            hash,
+            leaves: all_leaves,
+            has_hidden_nodes: a.has_hidden_nodes || b.has_hidden_nodes,
+        })
+    }
+
+    /// Creates an iterator over all leaves (including hidden leaves) in the tree.
+    pub fn leaf_nodes(&self) -> LeafNodes {
+        LeafNodes {
+            leaf_iter: self.leaves.iter(),
+        }
+    }
+
+    /// Returns the root [`TapNodeHash`] of this node info.
+    pub fn node_hash(&self) -> TapNodeHash {
+        self.hash
+    }
+}
+
+impl TryFrom<TaprootBuilder> for NodeInfo {
+    type Error = IncompleteBuilderError;
+
+    fn try_from(builder: TaprootBuilder) -> Result<Self, Self::Error> {
+        builder.try_into_node_info()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for NodeInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.leaves.len() * 2))?;
+        for tap_leaf in self.leaves.iter() {
+            seq.serialize_element(&tap_leaf.merkle_branch().len())?;
+            seq.serialize_element(&tap_leaf.leaf)?;
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for NodeInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct SeqVisitor;
+        impl<'de> serde::de::Visitor<'de> for SeqVisitor {
+            type Value = NodeInfo;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Taproot tree in DFS walk order")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let size = seq
+                    .size_hint()
+                    .map(|x| core::mem::size_of::<usize>() * 8 - x.leading_zeros() as usize)
+                    .map(|x| x / 2) // Each leaf is serialized as two elements.
+                    .unwrap_or(0)
+                    .min(TAPROOT_CONTROL_MAX_NODE_COUNT); // no more than 128 nodes
+                let mut builder = TaprootBuilder::with_capacity(size);
+                while let Some(depth) = seq.next_element()? {
+                    let tap_leaf: TapLeaf = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::custom("Missing tap_leaf"))?;
+                    match tap_leaf {
+                        TapLeaf::Script(script, ver) => {
+                            builder =
+                                builder.add_leaf_with_ver(depth, script, ver).map_err(|e| {
+                                    serde::de::Error::custom(format!("Leaf insertion error: {}", e))
+                                })?;
+                        }
+                        TapLeaf::Hidden(h) => {
+                            builder = builder.add_hidden_node(depth, h).map_err(|e| {
+                                serde::de::Error::custom(format!(
+                                    "Hidden node insertion error: {}",
+                                    e
+                                ))
+                            })?;
+                        }
+                    }
+                }
+                NodeInfo::try_from(builder).map_err(|e| {
+                    serde::de::Error::custom(format!("Incomplete taproot tree: {}", e))
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(SeqVisitor)
+    }
+}
+
+/// Leaf node in a taproot tree. Can be either hidden or known.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub enum TapLeaf {
+    /// A known script
+    Script(ScriptBuf, LeafVersion),
+    /// Hidden Node with the given leaf hash
+    Hidden(TapNodeHash),
+}
+
+impl TapLeaf {
+    /// Obtains the hidden leaf hash if the leaf is hidden.
+    pub fn as_hidden(&self) -> Option<&TapNodeHash> {
+        if let Self::Hidden(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Obtains a reference to script and version if the leaf is known.
+    pub fn as_script(&self) -> Option<(&Script, LeafVersion)> {
+        if let Self::Script(script, ver) = self {
+            Some((script, *ver))
+        } else {
+            None
+        }
+    }
+}
+
+/// Store information about taproot leaf node.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LeafNode {
+    /// The [`TapLeaf`]
+    leaf: TapLeaf,
+    /// The merkle proof (hashing partners) to get this node.
+    merkle_branch: TaprootMerkleBranch,
+}
+
+impl LeafNode {
+    /// Creates an new [`ScriptLeaf`] from `script` and `ver` and no merkle branch.
+    pub fn new_script(script: ScriptBuf, ver: LeafVersion) -> Self {
+        Self {
+            leaf: TapLeaf::Script(script, ver),
+            merkle_branch: Default::default(),
+        }
+    }
+
+    /// Creates an new [`ScriptLeaf`] from `hash` and no merkle branch.
+    pub fn new_hidden(hash: TapNodeHash) -> Self {
+        Self {
+            leaf: TapLeaf::Hidden(hash),
+            merkle_branch: Default::default(),
+        }
+    }
+
+    /// Returns the depth of this script leaf in the tap tree.
+    #[inline]
+    pub fn depth(&self) -> u8 {
+        // Depth is guarded by TAPROOT_CONTROL_MAX_NODE_COUNT.
+        u8::try_from(self.merkle_branch().len()).expect("depth is guaranteed to fit in a u8")
+    }
+
+    /// Computes a leaf hash for this [`ScriptLeaf`] if the leaf is known.
+    ///
+    /// This [`TapLeafHash`] is useful while signing taproot script spends.
+    ///
+    /// See [`LeafNode::node_hash`] for computing the [`TapNodeHash`] which returns the hidden node
+    /// hash if the node is hidden.
+    #[inline]
+    pub fn leaf_hash(&self) -> Option<TapLeafHash> {
+        let (script, ver) = self.leaf.as_script()?;
+        Some(TapLeafHash::from_script(script, ver))
+    }
+
+    /// Computes the [`TapNodeHash`] for this [`ScriptLeaf`]. This returns the
+    /// leaf hash if the leaf is known and the hidden node hash if the leaf is
+    /// hidden.
+    /// See also, [`LeafNode::leaf_hash`].
+    #[inline]
+    pub fn node_hash(&self) -> TapNodeHash {
+        match self.leaf {
+            TapLeaf::Script(ref script, ver) => TapLeafHash::from_script(script, ver).into(),
+            TapLeaf::Hidden(ref hash) => *hash,
+        }
+    }
+
+    /// Returns reference to the leaf script if the leaf is known.
+    #[inline]
+    pub fn script(&self) -> Option<&Script> {
+        self.leaf.as_script().map(|x| x.0)
+    }
+
+    /// Returns leaf version of the script if the leaf is known.
+    #[inline]
+    pub fn leaf_version(&self) -> Option<LeafVersion> {
+        self.leaf.as_script().map(|x| x.1)
+    }
+
+    /// Returns reference to the merkle proof (hashing partners) to get this
+    /// node in form of [`TaprootMerkleBranch`].
+    #[inline]
+    pub fn merkle_branch(&self) -> &TaprootMerkleBranch {
+        &self.merkle_branch
+    }
+
+    /// Returns a reference to the leaf of this [`ScriptLeaf`].
+    #[inline]
+    pub fn leaf(&self) -> &TapLeaf {
+        &self.leaf
+    }
+}
+
+/// Script leaf node in a taproot tree along with the merkle proof to get this node.
+/// Returned by [`TapTree::script_leaves`]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ScriptLeaf<'leaf> {
+    /// The version of the script leaf.
+    version: LeafVersion,
+    /// The script.
+    script: &'leaf Script,
+    /// The merkle proof (hashing partners) to get this node.
+    merkle_branch: &'leaf TaprootMerkleBranch,
+}
+
+impl<'leaf> ScriptLeaf<'leaf> {
+    /// Obtains the version of the script leaf.
+    pub fn version(&self) -> LeafVersion {
+        self.version
+    }
+
+    /// Obtains a reference to the script inside the leaf.
+    pub fn script(&self) -> &Script {
+        self.script
+    }
+
+    /// Obtains a reference to the merkle proof of the leaf.
+    pub fn merkle_branch(&self) -> &TaprootMerkleBranch {
+        self.merkle_branch
+    }
+
+    /// Obtains a script leaf from the leaf node if the leaf is not hidden.
+    pub fn from_leaf_node(leaf_node: &'leaf LeafNode) -> Option<Self> {
+        let (script, ver) = leaf_node.leaf.as_script()?;
+        Some(Self {
+            version: ver,
+            script,
+            merkle_branch: &leaf_node.merkle_branch,
+        })
+    }
+}
+
+/// Control block data structure used in Tapscript satisfaction.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct ControlBlock {
+    /// The tapleaf version.
+    pub leaf_version: LeafVersion,
+    /// The parity of the output key (NOT THE INTERNAL KEY WHICH IS ALWAYS XONLY).
+    pub output_key_parity: secp256k1::Parity,
+    /// The internal key.
+    pub internal_key: UntweakedPublicKey,
+    /// The merkle proof of a script associated with this leaf.
+    pub merkle_branch: TaprootMerkleBranch,
+}
+
+impl ControlBlock {
+    /// Decodes bytes representing a `ControlBlock`.
+    ///
+    /// This is an extra witness element that provides the proof that taproot script pubkey is
+    /// correctly computed with some specified leaf hash. This is the last element in taproot
+    /// witness when spending a output via script path.
+    ///
+    /// # Errors
+    ///
+    /// - [`TaprootError::InvalidControlBlockSize`] if `sl` is not of size 1 + 32 + 32N for any N >= 0.
+    /// - [`TaprootError::InvalidTaprootLeafVersion`] if first byte of `sl` is not a valid leaf version.
+    /// - [`TaprootError::InvalidInternalKey`] if internal key is invalid (first 32 bytes after the parity byte).
+    /// - [`TaprootError::InvalidMerkleTreeDepth`] if merkle tree is too deep (more than 128 levels).
+    pub fn decode(sl: &[u8]) -> Result<ControlBlock, TaprootError> {
+        if sl.len() < TAPROOT_CONTROL_BASE_SIZE
+            || (sl.len() - TAPROOT_CONTROL_BASE_SIZE) % TAPROOT_CONTROL_NODE_SIZE != 0
+        {
+            return Err(TaprootError::InvalidControlBlockSize(sl.len()));
+        }
+        let output_key_parity = match sl[0] & 1 {
+            0 => secp256k1::Parity::Even,
+            _ => secp256k1::Parity::Odd,
+        };
+
+        let leaf_version = LeafVersion::from_consensus(sl[0] & TAPROOT_LEAF_MASK)?;
+        let internal_key = UntweakedPublicKey::from_slice(&sl[1..TAPROOT_CONTROL_BASE_SIZE])
+            .map_err(TaprootError::InvalidInternalKey)?;
+        let merkle_branch = TaprootMerkleBranch::decode(&sl[TAPROOT_CONTROL_BASE_SIZE..])?;
+        Ok(ControlBlock {
+            leaf_version,
+            output_key_parity,
+            internal_key,
+            merkle_branch,
+        })
+    }
+
+    /// Returns the size of control block. Faster and more efficient than calling
+    /// `Self::serialize().len()`. Can be handy for fee estimation.
+    pub fn size(&self) -> usize {
+        TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * self.merkle_branch.len()
+    }
+
+    /// Serializes to a writer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written to the writer.
+    pub fn encode<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<usize> {
+        let first_byte: u8 =
+            i32::from(self.output_key_parity) as u8 | self.leaf_version.to_consensus();
+        writer.write_all(&[first_byte])?;
+        writer.write_all(&self.internal_key.serialize())?;
+        self.merkle_branch.encode(writer)?;
+        Ok(self.size())
+    }
+
+    /// Serializes the control block.
+    ///
+    /// This would be required when using [`ControlBlock`] as a witness element while spending an
+    /// output via script path. This serialization does not include the [`crate::VarInt`] prefix that would
+    /// be applied when encoding this element as a witness.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.size());
+        self.encode(&mut buf).expect("writers don't error");
+        buf
+    }
+
+    /// Verifies that a control block is correct proof for a given output key and script.
+    ///
+    /// Only checks that script is contained inside the taptree described by output key. Full
+    /// verification must also execute the script with witness data.
+    pub fn verify_taproot_commitment<C: secp256k1::Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        output_key: XOnlyPublicKey,
+        script: &Script,
+    ) -> bool {
+        // compute the script hash
+        // Initially the curr_hash is the leaf hash
+        let mut curr_hash = TapNodeHash::from_script(script, self.leaf_version);
+        // Verify the proof
+        for elem in &self.merkle_branch {
+            // Recalculate the curr hash as parent hash
+            curr_hash = TapNodeHash::from_node_hashes(curr_hash, *elem);
+        }
+        // compute the taptweak
+        let tweak =
+            TapTweakHash::from_key_and_tweak(self.internal_key, Some(curr_hash)).to_scalar();
+        self.internal_key
+            .tweak_add_check(secp, &output_key, self.output_key_parity, tweak)
+    }
+}
+
+/// Inner type representing future (non-tapscript) leaf versions. See [`LeafVersion::Future`].
+///
+/// NB: NO PUBLIC CONSTRUCTOR!
+/// The only way to construct this is by converting `u8` to [`LeafVersion`] and then extracting it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct FutureLeafVersion(u8);
+
+impl FutureLeafVersion {
+    pub(self) fn from_consensus(version: u8) -> Result<FutureLeafVersion, TaprootError> {
+        match version {
+            TAPROOT_LEAF_TAPSCRIPT => unreachable!(
+                "FutureLeafVersion::from_consensus should be never called for 0xC0 value"
+            ),
+            TAPROOT_ANNEX_PREFIX => Err(TaprootError::InvalidTaprootLeafVersion(
+                TAPROOT_ANNEX_PREFIX,
+            )),
+            odd if odd & 0xFE != odd => Err(TaprootError::InvalidTaprootLeafVersion(odd)),
+            even => Ok(FutureLeafVersion(even)),
+        }
+    }
+
+    /// Returns the consensus representation of this [`FutureLeafVersion`].
+    #[inline]
+    pub fn to_consensus(self) -> u8 {
+        self.0
+    }
+}
+
+impl fmt::Display for FutureLeafVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for FutureLeafVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for FutureLeafVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+/// The leaf version for tapleafs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LeafVersion {
+    /// BIP-342 tapscript.
+    TapScript,
+
+    /// Future leaf version.
+    Future(FutureLeafVersion),
+}
+
+impl LeafVersion {
+    /// Creates a [`LeafVersion`] from consensus byte representation.
+    ///
+    /// # Errors
+    ///
+    /// - If the last bit of the `version` is odd.
+    /// - If the `version` is 0x50 ([`TAPROOT_ANNEX_PREFIX`]).
+    pub fn from_consensus(version: u8) -> Result<Self, TaprootError> {
+        match version {
+            TAPROOT_LEAF_TAPSCRIPT => Ok(LeafVersion::TapScript),
+            TAPROOT_ANNEX_PREFIX => Err(TaprootError::InvalidTaprootLeafVersion(
+                TAPROOT_ANNEX_PREFIX,
+            )),
+            future => FutureLeafVersion::from_consensus(future).map(LeafVersion::Future),
+        }
+    }
+
+    /// Returns the consensus representation of this [`LeafVersion`].
+    pub fn to_consensus(self) -> u8 {
+        match self {
+            LeafVersion::TapScript => TAPROOT_LEAF_TAPSCRIPT,
+            LeafVersion::Future(version) => version.to_consensus(),
+        }
+    }
+}
+
+impl fmt::Display for LeafVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self, f.alternate()) {
+            (LeafVersion::TapScript, true) => f.write_str("tapscript"),
+            (LeafVersion::TapScript, false) => fmt::Display::fmt(&TAPROOT_LEAF_TAPSCRIPT, f),
+            (LeafVersion::Future(version), true) => write!(f, "future_script_{:#02x}", version.0),
+            (LeafVersion::Future(version), false) => fmt::Display::fmt(version, f),
+        }
+    }
+}
+
+impl fmt::LowerHex for LeafVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_consensus(), f)
+    }
+}
+
+impl fmt::UpperHex for LeafVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.to_consensus(), f)
+    }
+}
+
+/// Serializes [`LeafVersion`] as a `u8` using consensus encoding.
+#[cfg(feature = "serde")]
+impl serde::Serialize for LeafVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(self.to_consensus())
+    }
+}
+
+/// Deserializes [`LeafVersion`] as a `u8` using consensus encoding.
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LeafVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct U8Visitor;
+        impl<'de> serde::de::Visitor<'de> for U8Visitor {
+            type Value = LeafVersion;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid consensus-encoded taproot leaf version")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let value = u8::try_from(value).map_err(|_| {
+                    E::invalid_value(
+                        serde::de::Unexpected::Unsigned(value),
+                        &"consensus-encoded leaf version as u8",
+                    )
+                })?;
+                LeafVersion::from_consensus(value).map_err(|_| {
+                    E::invalid_value(
+                        ::serde::de::Unexpected::Unsigned(value as u64),
+                        &"consensus-encoded leaf version as u8",
+                    )
+                })
+            }
+        }
+
+        deserializer.deserialize_u8(U8Visitor)
+    }
+}
+
+/// Detailed error type for taproot builder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TaprootBuilderError {
+    /// Merkle tree depth must not be more than 128.
+    InvalidMerkleTreeDepth(usize),
+    /// Nodes must be added specified in DFS walk order.
+    NodeNotInDfsOrder,
+    /// Two nodes at depth 0 are not allowed.
+    OverCompleteTree,
+    /// Invalid taproot internal key.
+    InvalidInternalKey(secp256k1::Error),
+    /// Called finalize on a empty tree.
+    EmptyTree,
+}
+
+internals::impl_from_infallible!(TaprootBuilderError);
+
+impl fmt::Display for TaprootBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use TaprootBuilderError::*;
+
+        match *self {
+            InvalidMerkleTreeDepth(d) => {
+                write!(
+                    f,
+                    "Merkle Tree depth({}) must be less than {}",
+                    d, TAPROOT_CONTROL_MAX_NODE_COUNT
+                )
+            }
+            NodeNotInDfsOrder => {
+                write!(f, "add_leaf/add_hidden must be called in DFS walk order",)
+            }
+            OverCompleteTree => write!(
+                f,
+                "Attempted to create a tree with two nodes at depth 0. There must\
+                only be a exactly one node at depth 0",
+            ),
+            InvalidInternalKey(ref e) => {
+                write_err!(f, "invalid internal x-only key"; e)
+            }
+            EmptyTree => {
+                write!(f, "Called finalize on an empty tree")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TaprootBuilderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use TaprootBuilderError::*;
+
+        match self {
+            InvalidInternalKey(e) => Some(e),
+            InvalidMerkleTreeDepth(_) | NodeNotInDfsOrder | OverCompleteTree | EmptyTree => None,
+        }
+    }
+}
+
+/// Detailed error type for taproot utilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TaprootError {
+    /// Proof size must be a multiple of 32.
+    InvalidMerkleBranchSize(usize),
+    /// Merkle tree depth must not be more than 128.
+    InvalidMerkleTreeDepth(usize),
+    /// The last bit of tapleaf version must be zero.
+    InvalidTaprootLeafVersion(u8),
+    /// Invalid control block size.
+    InvalidControlBlockSize(usize),
+    /// Invalid taproot internal key.
+    InvalidInternalKey(secp256k1::Error),
+    /// Empty tap tree.
+    EmptyTree,
+}
+
+internals::impl_from_infallible!(TaprootError);
+
+impl fmt::Display for TaprootError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use TaprootError::*;
+
+        match *self {
+            InvalidMerkleBranchSize(sz) => write!(
+                f,
+                "Merkle branch size({}) must be a multiple of {}",
+                sz, TAPROOT_CONTROL_NODE_SIZE
+            ),
+            InvalidMerkleTreeDepth(d) => write!(
+                f,
+                "Merkle Tree depth({}) must be less than {}",
+                d, TAPROOT_CONTROL_MAX_NODE_COUNT
+            ),
+            InvalidTaprootLeafVersion(v) => {
+                write!(
+                    f,
+                    "Leaf version({}) must have the least significant bit 0",
+                    v
+                )
+            }
+            InvalidControlBlockSize(sz) => write!(
+                f,
+                "Control Block size({}) must be of the form 33 + 32*m where  0 <= m <= {} ",
+                sz, TAPROOT_CONTROL_MAX_NODE_COUNT
+            ),
+            InvalidInternalKey(ref e) => {
+                write_err!(f, "invalid internal x-only key"; e)
+            }
+            EmptyTree => write!(f, "Taproot Tree must contain at least one script"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TaprootError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use TaprootError::*;
+
+        match self {
+            InvalidInternalKey(e) => Some(e),
+            InvalidMerkleBranchSize(_)
+            | InvalidMerkleTreeDepth(_)
+            | InvalidTaprootLeafVersion(_)
+            | InvalidControlBlockSize(_)
+            | EmptyTree => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::str::FromStr;
+
+    use hashes::sha256;
+    use hashes::sha256t::Tag;
+    use hex::FromHex;
+    use secp256k1::VerifyOnly;
+
+    use super::*;
+    use crate::sighash::{TapSighash, TapSighashTag};
+    use crate::{Address, KnownHrp};
+    extern crate serde_json;
+
+    #[cfg(feature = "serde")]
+    use {
+        hex::test_hex_unwrap as hex,
+        serde_test::Configure,
+        serde_test::{assert_tokens, Token},
+    };
+
+    fn tag_engine(tag_name: &str) -> sha256::HashEngine {
+        let mut engine = sha256::Hash::engine();
+        let tag_hash = sha256::Hash::hash(tag_name.as_bytes());
+        engine.input(tag_hash.as_ref());
+        engine.input(tag_hash.as_ref());
+        engine
+    }
+
+    #[test]
+    fn test_midstates() {
+        // test that engine creation roundtrips
+        assert_eq!(
+            tag_engine("TapLeaf").midstate(),
+            TapLeafTag::engine().midstate()
+        );
+        assert_eq!(
+            tag_engine("TapBranch").midstate(),
+            TapBranchTag::engine().midstate()
+        );
+        assert_eq!(
+            tag_engine("TapTweak").midstate(),
+            TapTweakTag::engine().midstate()
+        );
+        assert_eq!(
+            tag_engine("TapSighash").midstate(),
+            TapSighashTag::engine().midstate()
+        );
+
+        // check that hash creation is the same as building into the same engine
+        fn empty_hash(tag_name: &str) -> [u8; 32] {
+            let mut e = tag_engine(tag_name);
+            e.input(&[]);
+            TapNodeHash::from_engine(e).to_byte_array()
+        }
+        assert_eq!(
+            empty_hash("TapLeaf"),
+            TapLeafHash::hash(&[]).to_byte_array()
+        );
+        assert_eq!(
+            empty_hash("TapBranch"),
+            TapNodeHash::hash(&[]).to_byte_array()
+        );
+        assert_eq!(
+            empty_hash("TapTweak"),
+            TapTweakHash::hash(&[]).to_byte_array()
+        );
+        assert_eq!(
+            empty_hash("TapSighash"),
+            TapSighash::hash(&[]).to_byte_array()
+        );
+    }
+
+    #[test]
+    fn test_vectors_core() {
+        //! Test vectors taken from Core
+
+        // uninitialized writers
+        //   CHashWriter writer = HasherTapLeaf;
+        //   writer.GetSHA256().GetHex()
+        assert_eq!(
+            TapLeafHash::from_engine(TapLeafTag::engine()).to_string(),
+            "5212c288a377d1f8164962a5a13429f9ba6a7b84e59776a52c6637df2106facb"
+        );
+        assert_eq!(
+            TapNodeHash::from_engine(TapBranchTag::engine()).to_string(),
+            "53c373ec4d6f3c53c1f5fb2ff506dcefe1a0ed74874f93fa93c8214cbe9ffddf"
+        );
+        assert_eq!(
+            TapTweakHash::from_engine(TapTweakTag::engine()).to_string(),
+            "8aa4229474ab0100b2d6f0687f031d1fc9d8eef92a042ad97d279bff456b15e4"
+        );
+        assert_eq!(
+            TapSighash::from_engine(TapSighashTag::engine()).to_string(),
+            "dabc11914abcd8072900042a2681e52f8dba99ce82e224f97b5fdb7cd4b9c803"
+        );
+
+        // 0-byte
+        //   CHashWriter writer = HasherTapLeaf;
+        //   writer << std::vector<unsigned char>{};
+        //   writer.GetSHA256().GetHex()
+        // Note that Core writes the 0 length prefix when an empty vector is written.
+        assert_eq!(
+            TapLeafHash::hash(&[0]).to_string(),
+            "ed1382037800c9dd938dd8854f1a8863bcdeb6705069b4b56a66ec22519d5829"
+        );
+        assert_eq!(
+            TapNodeHash::hash(&[0]).to_string(),
+            "92534b1960c7e6245af7d5fda2588db04aa6d646abc2b588dab2b69e5645eb1d"
+        );
+        assert_eq!(
+            TapTweakHash::hash(&[0]).to_string(),
+            "cd8737b5e6047fc3f16f03e8b9959e3440e1bdf6dd02f7bb899c352ad490ea1e"
+        );
+        assert_eq!(
+            TapSighash::hash(&[0]).to_string(),
+            "c2fd0de003889a09c4afcf676656a0d8a1fb706313ff7d509afb00c323c010cd"
+        );
+    }
+
+    fn _verify_tap_commitments(
+        secp: &Secp256k1<VerifyOnly>,
+        out_spk_hex: &str,
+        script_hex: &str,
+        control_block_hex: &str,
+    ) {
+        let out_pk = XOnlyPublicKey::from_str(&out_spk_hex[4..]).unwrap();
+        let out_pk = TweakedPublicKey::dangerous_assume_tweaked(out_pk);
+        let script = ScriptBuf::from_hex(script_hex).unwrap();
+        let control_block =
+            ControlBlock::decode(&Vec::<u8>::from_hex(control_block_hex).unwrap()).unwrap();
+        assert_eq!(
+            control_block_hex,
+            control_block.serialize().to_lower_hex_string()
+        );
+        assert!(control_block.verify_taproot_commitment(secp, out_pk.to_inner(), &script));
+    }
+
+    #[test]
+    fn control_block_verify() {
+        let secp = Secp256k1::verification_only();
+        // test vectors obtained from printing values in feature_taproot.py from Bitcoin Core
+        _verify_tap_commitments(&secp, "51205dc8e62b15e0ebdf44751676be35ba32eed2e84608b290d4061bbff136cd7ba9", "6a", "c1a9d6f66cd4b25004f526bfa873e56942f98e8e492bd79ed6532b966104817c2bda584e7d32612381cf88edc1c02e28a296e807c16ad22f591ee113946e48a71e0641e660d1e5392fb79d64838c2b84faf04b7f5f283c9d8bf83e39e177b64372a0cd22eeab7e093873e851e247714eff762d8a30be699ba4456cfe6491b282e193a071350ae099005a5950d74f73ba13077a57bc478007fb0e4d1099ce9cf3d4");
+        _verify_tap_commitments(&secp, "5120e208c869c40d8827101c5ad3238018de0f3f5183d77a0c53d18ac28ddcbcd8ad", "f4", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f40090ab1f4890d51115998242ebce636efb9ede1b516d9eb8952dc1068e0335306199aaf103cceb41d9bc37ec231aca89b984b5fd3c65977ce764d51033ac65adb4da14e029b1e154a85bfd9139e7aa2720b6070a4ceba8264ca61d5d3ac27aceb9ef4b54cd43c2d1fd5e11b5c2e93cf29b91ea3dc5b832201f02f7473a28c63246");
+        _verify_tap_commitments(
+            &secp,
+            "5120567666e7df90e0450bb608e17c01ed3fbcfa5355a5f8273e34e583bfaa70ce09",
+            "203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf4734279ac",
+            "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400",
+        );
+        _verify_tap_commitments(&secp, "5120580a19e47269414a55eb86d5d0c6c9b371455d9fd2154412a57dec840df99fe1", "6a", "bca0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f40042ba1bd1c63c03ccff60d4c4d53a653f87909eb3358e7fa45c9d805231fb08c933e1f4e0f9d17f591df1419df7d5b7eb5f744f404c5ef9ecdb1b89b18cafa3a816d8b5dba3205f9a9c05f866d91f40d2793a7586d502cb42f46c7a11f66ad4aa");
+        _verify_tap_commitments(&secp, "5120228b94a4806254a38d6efa8a134c28ebc89546209559dfe40b2b0493bafacc5b", "6a50", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4009c9aed3dfd11ab0e78bf87ef3bf296269dc4b0f7712140386d6980992bab4b45");
+        _verify_tap_commitments(
+            &secp,
+            "5120567666e7df90e0450bb608e17c01ed3fbcfa5355a5f8273e34e583bfaa70ce09",
+            "203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf4734279ac",
+            "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400",
+        );
+        _verify_tap_commitments(
+            &secp,
+            "5120b0a79103c31fe51eea61d2873bad8a25a310da319d7e7a85f825fa7a00ea3f85",
+            "203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf4734279ad51",
+            "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400",
+        );
+        _verify_tap_commitments(&secp, "5120f2f62e854a0012aeba78cd4ba4a0832447a5262d4c6eb4f1c95c7914b536fc6c", "6a86", "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4009ad3d30479f0689dbdf59a6b840d60ad485b2effbed1825a75ce19a44e460e09056f60ea686d79cfa4fb79f197b2e905ac857a983be4a5a41a4873e865aa950780c0237de279dc063e67deec46ef8e1bc351bf12c4d67a6d568001faf097e797e6ee620f53cfe0f8acaddf2063c39c3577853bb46d61ffcba5a024c3e1216837");
+        _verify_tap_commitments(&secp, "51202a4772070b49bae68b44315032cdbf9c40c7c2f896781b32b931b73dbfb26d7e", "6af8", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4006f183944a14618fc7fe9ceade0f58e43a19d3c3b179ea6c43c29616413b6971c99aaf103cceb41d9bc37ec231aca89b984b5fd3c65977ce764d51033ac65adb4c3462adec78cd04f3cc156bdadec50def99feae0dc6a23664e8a2b0d42d6ca9eb968dfdf46c23af642b2688351904e0a0630e71ffac5bcaba33b9b2c8a7495ec");
+        _verify_tap_commitments(&secp, "5120a32b0b8cfafe0f0f8d5870030ba4d19a8725ad345cb3c8420f86ac4e0dff6207", "4c", "e8a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400615da7ac8d078e5fc7f4690fc2127ba40f0f97cc070ade5b3a7919783d91ef3f13734aab908ae998e57848a01268fe8217d70bc3ee8ea8ceae158ae964a4b5f3af20b50d7019bf47fde210eee5c52f1cfe71cfca78f2d3e7c1fd828c80351525");
+        _verify_tap_commitments(
+            &secp,
+            "5120b0a79103c31fe51eea61d2873bad8a25a310da319d7e7a85f825fa7a00ea3f85",
+            "203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf4734279ad51",
+            "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400",
+        );
+        _verify_tap_commitments(&secp, "51208678459f1fa0f80e9b89b8ffdcaf46a022bdf60aa45f1fed9a96145edf4ec400", "6a50", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4001eff29e1a89e650076b8d3c56302881d09c9df215774ed99993aaed14acd6615");
+        _verify_tap_commitments(&secp, "5120017316303aed02bcdec424c851c9eacbe192b013139bd9634c4e19b3475b06e1", "61", "02a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f40050462265ca552b23cbb4fe021b474313c8cb87d4a18b3f7bdbeb2b418279ba31fc6509d829cd42336f563363cb3538d78758e0876c71e13012eb2b656eb0edb051a2420a840d5c8c6c762abc7410af2c311f606b20ca2ace56a8139f84b1379a");
+        _verify_tap_commitments(&secp, "5120896d4d5d2236e86c6e9320e86d1a7822e652907cbd508360e8c71aefc127c77d", "61", "14a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4001ab0e9d9a4858a0e69605fe9c5a42d739fbe26fa79650e7074f462b02645f7ea1c91802b298cd91e6b5af57c6a013d93397cd2ecbd5569382cc27becf44ff4fff8960b20f846160c159c58350f6b6072cf1b3daa5185b7a42524fb72cbc252576ae46732b8e31ac24bfa7d72f4c3713e8696f99d8ac6c07e4c820a03f249f144");
+        _verify_tap_commitments(&secp, "512093c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51", "04ffffffff203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf4734279ba04feffffff87ab", "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400c9a5cd1f6c8a81f5648e39f9810591df1c9a8f1fe97c92e03ecd7c0c016c951983e05473c6e8238cb4c780ea2ce62552b2a3eee068ceffc00517cd7b97e10dad");
+        _verify_tap_commitments(&secp, "5120b28d75a7179de6feb66b8bb0bfa2b2c739d1a41cf7366a1b393804a844db8a28", "61", "c4a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400eebc95ded88fb8050094e8dfa958c3be0894eaff0fafae678206b26918d8d7ac47039d40fe34d04b4155df7f1be7f2a49253c7e87812ea9e569e683ac27459e652d6503aa32d64734d00adfee8798b2eed28858abf3bd038e8fa58eb7df4a2d9");
+        _verify_tap_commitments(&secp, "512043e4aa733fc6f43c78a31c2b3c192623acf5cc8c01199ebcc4de88067baca83e", "bd4c", "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4003f7be6f8848b5bddf332c4d7bd83077f73701e2479f70e02b5730e841234d082b8b41ebea96ffd937715d9faeaa6895e6ef3b22919c554b75df12b3371d328023e443d1df50634ecc1cd169803a1e546f0d44304d8fc5056c408e597fed469b8437d6660eaad3cf72e35ba6e5ff7ddd5e293c1e7e813c871df4f46508e9946ec");
+        _verify_tap_commitments(&secp, "5120ee9aecb28f5f35ce1f8b5ec80275ac0f81bca4a21b29b4632fb4bcbef8823e6a", "2021a5981b13be29c9d4ea179ea44a8b773ea8c02d68f6f6eefd98de20d4bd055fac", "c13359c284c196b6e80f0cf1d93b6a397cf7ee722f0427b705bd954b88ada8838bd2622fd0e104fc50aa763b43c6a792d7d117029983abd687223b4344a9402c618bba7f5fc3fa8a57491f6842acde88c1e675ca35caea3b1a69ee2c2d9b10f615");
+        _verify_tap_commitments(&secp, "5120885274df2252b44764dcef53c21f21154e8488b7e79fafbc96b9ebb22ad0200d", "6a50", "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4000793597254158918e3369507f2d6fdbef17d18b1028bbb0719450ded0f42c58f");
+        _verify_tap_commitments(&secp, "512066f6f6f91d47674d198a28388e1eb05ec24e6ddbba10f16396b1a80c08675121", "6a50", "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400fe92aff70a2e8e2a4f34a913b99612468a41e0f8ecaff9a729a173d11013c27e");
+        _verify_tap_commitments(&secp, "5120868ed9307bd4637491ff03e3aa2c216a08fe213cac8b6cedbb9ab31dbfa6512c", "61", "a2a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400da584e7d32612381cf88edc1c02e28a296e807c16ad22f591ee113946e48a71e46c7eccffefd2d573ec014130e508f0c9963ccebd7830409f7b1b1301725e9fa759d4ef857ec8e0bb42d6d31609d3c7e77de3bfa28c38f93393a6ddbabe819ec560ed4f061fbe742a5fd2a648d5209469420434c8753da3fa7067cc2bb4c172a");
+        _verify_tap_commitments(&secp, "5120c1a00a9baa82888fd7d30291135a7eaa9e9966a5f16db2b10460572f8b108d8d", "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "5ba0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4007960d7b37dd1361aee34510e77acb4d27ddca17648a17e28475032538c1eb500f5a747f2c0893f79fe153ae918ac3d696de9322aa679aae62051ff5ed83aa502b338bd907346abd4cd9cf06117cb35d55a5a8dd950843522f8de7b5c7fba1804c38b0778d3d76b383f6db6fdf9d6e770da8fffbfa5152c0b8b38129885bcdee6");
+        _verify_tap_commitments(&secp, "5120bb9abeff7286b76dfc61800c548fe2621ff47506e47201a85c543b4a9a96fead", "75203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf47342796ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6ead6eadac", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4003eb5cdc419e0a6a800f34583ce750f387be34879c26f4230991bd61da743ad9d34d288e79397b709ac22ad8cc57645d593af3e15b97a876362117177ab2519c000000000000000000000000000000000000000000000000000000000000000007160c3a48c8b17bc3aeaf01db9e0a96ac47a5a9fa329e046856e7765e89c8a93ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff07feb9aa7cd72c78e66a85414cd19289f8b0ab1415013dc2a007666aa9248ec1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001fccc8bea662a9442a94f7ba0643c1d7ee7cc689f3b3506b7c8c99fd3f3b3d7772972dcdf2550cf95b65098aea67f72fef10abdcf1cef9815af8f4c4644b060e0000000000000000000000000000000000000000000000000000000000000000");
+        _verify_tap_commitments(&secp, "5120afddc189ea51094b4cbf463806792e9c8b35dfdc5e01228c78376380d0046b00", "4d09024747703eb9f759ce5ecd839109fecc40974ab16f5173ea390daaa5a78f7abe898165c90990062af998c5dc7989818393158a2c62b7ece727e7f5400d2efd33db8732599f6d1dce6b5b68d2d47317f2de6c9df118f61227f98453225036618aaf058140f2415d134fa69ba041c724ad81387f8c568d12ddc49eb32a71532096181b3f85fd465b8e9a176bb19f45c070baad47a2cc4505414b88c31cb5b0a192b2d2d56c404a37070b04d42c875c4ac351224f5b254f9ad0b820f43cad292d6565f796bf083173e14723f1e543c85a61689ddd5cb6666b240c15c38ce3320bf0c3be9e0322e5ef72366c294d3a2d7e8b8e7db875e7ae814537554f10b91c72b8b413e026bd5d5e917de4b54fa8f43f38771a7f242aa32dcb7ca1b0588dbf54af7ab9455047fbb894cdfdd242166db784276430eb47d4df092a6b8cb160eb982fe7d14a44283bdb4a9861ca65c06fd8b2546cfbfe38bc77f527de1b9bfd2c95a3e283b7b1d1d2b2fa291256a90a7003aefcef47ceabf113865a494af43e96a38b0b00919855eb7722ea2363e0ddfc9c51c08631d01e2a2d56e786b4ff6f1e5d415facc9c2619c285d9ad43001878294157cb025f639fb954271fd1d6173f6bc16535672f6abdd72b0284b4ff3eaf5b7247719d7c39365622610efae6562bef6e08a0b370fba75bb04dbdb90a482d8417e057f8bd021ea6ac32d0d48b08be9f77833b11e5e739960c9837d7583", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400ff698adfda0327f188e2ee35f7aecc0f90c9138a350d450648d968c2b5dd7ef94ddd3ec418dc0d03ee4956feb708d838ed2b20e5a193465a6a1467fd3054e1ea141ea4c4c503a6271e19a090e2a69a24282e3be04c4f98720f7a0eb274d9693d13a8e3c139aa625fa2aefd09854570527f9ac545bda1b689719f5cb715612c07");
+        _verify_tap_commitments(&secp, "5120afddc189ea51094b4cbf463806792e9c8b35dfdc5e01228c78376380d0046b00", "83", "c0a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f4007388cda01113397d4cd00bcfbd08fd68c3cfe3a42cbfe3a7651c1d5e6dacf1ad99aaf103cceb41d9bc37ec231aca89b984b5fd3c65977ce764d51033ac65adb4b59764bec92507e4a4c3f01a06f05980163ca10f1c549bfe01f85fa4f109a1295e607f5ed9f1008048474de336f11f67a1fbf2012f58944dede0ab19a3ca81f5");
+        _verify_tap_commitments(&secp, "512093c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51", "04ffffffff203455139bf238a3067bd72ed77e0ab8db590330f55ed58dba7366b53bf4734279ba04feffffff87ab", "c1a0eb12e60a52614986c623cbb6621dcdba3a47e3be6b37e032b7a11c7b98f400c9a5cd1f6c8a81f5648e39f9810591df1c9a8f1fe97c92e03ecd7c0c016c951983e05473c6e8238cb4c780ea2ce62552b2a3eee068ceffc00517cd7b97e10dad");
+    }
+
+    #[test]
+    fn build_huffman_tree() {
+        let secp = Secp256k1::verification_only();
+        let internal_key = UntweakedPublicKey::from_str(
+            "93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51",
+        )
+        .unwrap();
+
+        let script_weights = vec![
+            (10, ScriptBuf::from_hex("51").unwrap()), // semantics of script don't matter for this test
+            (20, ScriptBuf::from_hex("52").unwrap()),
+            (20, ScriptBuf::from_hex("53").unwrap()),
+            (30, ScriptBuf::from_hex("54").unwrap()),
+            (19, ScriptBuf::from_hex("55").unwrap()),
+        ];
+        let tree_info =
+            TaprootSpendInfo::with_huffman_tree(&secp, internal_key, script_weights.clone())
+                .unwrap();
+
+        /* The resulting tree should put the scripts into a tree similar
+         * to the following:
+         *
+         *   1      __/\__
+         *         /      \
+         *        /\     / \
+         *   2   54 52  53 /\
+         *   3            55 51
+         */
+
+        for (script, length) in [("51", 3), ("52", 2), ("53", 2), ("54", 2), ("55", 3)].iter() {
+            assert_eq!(
+                *length,
+                tree_info
+                    .script_map
+                    .get(&(ScriptBuf::from_hex(script).unwrap(), LeafVersion::TapScript))
+                    .expect("Present Key")
+                    .iter()
+                    .next()
+                    .expect("Present Path")
+                    .len()
+            );
+        }
+
+        // Obtain the output key
+        let output_key = tree_info.output_key();
+
+        // Try to create and verify a control block from each path
+        for (_weights, script) in script_weights {
+            let ver_script = (script, LeafVersion::TapScript);
+            let ctrl_block = tree_info.control_block(&ver_script).unwrap();
+            assert!(ctrl_block.verify_taproot_commitment(
+                &secp,
+                output_key.to_inner(),
+                &ver_script.0
+            ))
+        }
+    }
+
+    #[test]
+    fn taptree_builder() {
+        let secp = Secp256k1::verification_only();
+        let internal_key = UntweakedPublicKey::from_str(
+            "93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51",
+        )
+        .unwrap();
+
+        let builder = TaprootBuilder::new();
+        // Create a tree as shown below
+        // For example, imagine this tree:
+        // A, B , C are at depth 2 and D,E are at 3
+        //                                       ....
+        //                                     /      \
+        //                                    /\      /\
+        //                                   /  \    /  \
+        //                                  A    B  C  / \
+        //                                            D   E
+        let a = ScriptBuf::from_hex("51").unwrap();
+        let b = ScriptBuf::from_hex("52").unwrap();
+        let c = ScriptBuf::from_hex("53").unwrap();
+        let d = ScriptBuf::from_hex("54").unwrap();
+        let e = ScriptBuf::from_hex("55").unwrap();
+        let builder = builder.add_leaf(2, a.clone()).unwrap();
+        let builder = builder.add_leaf(2, b.clone()).unwrap();
+        let builder = builder.add_leaf(2, c.clone()).unwrap();
+        let builder = builder.add_leaf(3, d.clone()).unwrap();
+
+        // Trying to finalize an incomplete tree returns the Err(builder)
+        let builder = builder.finalize(&secp, internal_key).unwrap_err();
+        let builder = builder.add_leaf(3, e.clone()).unwrap();
+
+        #[cfg(feature = "serde")]
+        {
+            let tree = TapTree::try_from(builder.clone()).unwrap();
+            // test roundtrip serialization with serde_test
+            #[rustfmt::skip]
+            assert_tokens(&tree.readable(), &[
+                Token::Seq { len: Some(10) },
+                Token::U64(2), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("51"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(2), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("52"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(3), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("55"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(3), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("54"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(2), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("53"), Token::U8(192), Token::TupleVariantEnd,
+                Token::SeqEnd,
+            ],);
+
+            let node_info = TapTree::try_from(builder.clone()).unwrap().into_node_info();
+            // test roundtrip serialization with serde_test
+            #[rustfmt::skip]
+            assert_tokens(&node_info.readable(), &[
+                Token::Seq { len: Some(10) },
+                Token::U64(2), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("51"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(2), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("52"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(3), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("55"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(3), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("54"), Token::U8(192), Token::TupleVariantEnd,
+                Token::U64(2), Token::TupleVariant { name: "TapLeaf", variant: "Script", len: 2}, Token::Str("53"), Token::U8(192), Token::TupleVariantEnd,
+                Token::SeqEnd,
+            ],);
+        }
+
+        let tree_info = builder.finalize(&secp, internal_key).unwrap();
+        let output_key = tree_info.output_key();
+
+        for script in [a, b, c, d, e] {
+            let ver_script = (script, LeafVersion::TapScript);
+            let ctrl_block = tree_info.control_block(&ver_script).unwrap();
+            assert!(ctrl_block.verify_taproot_commitment(
+                &secp,
+                output_key.to_inner(),
+                &ver_script.0
+            ))
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_leaf_version_serde() {
+        let leaf_version = LeafVersion::TapScript;
+        // use serde_test to test serialization and deserialization
+        assert_tokens(&leaf_version, &[Token::U8(192)]);
+
+        let json = serde_json::to_string(&leaf_version).unwrap();
+        let leaf_version2 = serde_json::from_str(&json).unwrap();
+        assert_eq!(leaf_version, leaf_version2);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_merkle_branch_serde() {
+        let dummy_hash = hex!("03ba2a4dcd914fed29a1c630c7e811271b081a0e2f2f52cf1c197583dfd46c1b");
+        let hash1 = TapNodeHash::from_slice(&dummy_hash).unwrap();
+        let dummy_hash = hex!("8d79dedc2fa0b55167b5d28c61dbad9ce1191a433f3a1a6c8ee291631b2c94c9");
+        let hash2 = TapNodeHash::from_slice(&dummy_hash).unwrap();
+        let merkle_branch = TaprootMerkleBranch::from([hash1, hash2]);
+        // use serde_test to test serialization and deserialization
+        serde_test::assert_tokens(
+            &merkle_branch.readable(),
+            &[
+                Token::Seq { len: Some(2) },
+                Token::Str("03ba2a4dcd914fed29a1c630c7e811271b081a0e2f2f52cf1c197583dfd46c1b"),
+                Token::Str("8d79dedc2fa0b55167b5d28c61dbad9ce1191a433f3a1a6c8ee291631b2c94c9"),
+                Token::SeqEnd,
+            ],
+        );
+    }
+
+    // #[test]
+    // fn bip_341_tests() {
+    //     fn process_script_trees(
+    //         v: &serde_json::Value,
+    //         mut builder: TaprootBuilder,
+    //         leaves: &mut Vec<(ScriptBuf, LeafVersion)>,
+    //         depth: u8,
+    //     ) -> TaprootBuilder {
+    //         if v.is_null() {
+    //             // nothing to push
+    //         } else if v.is_array() {
+    //             for leaf in v.as_array().unwrap() {
+    //                 builder = process_script_trees(leaf, builder, leaves, depth + 1);
+    //             }
+    //         } else {
+    //             let script = ScriptBuf::from_hex(v["script"].as_str().unwrap()).unwrap();
+    //             let ver =
+    //                 LeafVersion::from_consensus(v["leafVersion"].as_u64().unwrap() as u8).unwrap();
+    //             leaves.push((script.clone(), ver));
+    //             builder = builder.add_leaf_with_ver(depth, script, ver).unwrap();
+    //         }
+    //         builder
+    //     }
+
+    //     let data = bip_341_read_json();
+    //     // Check the version of data
+    //     assert!(data["version"] == 1);
+    //     let secp = &secp256k1::Secp256k1::verification_only();
+
+    //     for arr in data["scriptPubKey"].as_array().unwrap() {
+    //         let internal_key =
+    //             XOnlyPublicKey::from_str(arr["given"]["internalPubkey"].as_str().unwrap()).unwrap();
+    //         // process the tree
+    //         let script_tree = &arr["given"]["scriptTree"];
+    //         let mut merkle_root = None;
+    //         if script_tree.is_null() {
+    //             assert!(arr["intermediary"]["merkleRoot"].is_null());
+    //         } else {
+    //             merkle_root = Some(
+    //                 TapNodeHash::from_str(arr["intermediary"]["merkleRoot"].as_str().unwrap())
+    //                     .unwrap(),
+    //             );
+    //             let leaf_hashes = arr["intermediary"]["leafHashes"].as_array().unwrap();
+    //             let ctrl_blks = arr["expected"]["scriptPathControlBlocks"]
+    //                 .as_array()
+    //                 .unwrap();
+    //             let mut builder = TaprootBuilder::new();
+    //             let mut leaves = vec![];
+    //             builder = process_script_trees(script_tree, builder, &mut leaves, 0);
+    //             let spend_info = builder.finalize(secp, internal_key).unwrap();
+    //             for (i, script_ver) in leaves.iter().enumerate() {
+    //                 let expected_leaf_hash = leaf_hashes[i].as_str().unwrap();
+    //                 let expected_ctrl_blk = ControlBlock::decode(
+    //                     &Vec::<u8>::from_hex(ctrl_blks[i].as_str().unwrap()).unwrap(),
+    //                 )
+    //                 .unwrap();
+
+    //                 let leaf_hash = TapLeafHash::from_script(&script_ver.0, script_ver.1);
+    //                 let ctrl_blk = spend_info.control_block(script_ver).unwrap();
+    //                 assert_eq!(leaf_hash.to_string(), expected_leaf_hash);
+    //                 assert_eq!(ctrl_blk, expected_ctrl_blk);
+    //             }
+    //         }
+    //         let expected_output_key =
+    //             XOnlyPublicKey::from_str(arr["intermediary"]["tweakedPubkey"].as_str().unwrap())
+    //                 .unwrap();
+    //         let expected_tweak =
+    //             TapTweakHash::from_str(arr["intermediary"]["tweak"].as_str().unwrap()).unwrap();
+    //         let expected_spk =
+    //             ScriptBuf::from_hex(arr["expected"]["scriptPubKey"].as_str().unwrap()).unwrap();
+    //         let expected_addr =
+    //             Address::from_str(arr["expected"]["bip350Address"].as_str().unwrap())
+    //                 .unwrap()
+    //                 .assume_checked();
+
+    //         let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
+    //         let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
+    //         let addr = Address::p2tr(secp, internal_key, merkle_root, KnownHrp::Mainnet);
+    //         let spk = addr.script_pubkey();
+
+    //         assert_eq!(expected_output_key, output_key.to_inner());
+    //         assert_eq!(expected_tweak, tweak);
+    //         assert_eq!(expected_addr, addr);
+    //         assert_eq!(expected_spk, spk);
+    //     }
+    // }
+
+    // fn bip_341_read_json() -> serde_json::Value {
+    //     let json_str = include_str!("../../tests/data/bip341_tests.json");
+    //     serde_json::from_str(json_str).expect("JSON was not well-formatted")
+    // }
+}

--- a/libs/bitcoin/src/taproot/serialized_signature.rs
+++ b/libs/bitcoin/src/taproot/serialized_signature.rs
@@ -1,0 +1,296 @@
+//! Implements [`SerializedSignature`] and related types.
+//!
+//! Serialized Taproot signatures have the issue that they can have different lengths.
+//! We want to avoid using `Vec` since that would require allocations making the code slower and
+//! unable to run on platforms without an allocator. We implement a special type to encapsulate
+//! serialized signatures and since it's a bit more complicated it has its own module.
+
+use core::borrow::Borrow;
+use core::{fmt, ops};
+
+pub use into_iter::IntoIter;
+use io::Write;
+
+use super::{SigFromSliceError, Signature};
+
+pub(crate) const MAX_LEN: usize = 65; // 64 for sig, 1B sighash flag
+
+/// A serialized Taproot Signature
+#[derive(Copy, Clone)]
+pub struct SerializedSignature {
+    data: [u8; MAX_LEN],
+    len: usize,
+}
+
+impl fmt::Debug for SerializedSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
+}
+
+impl fmt::Display for SerializedSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        hex::fmt_hex_exact!(f, MAX_LEN, self, hex::Case::Lower)
+    }
+}
+
+impl PartialEq for SerializedSignature {
+    #[inline]
+    fn eq(&self, other: &SerializedSignature) -> bool { **self == **other }
+}
+
+impl PartialEq<[u8]> for SerializedSignature {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool { **self == *other }
+}
+
+impl PartialEq<SerializedSignature> for [u8] {
+    #[inline]
+    fn eq(&self, other: &SerializedSignature) -> bool { *self == **other }
+}
+
+impl PartialOrd for SerializedSignature {
+    fn partial_cmp(&self, other: &SerializedSignature) -> Option<core::cmp::Ordering> {
+        Some((**self).cmp(&**other))
+    }
+}
+
+impl Ord for SerializedSignature {
+    fn cmp(&self, other: &SerializedSignature) -> core::cmp::Ordering { (**self).cmp(&**other) }
+}
+
+impl PartialOrd<[u8]> for SerializedSignature {
+    fn partial_cmp(&self, other: &[u8]) -> Option<core::cmp::Ordering> {
+        (**self).partial_cmp(other)
+    }
+}
+
+impl PartialOrd<SerializedSignature> for [u8] {
+    fn partial_cmp(&self, other: &SerializedSignature) -> Option<core::cmp::Ordering> {
+        self.partial_cmp(&**other)
+    }
+}
+
+impl core::hash::Hash for SerializedSignature {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) { (**self).hash(state) }
+}
+
+impl AsRef<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &[u8] { self }
+}
+
+impl Borrow<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow(&self) -> &[u8] { self }
+}
+
+impl ops::Deref for SerializedSignature {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] { &self.data[..self.len] }
+}
+
+impl Eq for SerializedSignature {}
+
+impl IntoIterator for SerializedSignature {
+    type IntoIter = IntoIter;
+    type Item = u8;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { IntoIter::new(self) }
+}
+
+impl<'a> IntoIterator for &'a SerializedSignature {
+    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = &'a u8;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { self.iter() }
+}
+
+impl From<Signature> for SerializedSignature {
+    fn from(value: Signature) -> Self { Self::from_signature(&value) }
+}
+
+impl<'a> From<&'a Signature> for SerializedSignature {
+    fn from(value: &'a Signature) -> Self { Self::from_signature(value) }
+}
+
+impl TryFrom<SerializedSignature> for Signature {
+    type Error = SigFromSliceError;
+
+    fn try_from(value: SerializedSignature) -> Result<Self, Self::Error> { value.to_signature() }
+}
+
+impl<'a> TryFrom<&'a SerializedSignature> for Signature {
+    type Error = SigFromSliceError;
+
+    fn try_from(value: &'a SerializedSignature) -> Result<Self, Self::Error> {
+        value.to_signature()
+    }
+}
+
+impl SerializedSignature {
+    /// Creates `SerializedSignature` from data and length.
+    ///
+    /// ## Panics
+    ///
+    /// If `len` > `MAX_LEN`
+    #[inline]
+    pub(crate) fn from_raw_parts(data: [u8; MAX_LEN], len: usize) -> Self {
+        assert!(len <= MAX_LEN, "attempt to set length to {} but the maximum is {}", len, MAX_LEN);
+        SerializedSignature { data, len }
+    }
+
+    /// Get the len of the used data.
+    // `len` is never 0, so `is_empty` would always return `false`.
+    #[allow(clippy::len_without_is_empty)]
+    #[inline]
+    pub fn len(&self) -> usize { self.len }
+
+    /// Set the length of the object.
+    #[inline]
+    pub(crate) fn set_len_unchecked(&mut self, len: usize) { self.len = len; }
+
+    /// Convert the serialized signature into the Signature struct.
+    /// (This deserializes it)
+    #[inline]
+    pub fn to_signature(&self) -> Result<Signature, SigFromSliceError> {
+        Signature::from_slice(self)
+    }
+
+    /// Create a SerializedSignature from a Signature.
+    /// (this serializes it)
+    #[inline]
+    pub fn from_signature(sig: &Signature) -> SerializedSignature { sig.serialize() }
+
+    /// Writes this serialized signature to a `writer`.
+    #[inline]
+    pub fn write_to<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(self)
+    }
+}
+
+/// Separate mod to prevent outside code from accidentally breaking invariants.
+mod into_iter {
+    use super::*;
+
+    /// Owned iterator over the bytes of [`SerializedSignature`]
+    ///
+    /// Created by [`IntoIterator::into_iter`] method.
+    // allowed because of https://github.com/rust-lang/rust/issues/98348
+    #[allow(missing_copy_implementations)]
+    #[derive(Debug, Clone)]
+    pub struct IntoIter {
+        signature: SerializedSignature,
+        // invariant: pos <= signature.len()
+        pos: usize,
+    }
+
+    impl IntoIter {
+        #[inline]
+        pub(crate) fn new(signature: SerializedSignature) -> Self {
+            IntoIter {
+                signature,
+                // for all unsigned n: 0 <= n
+                pos: 0,
+            }
+        }
+
+        /// Returns the remaining bytes as a slice.
+        ///
+        /// This method is analogous to [`core::slice::Iter::as_slice`].
+        #[inline]
+        pub fn as_slice(&self) -> &[u8] { &self.signature[self.pos..] }
+    }
+
+    impl Iterator for IntoIter {
+        type Item = u8;
+
+        #[inline]
+        fn next(&mut self) -> Option<Self::Item> {
+            let byte = *self.signature.get(self.pos)?;
+            // can't overflow or break invariant because if pos is too large we return early
+            self.pos += 1;
+            Some(byte)
+        }
+
+        #[inline]
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            // can't underlflow thanks to the invariant
+            let len = self.signature.len() - self.pos;
+            (len, Some(len))
+        }
+
+        // override for speed
+        #[inline]
+        fn nth(&mut self, n: usize) -> Option<Self::Item> {
+            if n >= self.len() {
+                // upholds invariant because the values will be equal
+                self.pos = self.signature.len();
+                None
+            } else {
+                // if n < signtature.len() - self.pos then n + self.pos < signature.len() which neither
+                // overflows nor breaks the invariant
+                self.pos += n;
+                self.next()
+            }
+        }
+    }
+
+    impl ExactSizeIterator for IntoIter {}
+
+    impl core::iter::FusedIterator for IntoIter {}
+
+    impl DoubleEndedIterator for IntoIter {
+        #[inline]
+        fn next_back(&mut self) -> Option<Self::Item> {
+            if self.pos == self.signature.len() {
+                return None;
+            }
+
+            // if len is 0 then pos is also 0 thanks to the invariant so we would return before we
+            // reach this
+            let new_len = self.signature.len() - 1;
+            let byte = self.signature[new_len];
+            self.signature.set_len_unchecked(new_len);
+            Some(byte)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SerializedSignature, MAX_LEN};
+
+    #[test]
+    fn iterator_ops_are_homomorphic() {
+        let mut fake_signature_data = [0; MAX_LEN];
+        for (i, byte) in fake_signature_data.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+
+        let fake_signature = SerializedSignature { data: fake_signature_data, len: MAX_LEN };
+
+        let mut iter1 = fake_signature.into_iter();
+        let mut iter2 = fake_signature.iter();
+
+        // while let so we can compare size_hint and as_slice
+        while let (Some(a), Some(b)) = (iter1.next(), iter2.next()) {
+            assert_eq!(a, *b);
+            assert_eq!(iter1.size_hint(), iter2.size_hint());
+            assert_eq!(iter1.as_slice(), iter2.as_slice());
+        }
+
+        let mut iter1 = fake_signature.into_iter();
+        let mut iter2 = fake_signature.iter();
+
+        // manual next_back instead of rev() so that we can check as_slice()
+        // if next_back is implemented correctly then rev() is also correct - provided by `core`
+        while let (Some(a), Some(b)) = (iter1.next_back(), iter2.next_back()) {
+            assert_eq!(a, *b);
+            assert_eq!(iter1.size_hint(), iter2.size_hint());
+            assert_eq!(iter1.as_slice(), iter2.as_slice());
+        }
+    }
+}

--- a/vanadium.code-workspace
+++ b/vanadium.code-workspace
@@ -16,6 +16,10 @@
       "path": "docs",
     },
     {
+      "path": "libs/bitcoin",
+      "name": "₿ vlib-bitcoin"
+    },
+    {
       "path": "apps/bitcoin/docs",
       "name": "₿ vnd-bitcoin documentation"
     },


### PR DESCRIPTION
Added a modified version of rust-bitcoin as a library crate that will be used by the bitcoin V-app (and other apps related to bitcoin).

This will allow to bring most of the library in, while surgically modifying anything that we want to reimplement in order to take advantage Vanadium's ECALLs (to do in followup PRs).

The `rust-sepc265k1` dependency is a bit tricky to handle and will need changes. Temporarily using a [patched version](https://github.com/LedgerHQ/vanadium-rust-secp256k1/tree/reloaded), but in the long term it might be better to get rid of it entirely and modify rust-bitcoin to use the Vanadium app-sdk, if that's not too complex.
