### PR TITLE
Improve UX serialization/deserialization helpers

### DIFF
--- a/app-sdk/.gitignore
+++ b/app-sdk/.gitignore
@@ -1,0 +1,1 @@
+src/ux_generated.rs

--- a/app-sdk/Cargo.toml
+++ b/app-sdk/Cargo.toml
@@ -12,6 +12,9 @@ subtle = { version="2.6.1", default-features = false }
 hex-literal = "0.4.1"
 zeroize = "1.8.1"
 
+[build-dependencies]
+common = { path = "../common", features = ["wrapped_serializable"] }
+
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]
 bip32 = "0.5.2"
 hex = "0.4.3"

--- a/app-sdk/build.rs
+++ b/app-sdk/build.rs
@@ -1,0 +1,186 @@
+use std::{fs::File, io::Write, path::Path};
+
+use common::ux::*;
+
+mod build_utils;
+
+use build_utils::{gen_u8_slice, make_page_maker};
+
+const PAGE_MAKERS: &[(&'static str, WrappedPage)] = &[
+    (
+        "spinner",
+        WrappedPage::Spinner {
+            text: rt_str("text", "&str"),
+        },
+    ),
+    (
+        "info",
+        WrappedPage::Info {
+            icon: rt("icon", "Icon"),
+            text: rt_str("text", "&str"),
+        },
+    ),
+    (
+        "confirm_reject",
+        WrappedPage::ConfirmReject {
+            title: rt_str("title", "&str"),
+            text: rt_str("text", "&str"),
+            confirm: rt_str("confirm", "&str"),
+            reject: rt_str("reject", "&str"),
+        },
+    ),
+    (
+        "review_pairs_intro",
+        WrappedPage::GenericPage {
+            navigation_info: Some(WrappedNavigationInfo {
+                active_page: rt("active_page", "u32"),
+                n_pages: rt("n_pages", "u32"),
+                skip_text: None,
+                nav_info: WrappedNavInfo::NavWithButtons {
+                    has_back_button: ct(true),
+                    has_page_indicator: ct(true),
+                    quit_text: Some(ct_str("Reject")),
+                },
+            }),
+            page_content_info: WrappedPageContentInfo {
+                title: ct(None),
+                top_right_icon: ct(Icon::None), // TODO: support icons
+                page_content: WrappedPageContent::TextSubtext {
+                    text: rt_str("intro_text", "&str"),
+                    subtext: rt_str("intro_subtext", "&str"),
+                },
+            },
+        },
+    ),
+    (
+        "review_pairs_content",
+        WrappedPage::GenericPage {
+            navigation_info: Some(WrappedNavigationInfo {
+                active_page: rt("active_page", "u32"),
+                n_pages: rt("n_pages", "u32"),
+                skip_text: None,
+                nav_info: WrappedNavInfo::NavWithButtons {
+                    has_back_button: ct(true),
+                    has_page_indicator: ct(true),
+                    quit_text: Some(ct_str("Reject")),
+                },
+            }),
+            page_content_info: WrappedPageContentInfo {
+                title: ct(None),
+                top_right_icon: ct(Icon::None), // TODO: support icons
+                page_content: WrappedPageContent::TagValueList {
+                    list: rt("pairs", "&[TagValue]"),
+                },
+            },
+        },
+    ),
+    (
+        "review_pairs_final_longpress",
+        WrappedPage::GenericPage {
+            navigation_info: Some(WrappedNavigationInfo {
+                active_page: rt("active_page", "u32"),
+                n_pages: rt("n_pages", "u32"),
+                skip_text: None,
+                nav_info: WrappedNavInfo::NavWithButtons {
+                    has_back_button: ct(true),
+                    has_page_indicator: ct(true),
+                    quit_text: Some(ct_str("Reject")),
+                },
+            }),
+            page_content_info: WrappedPageContentInfo {
+                title: ct(None),
+                top_right_icon: ct(Icon::None), // TODO: support icons
+                page_content: WrappedPageContent::ConfirmationLongPress {
+                    text: rt_str("final_text", "&str"),
+                    long_press_text: rt_str("final_button_text", "&str"),
+                },
+            },
+        },
+    ),
+    (
+        "review_pairs_final_confirmationbutton",
+        WrappedPage::GenericPage {
+            navigation_info: Some(WrappedNavigationInfo {
+                active_page: rt("active_page", "u32"),
+                n_pages: rt("n_pages", "u32"),
+                skip_text: None,
+                nav_info: WrappedNavInfo::NavWithButtons {
+                    has_back_button: ct(true),
+                    has_page_indicator: ct(true),
+                    quit_text: Some(ct_str("Reject")),
+                },
+            }),
+            page_content_info: WrappedPageContentInfo {
+                title: ct(None),
+                top_right_icon: ct(Icon::None), // TODO: support icons
+                page_content: WrappedPageContent::ConfirmationButton {
+                    text: rt_str("final_text", "&str"),
+                    button_text: rt_str("final_button_text", "&str"),
+                },
+            },
+        },
+    ),
+];
+
+// Precomputed pages with no variable part, so they can be directly
+// embedded in the binary as constants.
+fn make_const_pages(file: &mut File) {
+    let default_pages: &[(&'static str, Page)] = &[(
+        // "Application is ready"
+        "APP_DASHBOARD",
+        Page::GenericPage {
+            navigation_info: None,
+            page_content_info: PageContentInfo {
+                title: None,
+                top_right_icon: Icon::None,
+                page_content: PageContent::TextSubtext {
+                    text: "Application".into(),
+                    subtext: "is ready".into(),
+                },
+            },
+        },
+    )];
+
+    for (page_name, page) in default_pages {
+        let serialized = page.serialized();
+
+        writeln!(
+            file,
+            "pub const RAW_PAGE_{}: [u8; {}] = {};",
+            page_name,
+            serialized.len(),
+            gen_u8_slice(&serialized)
+        )
+        .expect("Could not write");
+    }
+
+    writeln!(file).expect("Could not write");
+}
+
+fn main() {
+    let dest_path = Path::new("src/ux_generated.rs");
+    let mut file = File::create(&dest_path).expect("Could not create file");
+
+    writeln!(
+        file,
+        "// This file is automatically generated by the build.rs script.
+
+use crate::ecalls::{{Ecall, EcallsInterface}};
+use alloc::vec::Vec;
+use common::ux::*;
+use core::mem::MaybeUninit;
+
+#[inline(always)]
+fn show_page_raw(page: &[u8]) {{
+    Ecall::show_page(page.as_ptr(), page.len());
+}}
+"
+    )
+    .expect("Could not write");
+
+    make_const_pages(&mut file);
+
+    for (fn_name, wrapped_page) in PAGE_MAKERS.iter() {
+        make_page_maker(&mut file, &wrapped_page.serialize_wrapped(), fn_name);
+    }
+}

--- a/app-sdk/build_utils/mod.rs
+++ b/app-sdk/build_utils/mod.rs
@@ -1,0 +1,280 @@
+use common::ux::*;
+use std::{fs::File, io::Write};
+
+pub fn gen_u8_slice(data: &[u8]) -> String {
+    format!(
+        "[{}]",
+        data.iter()
+            .map(|b| format!("{}u8", b))
+            .collect::<Vec<String>>()
+            .join(", ")
+    )
+}
+
+fn merge_static_parts(parts: &[SerializedPart]) -> Vec<SerializedPart> {
+    let mut result = Vec::new();
+
+    for part in parts {
+        match part {
+            SerializedPart::Static(vec) => {
+                if let Some(SerializedPart::Static(last_vec)) = result.last_mut() {
+                    // If the last element is Static, extend its vector
+                    last_vec.extend(vec);
+                } else {
+                    // Otherwise, add a new Static element
+                    result.push(SerializedPart::Static(vec.clone()));
+                }
+            }
+            SerializedPart::Runtime { arg_name, arg_type } => {
+                // Add Runtime elements as is
+                result.push(SerializedPart::Runtime { arg_name, arg_type });
+            }
+        }
+    }
+
+    result
+}
+
+pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str) {
+    let parts = merge_static_parts(parts);
+    // make a list of all the Runtime parts
+    let mut runtime_parts = Vec::new();
+    for part in parts.iter() {
+        if let SerializedPart::Runtime { arg_name, arg_type } = part {
+            runtime_parts.push((arg_name, arg_type));
+        }
+    }
+
+    let fn_args = runtime_parts
+        .iter()
+        .map(|(arg_name, arg_type)| format!("{}: {}", arg_name, arg_type))
+        .collect::<Vec<String>>()
+        .join(", ");
+
+    writeln!(file, "#[allow(dead_code)]").expect("Could not write");
+    writeln!(file, "#[inline(always)]").expect("Could not write");
+    writeln!(file, "pub fn show_{}({}) {{", fn_name, fn_args).expect("Could not write");
+    if parts.len() == 1 {
+        // special case, can be optimized slightly
+        match &parts[0] {
+            SerializedPart::Static(vec) => {
+                writeln!(
+                    file,
+                    "    let serialized: [u8; {}] = {};",
+                    vec.len(),
+                    gen_u8_slice(&vec)
+                )
+                .expect("Could not write");
+            }
+            SerializedPart::Runtime {
+                arg_name,
+                arg_type: _,
+            } => {
+                writeln!(
+                    file,
+                    "    let total_len: usize = {}.get_serialized_length();
+    let mut serialized = Vec::<u8>::with_capacity(total_len);
+    unsafe {{
+        serialized.set_len(total_len);
+    }}
+    let mut cur: usize = 0;
+    {}.serialize(&mut serialized, &mut cur);",
+                    arg_name, arg_name
+                )
+                .expect("Could not write");
+            }
+        }
+
+        writeln!(file, "    show_page_raw(&serialized);").expect("Could not write");
+    } else {
+        writeln!(file, "    let mut total_len: usize = 0;").expect("Could not write");
+
+        // Compute total length
+        for part in parts.iter() {
+            match part {
+                SerializedPart::Static(vec) => {
+                    writeln!(file, "    total_len += {};", vec.len()).expect("Could not write");
+                }
+                SerializedPart::Runtime {
+                    arg_name,
+                    arg_type: _,
+                } => {
+                    writeln!(
+                        file,
+                        "    total_len += {}.get_serialized_length();",
+                        arg_name
+                    )
+                    .expect("Could not write");
+                }
+            }
+        }
+
+        writeln!(file, "    const MAX_STATIC_LEN: usize = 64;").expect("Could not write");
+
+        writeln!(file, "    if total_len <= MAX_STATIC_LEN {{").expect("Could not write");
+
+        // if the total length is short enough, serialize each part, using a slice
+        // this avoids allocations
+        // We also use an uninitialized buffer, as we will overwrite it anyway
+
+        writeln!(
+            file,
+            "        let mut buffer: MaybeUninit<[u8; MAX_STATIC_LEN]> = MaybeUninit::uninit();
+        let buffer_ptr = buffer.as_mut_ptr() as *mut u8;
+        let mut serialized = unsafe {{ core::slice::from_raw_parts_mut(buffer_ptr, MAX_STATIC_LEN) }};
+        let mut cur: usize = 0;"
+        )
+        .expect("Could not write");
+
+        for part in parts.iter() {
+            match part {
+                SerializedPart::Static(vec) => {
+                    writeln!(
+                        file,
+                        "
+        let next_len = {};
+        serialized[cur..cur + next_len].copy_from_slice(&{});
+        cur += next_len;",
+                        vec.len(),
+                        gen_u8_slice(&vec)
+                    )
+                    .expect("Could not write");
+                }
+                SerializedPart::Runtime {
+                    arg_name,
+                    arg_type: _,
+                } => {
+                    writeln!(
+                        file,
+                        "
+        {}.serialize(&mut serialized, &mut cur);\n",
+                        arg_name
+                    )
+                    .expect("Could not write");
+                }
+            }
+        }
+
+        writeln!(file, "        show_page_raw(&serialized[0..total_len]);")
+            .expect("Could not write");
+
+        writeln!(file, "    }} else {{").expect("Could not write");
+
+        // serialize each part, using a vector
+        // We don't initialize the vector's conmtent, as we will overwrite it anyway
+        writeln!(
+            file,
+            "        let mut serialized = Vec::<u8>::with_capacity(total_len);
+        unsafe {{
+            serialized.set_len(total_len);
+        }}
+
+        let mut cur: usize = 0;"
+        )
+        .expect("Could not write");
+
+        for part in parts.iter() {
+            match part {
+                SerializedPart::Static(vec) => {
+                    writeln!(
+                        file,
+                        "
+        let next_len = {};
+        serialized[cur..cur + next_len].copy_from_slice(&{});
+        cur += next_len;",
+                        vec.len(),
+                        gen_u8_slice(&vec)
+                    )
+                    .expect("Could not write");
+                }
+                SerializedPart::Runtime {
+                    arg_name,
+                    arg_type: _,
+                } => {
+                    writeln!(
+                        file,
+                        "
+        {}.serialize(&mut serialized, &mut cur);\n",
+                        arg_name
+                    )
+                    .expect("Could not write");
+                }
+            }
+        }
+
+        writeln!(file, "        show_page_raw(&serialized);").expect("Could not write");
+        writeln!(file, "    }}").expect("Could not write");
+    }
+    writeln!(file, "}}\n").expect("Could not write");
+
+    // Make a make_<page_name> function that returns the serialized page as a Vec<u8>
+    writeln!(file, "#[allow(dead_code)]").expect("Could not write");
+    writeln!(file, "#[inline(always)]").expect("Could not write");
+    writeln!(file, "pub fn make_{}({}) -> Vec<u8> {{", fn_name, fn_args).expect("Could not write");
+
+    writeln!(file, "    let mut total_len: usize = 0;").expect("Could not write");
+
+    // Compute total length
+    for part in parts.iter() {
+        match part {
+            SerializedPart::Static(vec) => {
+                writeln!(file, "    total_len += {};", vec.len()).expect("Could not write");
+            }
+            SerializedPart::Runtime {
+                arg_name,
+                arg_type: _,
+            } => {
+                writeln!(
+                    file,
+                    "    total_len += {}.get_serialized_length();",
+                    arg_name
+                )
+                .expect("Could not write");
+            }
+        }
+    }
+
+    // serialize each part, using a vector
+    // We don't initialize the vector's conmtent, as we will overwrite it anyway
+    writeln!(
+        file,
+        "    let mut serialized = Vec::<u8>::with_capacity(total_len);
+    unsafe {{
+        serialized.set_len(total_len);
+    }}
+
+    let mut cur: usize = 0;"
+    )
+    .expect("Could not write");
+
+    for part in parts.iter() {
+        match part {
+            SerializedPart::Static(vec) => {
+                writeln!(
+                    file,
+                    "
+    let next_len = {};
+    serialized[cur..cur + next_len].copy_from_slice(&{});
+    cur += next_len;",
+                    vec.len(),
+                    gen_u8_slice(&vec)
+                )
+                .expect("Could not write");
+            }
+            SerializedPart::Runtime {
+                arg_name,
+                arg_type: _,
+            } => {
+                writeln!(
+                    file,
+                    "
+    {}.serialize(&mut serialized, &mut cur);\n",
+                    arg_name
+                )
+                .expect("Could not write");
+            }
+        }
+    }
+    writeln!(file, "    serialized").expect("Could not write");
+    writeln!(file, "}}\n").expect("Could not write");
+}

--- a/app-sdk/src/ecalls_native.rs
+++ b/app-sdk/src/ecalls_native.rs
@@ -221,8 +221,8 @@ impl EcallsInterface for Ecall {
                     common::ux::PageContent::TextSubtext { text, subtext } => {
                         println!("{}\n{}", text, subtext);
                     }
-                    common::ux::PageContent::TagValueList(tag_values) => {
-                        for tag_value in tag_values {
+                    common::ux::PageContent::TagValueList { list } => {
+                        for tag_value in list {
                             println!("{}: {}", tag_value.tag, tag_value.value);
                         }
                     }

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -21,6 +21,8 @@ mod ecalls_riscv;
 #[cfg(not(target_arch = "riscv32"))]
 mod ecalls_native;
 
+mod ux_generated;
+
 use ecalls::{Ecall, EcallsInterface};
 use embedded_alloc::Heap;
 

--- a/apps/test/app/src/handlers/show_ux_screen.rs
+++ b/apps/test/app/src/handlers/show_ux_screen.rs
@@ -7,9 +7,18 @@ pub fn handle_show_ux_screen(data: &[u8]) -> Vec<u8> {
 
     let screen_id = data[0];
     match screen_id {
-        0 => sdk::ux::show_info(sdk::ux::Icon::Success, "Oh yeah!"),
-        1 => sdk::ux::show_info(sdk::ux::Icon::Failure, "Oh no!"),
-        2 => sdk::ux::show_spinner("Loading..."),
+        0 => {
+            sdk::ux::show_info(sdk::ux::Icon::Success, "Oh yeah!");
+            sdk::ux::wait(10);
+        }
+        1 => {
+            sdk::ux::show_info(sdk::ux::Icon::Failure, "Oh no!");
+            sdk::ux::wait(10);
+        }
+        2 => {
+            sdk::ux::show_spinner("Loading...");
+            sdk::ux::wait(10);
+        }
         3 => {
             sdk::ux::show_confirm_reject("Confirm", "Do you want to confirm?", "Yes", "No");
         }
@@ -46,6 +55,8 @@ pub fn handle_show_ux_screen(data: &[u8]) -> Vec<u8> {
         }
         _ => panic!("Unknown screen id"),
     }
+
+    sdk::ux::ux_idle();
 
     vec![]
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,3 +16,6 @@ postcard = { version = "1.0.8", default-features = false, features = ["alloc"] }
 [features]
 default = []
 device_sdk = ["ledger_device_sdk"]
+
+# This feature should only be used in the build.rs script app-sdk crate
+wrapped_serializable = []

--- a/common/src/ux.rs
+++ b/common/src/ux.rs
@@ -547,10 +547,12 @@ macro_rules! define_serializable_struct {
         }
 
         impl Serializable for $name {
+            #[inline(always)]
             fn get_serialized_length(&self) -> usize {
                 0 $( + self.$field.get_serialized_length() )*
             }
 
+            #[inline(always)]
             fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
                 $( self.$field.serialize(buf, pos); )*
             }
@@ -605,6 +607,7 @@ macro_rules! define_serializable_enum {
         }
 
         impl Serializable for $name {
+            #[inline(always)]
             fn get_serialized_length(&self) -> usize {
                 match self {
                     $(
@@ -613,6 +616,7 @@ macro_rules! define_serializable_enum {
                 }
             }
 
+            #[inline(always)]
             fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
                 match self {
                     $(

--- a/vm/src/handlers/lib/ecall/ux_handler.rs
+++ b/vm/src/handlers/lib/ecall/ux_handler.rs
@@ -340,8 +340,8 @@ impl UxHandler {
                                 },
                             );
                         }
-                        common::ux::PageContent::TagValueList(tvl) => {
-                            let tag_value_list = tvl
+                        common::ux::PageContent::TagValueList { list } => {
+                            let tag_value_list = list
                                 .iter()
                                 .map(|t| {
                                     let mut res =

--- a/vm/src/handlers/lib/ecall/ux_handler.rs
+++ b/vm/src/handlers/lib/ecall/ux_handler.rs
@@ -442,6 +442,12 @@ impl UxHandler {
                 }
             },
         }
+
+        #[cfg(any(target_os = "stax", target_os = "flex"))]
+        unsafe {
+            ledger_secure_sdk_sys::nbgl_refresh();
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
The UX framework has rather complex structures, like:

```rust
pub enum NavInfo {
    NavWithButtons {
        has_back_button: bool,
        has_page_indicator: bool,
        quit_text: Option<String>,
    },
}

pub struct NavigationInfo {
    pub active_page: u32,
    pub n_pages: u32,
    pub skip_text: Option<String>,
    pub nav_info: NavInfo,
}

pub struct TagValue {
    pub tag: String,
    pub value: String,
}

pub enum PageContent {
    TextSubtext { text: String, subtext: String },
    TagValueList { list: Vec<TagValue> },
    ConfirmationButton { text: String, button_text: String },
    ConfirmationLongPress { text: String, long_press_text: String },
}

pub struct PageContentInfo {
    pub title: Option<String>,
    pub top_right_icon: Icon,
    pub page_content: PageContent,
}

pub enum Page {
    Spinner { text: String },
    Info { icon: Icon, text: String },
    ConfirmReject { title: String, text: String, confirm: String, reject: String },
    GenericPage {
        navigation_info: Option<NavigationInfo>,
        page_content_info: PageContentInfo,
    },
}
```

A `Page` will be serialized in a standard format in the V-App when using `ECALL_SHOW_PAGE`; the VM deserializes it back to a `Page`, and shows the page appropriately.

While deserialization happens at the native speed, serialization is rather expensive, as it requires a lot of allocations and memory copying. Therefore, we want to do our best to minimize the work done to produce the serialized version of pages, by
- precomputing whenever possible
- inlining computations related to serialization, allowing the compiler to optimize

Notably, the `WrappedSerializable` trait allows the app-sdk to create specialized versions of those structures where for each field it can be decided whether its value is known at compilation time, or decided at runtime.

By using a combination macro in the `common` crate, and a `build.rs` script in the `app-sdk` crate, this PR greatly improves the performance of UX-related code.

### Future work

Possible future enhancements:

- Allow _fixed length_ pages that can be pre-allocated in memory, writing only the runtime fields at fixed locations. This requires (for example) having fixed length for strings (by deciding their maximum length). This would avoid 
- Possibly, improving the macros so that V-apps as well can take advantage of the framework (instead of just the SDK). TBD if this is worth it, perhaps not needed if the SDK already has enough functionality and with good enough performance.

Closes: #65