### PR TITLE
Add secp-lowmemory feature to vlib-bitcoin, and enable as default

### DIFF
--- a/apps/bitcoin/app/Cargo.toml
+++ b/apps/bitcoin/app/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitcoin = { package = "vlib-bitcoin", path = "../../../libs/bitcoin", default-features = false}
+bitcoin = { package = "vlib-bitcoin", path = "../../../libs/bitcoin"}
 common = { package = "vnd-bitcoin-common", path = "../common"}
 quick-protobuf = { version = "0.8.1", default-features = false }
 sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}

--- a/libs/bitcoin/Cargo.toml
+++ b/libs/bitcoin/Cargo.toml
@@ -7,11 +7,13 @@ repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
 documentation = "https://docs.rs/bitcoin/"
 
 [features]
-default = []
+default = ["secp-lowmemory"]
 std = []
 rand-std = []
 rand = []
 serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "internals/serde", "units/serde"]
+secp-lowmemory = ["secp256k1/lowmemory"]
+secp-recovery = ["secp256k1/recovery"]
 
 
 [lib]


### PR DESCRIPTION
Should help for embedded targets.