### PR TITLE
added derive macro for Serializable trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [
-    "app-sdk",
-    "client-sdk"
-]
+members = ["app-sdk", "client-sdk", "macros", "common"]
+
+[workspace.dependencies]
+vanadium_macros = { path = "./macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["app-sdk", "client-sdk", "macros", "common"]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
 resolver = "2"
 members = ["app-sdk", "client-sdk", "macros", "common"]
-
-[workspace.dependencies]
-vanadium_macros = { path = "./macros" }

--- a/app-sdk/src/ecalls_native.rs
+++ b/app-sdk/src/ecalls_native.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 
 use crate::ecalls::EcallsInterface;
 use common::ecall_constants::{CurveKind, MAX_BIGNUMBER_SIZE};
-use common::ux::{EventCode, EventData, Serializable};
+use common::ux::{EventCode, EventData, Deserializable};
 
 use bip32::{ChildNumber, XPrv};
 use hex_literal::hex;

--- a/app-sdk/src/ux.rs
+++ b/app-sdk/src/ux.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 pub use common::ux::{
     Action, Event, EventCode, EventData, Icon, NavInfo, NavigationInfo, Page, PageContent,
-    PageContentInfo, Serializable, TagValue,
+    PageContentInfo, Deserializable, TagValue,
 };
 
 use crate::ux_generated;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,7 +8,7 @@ serde = { version = "1.0.204", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-vanadium_macros = { workspace = true }
+vanadium_macros = { path = "../macros" }
 
 # Optional dependencies
 ledger_device_sdk = { version = "1.15.4", optional = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,4 +23,4 @@ default = []
 device_sdk = ["ledger_device_sdk"]
 
 # This feature should only be used in the build.rs script app-sdk crate
-wrapped_serializable = ["vanadium_macros/wrapped_serializable"]
+wrapped_serializable = []

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.204", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0.204", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
+vanadium_macros = { workspace = true }
 
 # Optional dependencies
 ledger_device_sdk = { version = "1.15.4", optional = true }
+
 
 [dev-dependencies]
 sha2 = { version = "0.10.8", default-features = false }
@@ -18,4 +23,4 @@ default = []
 device_sdk = ["ledger_device_sdk"]
 
 # This feature should only be used in the build.rs script app-sdk crate
-wrapped_serializable = []
+wrapped_serializable = ["vanadium_macros/wrapped_serializable"]

--- a/common/src/ux/codec.rs
+++ b/common/src/ux/codec.rs
@@ -1,10 +1,24 @@
 use alloc::{string::String, vec::Vec};
 use core::convert::TryInto;
 
-pub trait Serializable: Sized {
+// a reduced-functionality version of Serializable, only used for &str
+// and its composite types, and slices of Serializable types.
+pub trait MiniSerializable {
     fn get_serialized_length(&self) -> usize;
-
     fn serialize(&self, buf: &mut [u8], pos: &mut usize);
+}
+
+impl<T: MiniSerializable + ?Sized> MiniSerializable for &T {
+    fn get_serialized_length(&self) -> usize {
+        T::get_serialized_length(self)
+    }
+
+    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
+        T::serialize(self, buf, pos);
+    }
+}
+
+pub trait Serializable: MiniSerializable + Sized {
     fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str>;
 
     #[inline(always)]
@@ -30,7 +44,7 @@ pub trait Serializable: Sized {
     }
 }
 
-impl Serializable for bool {
+impl MiniSerializable for bool {
     #[inline(always)]
     fn get_serialized_length(&self) -> usize {
         1
@@ -41,21 +55,20 @@ impl Serializable for bool {
         buf[*pos] = *self as u8;
         *pos += 1;
     }
+}
 
+impl Serializable for bool {
     fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        if let Some((&byte, rest)) = slice.split_first() {
-            match byte {
-                0 => Ok((false, rest)),
-                1 => Ok((true, rest)),
-                _ => Err("invalid boolean value"),
-            }
-        } else {
-            Err("slice too short for bool")
+        match slice {
+            [0, rest @ ..] => Ok((false, rest)),
+            [1, rest @ ..] => Ok((true, rest)),
+            [_, ..] => Err("invalid boolean value"),
+            _ => Err("slice too short for bool"),
         }
     }
 }
 
-impl Serializable for u8 {
+impl MiniSerializable for u8 {
     #[inline(always)]
     fn get_serialized_length(&self) -> usize {
         1
@@ -66,17 +79,18 @@ impl Serializable for u8 {
         buf[*pos] = *self;
         *pos += 1;
     }
+}
 
+impl Serializable for u8 {
     fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        if let Some((&byte, rest)) = slice.split_first() {
-            Ok((byte, rest))
-        } else {
-            Err("slice too short for u8")
+        match slice {
+            [byte, rest @ ..] => Ok((*byte, rest)),
+            _ => Err("slice too short for u8"),
         }
     }
 }
 
-impl Serializable for u16 {
+impl MiniSerializable for u16 {
     #[inline(always)]
     fn get_serialized_length(&self) -> usize {
         2
@@ -90,19 +104,21 @@ impl Serializable for u16 {
         buf[*pos + 1] = (*self & 0xFF) as u8;
         *pos += 2;
     }
+}
 
+impl Serializable for u16 {
     fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        if slice.len() < 2 {
-            Err("slice too short for u16")
-        } else {
-            let (bytes, rest) = slice.split_at(2);
-            let arr: [u8; 2] = bytes.try_into().unwrap();
-            Ok((u16::from_be_bytes(arr), rest))
+        match slice {
+            [b1, b2, rest @ ..] => {
+                let value = u16::from_be_bytes([*b1, *b2]);
+                Ok((value, rest))
+            }
+            _ => Err("slice too short for u16"),
         }
     }
 }
 
-impl Serializable for u32 {
+impl MiniSerializable for u32 {
     #[inline(always)]
     fn get_serialized_length(&self) -> usize {
         4
@@ -118,37 +134,33 @@ impl Serializable for u32 {
         buf[*pos + 3] = (*self & 0xFF) as u8;
         *pos += 4;
     }
+}
 
+impl Serializable for u32 {
     fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        if slice.len() < 4 {
-            Err("slice too short for u32")
-        } else {
-            let (bytes, rest) = slice.split_at(4);
-            let arr: [u8; 4] = bytes.try_into().unwrap();
-            Ok((u32::from_be_bytes(arr), rest))
+        match slice {
+            [b1, b2, b3, b4, rest @ ..] => {
+                let value = u32::from_be_bytes([*b1, *b2, *b3, *b4]);
+                Ok((value, rest))
+            }
+            _ => Err("slice too short for u32"),
         }
     }
 }
 
-impl Serializable for String {
+impl MiniSerializable for String {
     #[inline(always)]
     fn get_serialized_length(&self) -> usize {
-        core::mem::size_of::<u16>() + self.len()
+        MiniSerializable::get_serialized_length(self.as_str())
     }
 
     #[inline(always)]
     fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        let bytes = self.as_bytes();
-        let len = bytes.len();
-        if len > u16::MAX as usize {
-            panic!("string too long");
-        }
-        (len as u16).serialize(buf, pos);
-
-        buf[*pos..*pos + len].copy_from_slice(bytes);
-        *pos += len;
+        MiniSerializable::serialize(self.as_str(), buf, pos);
     }
+}
 
+impl Serializable for String {
     fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
         let (len, rest) = u16::deserialize(slice)?;
         let len = len as usize;
@@ -158,127 +170,6 @@ impl Serializable for String {
         let (string_bytes, rest) = rest.split_at(len);
         let s = String::from_utf8(string_bytes.to_vec()).map_err(|_| "invalid utf8")?;
         Ok((s, rest))
-    }
-}
-
-impl<T: Serializable> Serializable for Option<T> {
-    #[inline(always)]
-    fn get_serialized_length(&self) -> usize {
-        1 + match self {
-            Some(value) => value.get_serialized_length(),
-            None => 0,
-        }
-    }
-
-    #[inline(always)]
-    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        match self {
-            Some(value) => {
-                buf[*pos] = 1;
-                *pos += 1;
-                value.serialize(buf, pos);
-            }
-            None => {
-                buf[*pos] = 0;
-                *pos += 1;
-            }
-        }
-    }
-
-    fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        if let Some((&tag, rest)) = slice.split_first() {
-            match tag {
-                1 => {
-                    let (value, rest) = T::deserialize(rest)?;
-                    Ok((Some(value), rest))
-                }
-                0 => Ok((None, rest)),
-                _ => Err("invalid Option tag"),
-            }
-        } else {
-            Err("slice too short for Option tag")
-        }
-    }
-}
-
-impl<T: Serializable> Serializable for Vec<T> {
-    #[inline(always)]
-    fn get_serialized_length(&self) -> usize {
-        4 + self
-            .iter()
-            .map(Serializable::get_serialized_length)
-            .sum::<usize>()
-    }
-
-    #[inline(always)]
-    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        let len = self.len();
-        if len > (u32::MAX as usize) {
-            panic!("vector too long");
-        }
-        (len as u32).serialize(buf, pos);
-        for item in self {
-            item.serialize(buf, pos);
-        }
-    }
-
-    fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        let (len, mut rem) = u32::deserialize(slice)?;
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let (item, next) = T::deserialize(rem)?;
-            vec.push(item);
-            rem = next;
-        }
-        Ok((vec, rem))
-    }
-}
-
-// a reduced-functionality version of Serializable, only used for &str
-// and its composite types, and slices of Serializable types.
-pub trait MiniSerializable: Sized {
-    fn get_serialized_length(&self) -> usize;
-    fn serialize(&self, buf: &mut [u8], pos: &mut usize);
-}
-
-impl MiniSerializable for &str {
-    #[inline(always)]
-    fn get_serialized_length(&self) -> usize {
-        core::mem::size_of::<u16>() + self.len()
-    }
-
-    #[inline(always)]
-    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        let bytes = self.as_bytes();
-        let len = bytes.len();
-        if len > u16::MAX as usize {
-            panic!("string too long");
-        }
-        (len as u16).serialize(buf, pos);
-        buf[*pos..*pos + len].copy_from_slice(bytes);
-        *pos += len;
-    }
-}
-
-impl<T: Serializable> MiniSerializable for &[T] {
-    #[inline(always)]
-    fn get_serialized_length(&self) -> usize {
-        4 + self
-            .iter()
-            .map(Serializable::get_serialized_length)
-            .sum::<usize>()
-    }
-
-    #[inline(always)]
-    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        let len = self.len();
-        if len > (u32::MAX as usize) {
-            panic!("slice too long");
-        }
-        (len as u32).serialize(buf, pos);
-        for item in self.iter() {
-            item.serialize(buf, pos);
-        }
     }
 }
 
@@ -307,7 +198,65 @@ impl<T: MiniSerializable> MiniSerializable for Option<T> {
     }
 }
 
+impl<T: Serializable> Serializable for Option<T> {
+    fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
+        match slice {
+            [0, rest @ ..] => Ok((None, rest)),
+            [1, rest @ ..] => {
+                let (value, rest) = T::deserialize(rest)?;
+                Ok((Some(value), rest))
+            }
+            [] => Err("slice too short for Option tag"),
+            _ => Err("invalid Option tag"),
+        }
+    }
+}
+
 impl<T: MiniSerializable> MiniSerializable for Vec<T> {
+    #[inline(always)]
+    fn get_serialized_length(&self) -> usize {
+        MiniSerializable::get_serialized_length(self.as_slice())
+    }
+
+    #[inline(always)]
+    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
+        MiniSerializable::serialize(self.as_slice(), buf, pos);
+    }
+}
+
+impl<T: Serializable> Serializable for Vec<T> {
+    fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
+        let (len, mut rem) = u32::deserialize(slice)?;
+        let mut vec = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            let (item, next) = T::deserialize(rem)?;
+            vec.push(item);
+            rem = next;
+        }
+        Ok((vec, rem))
+    }
+}
+
+impl MiniSerializable for str {
+    #[inline(always)]
+    fn get_serialized_length(&self) -> usize {
+        core::mem::size_of::<u16>() + self.len()
+    }
+
+    #[inline(always)]
+    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
+        let bytes = self.as_bytes();
+        let len = self.len();
+        let Ok(casted_len) = TryInto::<u16>::try_into(len) else {
+            panic!("slice too long");
+        };
+        MiniSerializable::serialize(&casted_len, buf, pos);
+        buf[*pos..][..len].copy_from_slice(bytes);
+        *pos += len;
+    }
+}
+
+impl<T: MiniSerializable> MiniSerializable for [T] {
     #[inline(always)]
     fn get_serialized_length(&self) -> usize {
         4 + self
@@ -318,13 +267,11 @@ impl<T: MiniSerializable> MiniSerializable for Vec<T> {
 
     #[inline(always)]
     fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        let len = self.len();
-        if len > (u32::MAX as usize) {
-            panic!("vector too long");
-        }
-
-        (len as u32).serialize(buf, pos);
-        for item in self {
+        let Ok(len) = TryInto::<u32>::try_into(self.len()) else {
+            panic!("slice too long");
+        };
+        MiniSerializable::serialize(&len, buf, pos);
+        for item in self.iter() {
             item.serialize(buf, pos);
         }
     }
@@ -543,193 +490,3 @@ impl<'a> Makeable<'a> for String {
 impl<'a, T: Makeable<'a>> Makeable<'a> for Option<T> {
     type ArgType = Option<T::ArgType>;
 }
-
-// MACROS
-
-macro_rules! define_serializable_struct {
-    (
-        $name:ident {
-            $($field:ident : $field_ty:ty),* $(,)?
-        },
-        wrapped: $wrapped_name:ident
-    ) => {
-        // Non-wrapped struct
-        #[derive(Debug, PartialEq, Eq, Clone)]
-        pub struct $name {
-            $(pub $field: $field_ty),*
-        }
-
-        impl Serializable for $name {
-            #[inline(always)]
-            fn get_serialized_length(&self) -> usize {
-                0 $( + self.$field.get_serialized_length() )*
-            }
-
-            #[inline(always)]
-            fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-                $( self.$field.serialize(buf, pos); )*
-            }
-
-            fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-                let mut slice = slice;
-                $(
-                    let ($field, new_slice) = <$field_ty>::deserialize(slice)?;
-                    slice = new_slice;
-                )*
-                Ok((Self { $($field),* }, slice))
-            }
-        }
-
-        // Wrapped struct (under feature flag)
-        #[cfg(feature = "wrapped_serializable")]
-        #[derive(Debug, PartialEq, Eq, Clone)]
-        pub struct $wrapped_name {
-            $(pub $field: <$field_ty as Wrappable>::Wrapped),*
-        }
-
-        #[cfg(feature = "wrapped_serializable")]
-        impl WrappedSerializable for $wrapped_name {
-            fn serialize_wrapped(&self) -> alloc::vec::Vec<SerializedPart> {
-                let mut parts = alloc::vec::Vec::new();
-                $(
-                    parts.extend(self.$field.serialize_wrapped());
-                )*
-                parts
-            }
-        }
-
-        #[cfg(feature = "wrapped_serializable")]
-        impl Wrappable for $name {
-            type Wrapped = $wrapped_name;
-        }
-
-        impl Makeable<'_> for $name {
-            type ArgType = $name;
-        }
-    };
-}
-
-macro_rules! define_serializable_enum {
-    (
-        $name:ident {
-            $(
-                $tag:expr => $variant:ident {
-                    $($field:ident : $enum_ty:ty),* $(,)?
-                } as ($fn_maker:ident, $fn_maker_wrapped:ident)
-            ),* $(,)?
-        },
-        wrapped: $wrapped_name:ident
-    ) => {
-        // Non-wrapped enum
-        #[derive(Debug, PartialEq, Eq, Clone)]
-        pub enum $name {
-            $(
-                $variant { $($field: $enum_ty),* },
-            )*
-        }
-
-        impl Serializable for $name {
-            #[inline(always)]
-            fn get_serialized_length(&self) -> usize {
-                match self {
-                    $(
-                        Self::$variant { $($field),* } => 1 $( + $field.get_serialized_length() )*
-                    ),*
-                }
-            }
-
-            #[inline(always)]
-            fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-                match self {
-                    $(
-                        Self::$variant { $($field),* } => {
-                            $tag.serialize(buf, pos);
-                            $(
-                                $field.serialize(buf, pos);
-                            )*
-                        }
-                    ),*
-                }
-            }
-
-            fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-                if slice.is_empty() {
-                    return Err(concat!(stringify!($name), " slice too short for tag"));
-                }
-                let (tag, rest) = slice.split_first().unwrap();
-                match tag {
-                    $(
-                        x if *x == $tag => {
-                            let mut r = rest;
-                            $(
-                                let ($field, new_r) = <$enum_ty>::deserialize(r)?;
-                                r = new_r;
-                            )*
-                            Ok((Self::$variant { $($field),* }, r))
-                        }
-                    ),*,
-                    _ => Err("unknown tag"),
-                }
-            }
-        }
-
-        // Maker functions
-        impl $name {
-            $(
-                #[inline(always)]
-                pub fn $fn_maker($($field: <$enum_ty as Makeable>::ArgType),*) -> alloc::vec::Vec<u8> {
-                    let len = {
-                        let mut len = $tag.get_serialized_length();
-                        $( len += $field.get_serialized_length(); )*
-                        len
-                    };
-                    let mut buf = alloc::vec::Vec::with_capacity(len);
-                    unsafe { buf.set_len(len); }
-                    let mut pos: usize = 0;
-                    $tag.serialize(&mut buf, &mut pos);
-                    $( $field.serialize(&mut buf, &mut pos); )*
-                    buf
-                }
-            )*
-        }
-
-        // Wrapped enum
-        #[cfg(feature = "wrapped_serializable")]
-        #[derive(Debug, PartialEq, Eq, Clone)]
-        pub enum $wrapped_name {
-            $(
-                $variant { $($field: <$enum_ty as Wrappable>::Wrapped),* },
-            )*
-        }
-
-        #[cfg(feature = "wrapped_serializable")]
-        impl WrappedSerializable for $wrapped_name {
-            fn serialize_wrapped(&self) -> alloc::vec::Vec<SerializedPart> {
-                let mut parts = alloc::vec::Vec::new();
-                match self {
-                    $(
-                        Self::$variant { $($field),* } => {
-                            parts.push(SerializedPart::Static(alloc::vec![$tag]));
-                            $(
-                                parts.extend($field.serialize_wrapped());
-                            )*
-                        }
-                    ),*
-                }
-                parts
-            }
-        }
-
-        #[cfg(feature = "wrapped_serializable")]
-        impl Wrappable for $name {
-            type Wrapped = $wrapped_name;
-        }
-
-        impl Makeable<'_> for $name {
-            type ArgType = $name;
-        }
-    };
-}
-
-pub(crate) use define_serializable_enum;
-pub(crate) use define_serializable_struct;

--- a/common/src/ux/mod.rs
+++ b/common/src/ux/mod.rs
@@ -1,7 +1,7 @@
 mod codec;
 mod types;
 
-pub use codec::{MiniSerializable, Serializable};
+pub use codec::{Deserializable, Serializable};
 
 #[cfg(feature = "wrapped_serializable")]
 pub use codec::{ct, ct_str, rt, rt_str, SerializedPart, WrappedSerializable};

--- a/common/src/ux/types.rs
+++ b/common/src/ux/types.rs
@@ -63,7 +63,7 @@ pub enum Event {
 
 /// For the Icon page, define whether the icon indicates success or failure.
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(maybe_const)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(maybe_const))]
 pub enum Icon {
     None,
     Success,
@@ -73,7 +73,7 @@ pub enum Icon {
 // Structured types
 
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(name = WrappedNavInfo)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(name = WrappedNavInfo))]
 pub enum NavInfo {
     #[maker(make_nav_with_buttons)]
     NavWithButtons {
@@ -84,7 +84,7 @@ pub enum NavInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(name = WrappedNavigationInfo)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(name = WrappedNavigationInfo))]
 pub struct NavigationInfo {
     pub active_page: u32,
     pub n_pages: u32,
@@ -93,14 +93,14 @@ pub struct NavigationInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(name = WrappedTagValue)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(name = WrappedTagValue))]
 pub struct TagValue {
     pub tag: String,
     pub value: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(name = WrappedPageContent)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(name = WrappedPageContent))]
 pub enum PageContent {
     #[maker(make_text_subtext)]
     TextSubtext { text: String, subtext: String },
@@ -117,7 +117,7 @@ pub enum PageContent {
 
 // nbgl_pageContent_t
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(name = WrappedPageContentInfo)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(name = WrappedPageContentInfo))]
 pub struct PageContentInfo {
     pub title: Option<String>,
     pub top_right_icon: Icon,
@@ -125,12 +125,15 @@ pub struct PageContentInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serializable)]
-#[wrapped(name = WrappedPage)]
+#[cfg_attr(feature = "wrapped_serializable", wrapped(name = WrappedPage))]
 pub enum Page {
+    /// A page showing a spinner and some text.
     #[maker(make_spinner)]
     Spinner { text: String },
+    /// A page showing an icon (either success or failure) and some text.
     #[maker(make_info)]
     Info { icon: Icon, text: String },
+    /// A page with a title, text, a "confirm" button, and a "reject" button.
     #[maker(make_confirm_reject)]
     ConfirmReject {
         title: String,
@@ -138,6 +141,7 @@ pub enum Page {
         confirm: String,
         reject: String,
     },
+    /// A generic page with navigation, implementing a subset of the pages supported by nbgl_pageDrawGenericContent
     #[maker(make_generic_page)]
     GenericPage {
         navigation_info: Option<NavigationInfo>,

--- a/common/src/ux/types.rs
+++ b/common/src/ux/types.rs
@@ -157,7 +157,7 @@ mod tests {
     // Helper function for round-trip serialization/deserialization tests.
     fn round_trip<T>(value: &T)
     where
-        T: Serializable + PartialEq + core::fmt::Debug,
+        T: Deserializable + Serializable + PartialEq + core::fmt::Debug,
     {
         let serialized = value.serialized();
         let (deserialized, rest) = T::deserialize(&serialized).unwrap();

--- a/common/src/ux/types.rs
+++ b/common/src/ux/types.rs
@@ -1,4 +1,5 @@
 use alloc::{string::String, vec::Vec};
+use vanadium_macros::Serializable;
 
 use super::codec::*;
 
@@ -61,139 +62,87 @@ pub enum Event {
 }
 
 /// For the Icon page, define whether the icon indicates success or failure.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(maybe_const)]
 pub enum Icon {
     None,
     Success,
     Failure,
 }
 
-impl Serializable for Icon {
-    #[inline(always)]
-    fn get_serialized_length(&self) -> usize {
-        1
-    }
-
-    #[inline(always)]
-    fn serialize(&self, buf: &mut [u8], pos: &mut usize) {
-        let tag: u8 = match self {
-            Icon::None => 0,
-            Icon::Success => 1,
-            Icon::Failure => 2,
-        };
-        tag.serialize(buf, pos);
-    }
-
-    fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
-        if slice.len() < 1 {
-            return Err("slice too short for icon tag");
-        }
-        let (tag, rest) = slice.split_first().unwrap();
-        match tag {
-            0 => Ok((Icon::None, rest)),
-            1 => Ok((Icon::Success, rest)),
-            2 => Ok((Icon::Failure, rest)),
-            _ => Err("invalid icon tag"),
-        }
-    }
-}
-
-#[cfg(feature = "wrapped_serializable")]
-impl Wrappable for Icon {
-    type Wrapped = MaybeConst<Icon>;
-}
-
-impl Makeable<'_> for Icon {
-    type ArgType = Icon;
-}
-
 // Structured types
 
-define_serializable_enum! {
-    NavInfo {
-        0x01u8 => NavWithButtons {
-            has_back_button: bool,
-            has_page_indicator: bool,
-            quit_text: Option<String>,
-        } as (make_nav_with_buttons, make_nav_with_buttons_wrapped),
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(name = WrappedNavInfo)]
+pub enum NavInfo {
+    #[maker(make_nav_with_buttons)]
+    NavWithButtons {
+        has_back_button: bool,
+        has_page_indicator: bool,
+        quit_text: Option<String>,
     },
-    wrapped: WrappedNavInfo
 }
 
-define_serializable_struct! {
-    NavigationInfo {
-        active_page: u32,
-        n_pages: u32,
-        skip_text: Option<String>,
-        nav_info: NavInfo
-    },
-    wrapped: WrappedNavigationInfo
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(name = WrappedNavigationInfo)]
+pub struct NavigationInfo {
+    pub active_page: u32,
+    pub n_pages: u32,
+    pub skip_text: Option<String>,
+    pub nav_info: NavInfo,
 }
 
-define_serializable_struct! {
-    TagValue {
-        tag: String,
-        value: String,
-    },
-    wrapped: WrappedTagValue
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(name = WrappedTagValue)]
+pub struct TagValue {
+    pub tag: String,
+    pub value: String,
 }
 
-define_serializable_enum! {
-    PageContent {
-        0x01u8 => TextSubtext {
-            text: String,
-            subtext: String,
-        } as (make_text_subtext, make_text_subtext_wrapped),
-        0x02u8 => TagValueList {
-            list: Vec<TagValue>,
-        } as (make_tag_value_list, make_tag_value_list_wrapped),
-        0x03u8 => ConfirmationButton {
-            text: String,
-            button_text: String,
-        } as (make_confirmation_button, make_confirmation_button_wrapped),
-        0x04u8 => ConfirmationLongPress {
-            text: String,
-            long_press_text: String,
-        } as (make_confirmation_long_press, make_confirmation_long_press_wrapped),
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(name = WrappedPageContent)]
+pub enum PageContent {
+    #[maker(make_text_subtext)]
+    TextSubtext { text: String, subtext: String },
+    #[maker(make_tag_value_list)]
+    TagValueList { list: Vec<TagValue> },
+    #[maker(make_confirmation_button)]
+    ConfirmationButton { text: String, button_text: String },
+    #[maker(make_confirmation_long_press)]
+    ConfirmationLongPress {
+        text: String,
+        long_press_text: String,
     },
-    wrapped: WrappedPageContent
 }
 
 // nbgl_pageContent_t
-define_serializable_struct! {
-    PageContentInfo {
-        title: Option<String>,
-        top_right_icon: Icon,
-        page_content: PageContent,
-    },
-    wrapped: WrappedPageContentInfo
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(name = WrappedPageContentInfo)]
+pub struct PageContentInfo {
+    pub title: Option<String>,
+    pub top_right_icon: Icon,
+    pub page_content: PageContent,
 }
 
-define_serializable_enum! {
-    Page {
-        // A page showing a spinner and some text.
-        0x01u8 => Spinner {
-            text: String,
-        } as (make_spinner, make_spinner_wrapped),
-        // A page showing an icon (either success or failure) and some text.
-        0x02u8 => Info {
-            icon: Icon,
-            text: String,
-        } as (make_info, make_info_wrapped),
-        // A page with a title, text, a "confirm" button, and a "reject" button.
-        0x03u8 => ConfirmReject {
-            title: String,
-            text: String,
-            confirm: String,
-            reject: String,
-        } as (make_confirm_reject, make_confirm_reject_wrapped),
-        // A generic page with navigation, implementing a subset of the pages supported by nbgl_pageDrawGenericContent
-        0x04u8 => GenericPage {
-            navigation_info: Option<NavigationInfo>,
-            page_content_info: PageContentInfo }
-            as (make_generic_page, make_generic_page_wrapped),
+#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
+#[wrapped(name = WrappedPage)]
+pub enum Page {
+    #[maker(make_spinner)]
+    Spinner { text: String },
+    #[maker(make_info)]
+    Info { icon: Icon, text: String },
+    #[maker(make_confirm_reject)]
+    ConfirmReject {
+        title: String,
+        text: String,
+        confirm: String,
+        reject: String,
     },
-    wrapped: WrappedPage
+    #[maker(make_generic_page)]
+    GenericPage {
+        navigation_info: Option<NavigationInfo>,
+        page_content_info: PageContentInfo,
+    },
 }
 
 #[cfg(test)]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,4 +13,5 @@ proc-macro2 = "1"
 proc-macro-error2 = { version = "2.0", default-features = false }
 
 [features]
+default = []
 wrapped_serializable = []

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,7 +11,3 @@ syn = "2.0"
 quote = "1"
 proc-macro2 = "1"
 proc-macro-error2 = { version = "2.0", default-features = false }
-
-[features]
-default = []
-wrapped_serializable = []

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vanadium_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1"
+proc-macro2 = "1"
+proc-macro-error2 = { version = "2.0", default-features = false }
+
+[features]
+wrapped_serializable = []

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vanadium_macros"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/macros/src/derive_serializable.rs
+++ b/macros/src/derive_serializable.rs
@@ -1,0 +1,693 @@
+use proc_macro2::TokenStream;
+use proc_macro_error2::abort;
+use quote::{format_ident, quote, ToTokens};
+use syn::{parse::Parse, DataEnum, DataStruct, DeriveInput, Field, Fields, Ident, Member, Meta, Token, Visibility};
+
+enum Wrapped {
+    // the inner ident is useless in itself, just stored to keep the span.
+    MaybeConst(Ident), 
+    Ident(Ident)
+}
+
+impl Parse for Wrapped {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let ident = input.parse::<Ident>()?;
+        if input.is_empty() {
+            if ident == "maybe_const" {
+                return Ok(Wrapped::MaybeConst(ident));
+            } else {
+                return Err(syn::Error::new_spanned(ident, "only `maybe_const` and `name = $ident` or allowed."));
+            }
+        }
+        input.parse::<Token![=]>()?;
+        let name = input.parse::<Ident>()?;
+        if ident != "name" {
+            return Err(syn::Error::new_spanned(ident, "only `maybe_const` and `name = $ident` or allowed."))
+        }
+        Ok(Wrapped::Ident(name))
+    }
+}
+
+pub fn derive_serializable(input: DeriveInput) -> TokenStream {
+    let mut iter = input.attrs.iter().filter_map(|att| match &att.meta {
+        Meta::List(meta_list) if meta_list.path.segments.first().unwrap().ident == "wrapped" => {
+            match meta_list.parse_args::<Wrapped>() {
+                Ok(wrapped) => Some(wrapped),
+                Err(err) => abort!(meta_list, "invalid wrapped args: {}", err),
+            }
+        }
+        _ => None,
+    });
+
+    let wrapped_ident = iter.next();
+    if let Some(Wrapped::Ident(dup) | Wrapped::MaybeConst(dup)) = iter.next() {
+        abort!(dup, "duplicate wrapped attribute");
+        
+    }
+
+    let mut iter = input.attrs.iter().filter_map(|att| match &att.meta {
+        Meta::List(meta_list) if meta_list.path.segments.first().unwrap().ident == "maker" => {
+            match meta_list.parse_args::<Ident>() {
+                Ok(fn_name) => Some(fn_name),
+                Err(err) => abort!(meta_list, "invalid maker args: {}", err),
+            }
+        }
+        _ => None,
+    });
+
+    let make_fn_ident = iter.next();
+    if let Some(dup) = iter.next() {
+        abort!(dup, "duplicate maker");
+    }
+
+    let vis = &input.vis;
+
+    match &input.data {
+        syn::Data::Struct(data) => derive_struct(vis, &input.ident, data, wrapped_ident.as_ref(), make_fn_ident.as_ref()),
+        syn::Data::Enum(data) => derive_enum(vis, &input.ident, data, wrapped_ident.as_ref()),
+        syn::Data::Union(data) => abort!(data.union_token, "unions are not supported"),
+    }
+}
+
+fn derive_enum(
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataEnum,
+    wrapped_ident: Option<&Wrapped>,
+) -> TokenStream {
+
+    let wrapped = if cfg!(feature = "wrapped_serializable") {
+        if let Some(wrapped_ident) = wrapped_ident {
+
+            Some(wrappable_enum(vis, ident, data, wrapped_ident))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let serialized_length_match_arms = data.variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        match &variant.fields {
+            Fields::Named(fields) => {
+                let spread_fields = fields.named.iter().map(|field| field.ident.as_ref());
+                let get_field_length = spread_fields.clone();
+                quote! {
+                    Self::#variant_ident { #(#spread_fields,)* } => 1 #(
+                        + MiniSerializable::get_serialized_length(#get_field_length)
+                    )*
+                }
+            }
+            Fields::Unnamed(fields_unnamed) => {
+                let field_names = fields_unnamed
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| format_ident!("__field_{}__", i))
+                    .collect::<Vec<_>>();
+                quote! {
+                    Self::#variant_ident(#(#field_names),*) => 1 #(
+                        + MiniSerializable::get_serialized_length(#field_names)
+                    )*
+                }
+            }
+            Fields::Unit => quote!(Self::#variant_ident => 1),
+        }
+    });
+    let deserialize_match_arms = data
+        .variants
+        .iter()
+        .enumerate()
+        .map(|(discriminant, variant)| {
+            let variant_ident = &variant.ident;
+            let discriminant = discriminant as u8;
+            match &variant.fields {
+                Fields::Named(fields_named) => {
+                    let deserialize_fields = fields_named.named.iter().map(|field| {
+                        let field_name = field.ident.as_ref();
+                        let ty = &field.ty;
+                        // we could use the `?` operator, but it incrase compile times, and since nobody looks at macro code output... 
+                        quote! {
+                            let (#field_name, rest) = match <#ty as Serializable>::deserialize(rest) {
+                                Ok(v) => v,
+                                Err(err) => return Err(err)
+                            };
+                        }
+                    });
+                    let spread_fields = fields_named.named.iter().map(|field| field.ident.as_ref());
+                    quote! {
+                        [#discriminant, rest @ ..] => {
+                            #(
+                                #deserialize_fields
+                            )*
+                            Ok((Self::#variant_ident { #(#spread_fields,)* }, rest))
+                        }
+                    }
+                }
+                Fields::Unnamed(fields_unnamed) => {
+                    let fields = fields_unnamed
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .map(|(i, field)| (format_ident!("__field_{}__", i), &field.ty))
+                        .collect::<Vec<_>>();
+
+                        let deserialize_fields = fields.iter().map(|(field_name, ty)| {
+                            // we could use the `?` operator, but it incrase compile times, and since nobody looks at macro code output... 
+                            quote! {
+                                let (#field_name, rest) = match <#ty as Serializable>::deserialize(rest) {
+                                    Ok(v) => v,
+                                    Err(err) => return Err(err),
+                                };
+                            }
+                        });
+
+                    let spread_fields = fields.iter().map(|(ident, _)| ident);
+
+                    quote! {
+                        [#discriminant, rest @ ..] => {
+                            #(
+                                #deserialize_fields
+                            )*
+                            Ok((Self::#variant_ident(#(#spread_fields),*), rest))
+                        }
+                    }
+                }
+                Fields::Unit => quote! {
+                    [#discriminant, rest @ ..] => Ok((Self::#variant_ident, rest))
+                },
+            }
+        });
+    let slice_too_short = format!("{} slice to short for tag", ident);
+
+    let serialize_match_arms = data
+        .variants
+        .iter()
+        .enumerate()
+        .map(|(discriminant, variant)| {
+            let discriminant = discriminant as u8;
+            let variant_ident = &variant.ident;
+            match &variant.fields {
+                Fields::Named(fields_named) => {
+                    let fields_names = fields_named.named.iter().map(|field| field.ident.as_ref());
+                    let fields = fields_names.clone();
+                    quote! {
+                        Self::#variant_ident { #(#fields_names,)* } => {
+                            __buff[0] = #discriminant;
+                            *__pos += 1;
+                            #(
+                                MiniSerializable::serialize(#fields, __buff, __pos);
+                            )*
+                        }
+                    }
+                }
+                Fields::Unnamed(fields_unnamed) => {
+                    let field_names = fields_unnamed
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| format_ident!("__field_{}__", i))
+                        .collect::<Vec<_>>();
+
+                    quote! {
+                        Self::#variant_ident(#(#field_names),*) => {
+                            __buff[0] = #discriminant;
+                            *__pos += 1;
+                            #(
+                                MiniSerializable::serialize(#field_names, __buff, __pos);
+                            )*
+                        }
+                    }
+                }
+                Fields::Unit => quote! {
+                    Self::#variant_ident => {
+                        __buff[0] = #discriminant;
+                        *__pos += 1;
+                    }
+                },
+            }
+        });
+
+    let maker_functions = data
+        .variants
+        .iter()
+        .enumerate()
+        .filter_map(|(discriminant, variant)| {
+            let mut iter = variant.attrs.iter().filter_map(|att| match &att.meta {
+                Meta::List(list) if list.path.segments.first().unwrap().ident == "maker" => {
+                    match list.parse_args::<Ident>() {
+                        Ok(ident) => Some(ident),
+                        Err(err) => abort!(list, "invalid maker args: {}", err)
+                    }
+                }
+                _ => None,
+            });
+            match (iter.next(), iter.next()) {
+                (Some(ident), None) => Some((variant, ident, discriminant)),
+                (Some(_), Some(dup)) => abort!(dup, "duplicates maker attribute"),
+                _ => None,
+            }
+        })
+        .map(|(variant, fn_make_ident, discriminant)| {
+            let discriminant = discriminant as u8;
+            let (args, get_len, serialize) = match &variant.fields {
+                Fields::Named(fields_named) => {
+                    let args = fields_named.named.iter().map(|field| {
+                        let name = &field.ident;
+                        let ty = &field.ty;
+                        quote!(#name: <#ty as Makeable>::ArgType)
+                    });
+                    let get_fields_len = fields_named.named.iter().map(|field| {
+                        let name = &field.ident;
+                        quote!(MiniSerializable::get_serialized_length(&#name))
+                    });
+                    let serialize_field = fields_named.named.iter().map(|field| {
+                        let name = &field.ident;
+                        quote!(MiniSerializable::serialize(&#name, &mut __buff, &mut __pos))
+                    });
+                    (
+                        quote!(#(#args),*),
+                        quote!({
+                            1 #( + #get_fields_len)*
+                        }),
+                        quote!({
+                            __buff[0] = #discriminant;
+                            __pos += 1;
+                            #(
+                                #serialize_field;
+                            )*
+                        }),
+                    )
+                }
+                Fields::Unnamed(fields_unnamed) => {
+                    let fields = fields_unnamed
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .map(|(i, field)| (format_ident!("__field_{}__", i), &field.ty))
+                        .collect::<Vec<_>>();
+                    let args = fields
+                        .iter()
+                        .map(|(name, ty)| quote!(#name: <#ty as Makeable>::ArgType));
+                    let serialize_field = fields
+                        .iter()
+                        .map(|(name, _)| quote!(MiniSerializable::serialize(&#name, &mut __buff, &mut __pos)));
+                    let get_fields_len = fields
+                        .iter()
+                        .map(|(name, _)| quote!(MiniSerializable::get_serialized_length(&#name)));
+                    (
+                        quote!(#(#args),*),
+                        quote!({
+                            1 #( + #get_fields_len)*
+                        }),
+                        quote!({
+                            __buff[0] = #discriminant;
+                            __pos += 1;
+                            #(
+                                #serialize_field;
+                            )*
+                        })
+                    )
+                }
+                Fields::Unit => (
+                    quote!(),
+                    quote!(1usize),
+                    quote! {
+                        __buff[0] = #discriminant;
+                    },
+                ),
+            };
+
+            quote! {
+                pub fn #fn_make_ident(#args) -> Vec<u8> {
+                    let len = #get_len;
+                    let mut __buff = alloc::vec![0; len];
+                    let mut __pos = 0;
+                    #serialize
+                    __buff
+                }
+            }
+        });
+
+    quote! {
+
+        impl MiniSerializable for #ident {
+            fn get_serialized_length(&self) -> usize {
+                match self {
+                    #(
+                        #serialized_length_match_arms,
+                    )*
+                }
+            }
+
+            fn serialize(&self, __buff: &mut [u8], __pos: &mut usize) {
+                match self {
+                    #(
+                        #serialize_match_arms,
+                    )*
+                }
+            }
+        }
+
+        impl Serializable for #ident {
+            fn deserialize(slice: &[u8]) -> Result<(Self, &[u8]), &'static str> {
+                match slice {
+                    [] => Err(#slice_too_short),
+                    #(
+                        #deserialize_match_arms,
+                    )*
+                    _ => Err("unknown tag"),
+                }
+            }
+        }
+
+        impl #ident {
+            #(
+                #maker_functions
+            )*
+        }
+
+        #wrapped
+
+        impl Makeable<'_> for #ident {
+            type ArgType = #ident;
+        }
+    }
+}
+
+fn wrappable_enum(
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataEnum,
+    wrapped_ident: &Wrapped,
+) -> TokenStream {
+    let wrapped_ident = match wrapped_ident {
+        Wrapped::Ident(ident) => ident,
+        Wrapped::MaybeConst(_) => {
+            return quote! {
+                impl Wrappable for #ident {
+                    type Wrapped = MaybeConst<#ident>;
+                }
+            };
+        }
+    };
+
+    let variants = data.variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        match &variant.fields {
+            Fields::Named(fields_named) => {
+                let fields = fields_named.named.iter().map(|field| {
+                    let ident = field.ident.as_ref();
+                    let ty = &field.ty;
+                    quote!(#ident: <#ty as Wrappable>::Wrapped)
+                });
+                quote! {
+                    #variant_ident{
+                        #(
+                            #fields,
+                        )*
+                    }
+                }
+            }
+            Fields::Unnamed(fields_unnamed) => {
+                let fields = fields_unnamed.unnamed.iter().map(|field| {
+                    let ty = &field.ty;
+                    quote!(<#ty as Wrappable>::Wrapped)
+                });
+                quote!(#variant_ident(#(#fields),*))
+            }
+            Fields::Unit => quote!(#variant_ident),
+        }
+    });
+    let serialize_wrapped_match_arms = data.variants.iter().enumerate().map(|(discriminant,variant)| {
+        let discriminant = discriminant as u8;
+        let variant_ident = &variant.ident;
+
+        match &variant.fields {
+            Fields::Named(fields_named) => {
+                let fields = fields_named.named.iter().map(|field| field.ident.as_ref());
+                let serialize_fields = fields.clone();
+                quote! {
+                    Self::#variant_ident { #(#fields,)* } => {
+                        __parts.push(SerializedPart::Static(alloc::vec![#discriminant]));
+                        #(
+                            __parts.extend(WrappedSerializable::serialize_wrapped(#serialize_fields));
+                        )*
+                    }
+                }
+            },
+            Fields::Unnamed(fields_unnamed) => {
+                let fields = fields_unnamed
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| format_ident!("__field_{}__", i))
+                        .collect::<Vec<_>>();
+                
+                quote! {
+                    Self::#variant_ident(#(#fields),*) => {
+                        __parts.push(SerializedPart::Static(alloc::vec![#discriminant]));
+                        #(
+                            __parts.extend(WrappedSerializable::serialize_wrapped(#fields));
+                        )*
+                    }
+                }
+            },
+            Fields::Unit => {
+                quote! {
+                    Self::#variant_ident => {
+                        __parts.push(SerializedPart::Static(alloc::vec![#discriminant]));
+                    }
+                }
+            },
+        }
+    });
+
+    quote! {
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        #vis enum #wrapped_ident {
+            #(
+                #variants,
+            )*
+        }
+
+        impl WrappedSerializable for #wrapped_ident {
+            fn serialize_wrapped(&self) -> Vec<SerializedPart> {
+                let mut __parts = Vec::new();
+                match self {
+                    #(
+                        #serialize_wrapped_match_arms,
+                    )*
+                }
+                __parts
+            }
+        }
+
+        impl Wrappable for #ident {
+            type Wrapped = #wrapped_ident;
+        }
+    }
+}
+
+struct CustomFields<'a> {
+    member: Member,
+    field: &'a Field,
+}
+
+impl ToTokens for CustomFields<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.member.to_tokens(tokens);
+    }
+}
+
+fn derive_struct(vis: &Visibility, ident: &Ident, data: &DataStruct, wrapped_ident: Option<&Wrapped>, make_fn_ident: Option<&Ident>) -> TokenStream {
+    let fields = data.fields.members().zip(&data.fields).map(|(member, field)| {
+        CustomFields {
+            member,
+            field
+        }
+    }).collect::<Vec<_>>();
+
+    let maker_fn = make_fn_ident.map(|make_fn_ident| {
+        let (args, get_len, serialize) = match &data.fields {
+            Fields::Named(fields_named) => {
+                let args = fields_named.named.iter().map(|field| {
+                    let name = &field.ident;
+                    let ty = &field.ty;
+                    quote!(#name: <#ty as Makeable>::ArgType)
+                });
+                let get_fields_len = fields_named.named.iter().map(|field| {
+                    let name = &field.ident;
+                    quote!(MiniSerializable::get_serialized_length(&#name))
+                });
+                let serialize_field = fields_named.named.iter().map(|field| {
+                    let name = &field.ident;
+                    quote!(MiniSerializable::serialize(&#name, &mut __buff, &mut __pos))
+                });
+                (
+                    quote!(#(#args),*),
+                    quote!({
+                        0 #( + #get_fields_len)*
+                    }),
+                    quote!({
+                        #(
+                            #serialize_field;
+                        )*
+                    }),
+                )
+            },
+            Fields::Unnamed(fields_unnamed) => {
+                let fields = fields_unnamed.unnamed.iter().enumerate().map(|(i, field)| {
+                    let ty = &field.ty;
+                    (format_ident!("field_{}", i), ty)
+                }).collect::<Vec<_>>();
+                let args = fields
+                        .iter()
+                        .map(|(name, ty)| quote!(#name: <#ty as Makeable>::ArgType));
+                    let serialize_field = fields
+                        .iter()
+                        .map(|(name, _)| quote!(MiniSerializable::serialize(&#name, &mut __buff, &mut __pos)));
+                    let get_fields_len = fields
+                        .iter()
+                        .map(|(name, _)| quote!(MiniSerializable::get_serialized_length(&#name)));
+                    (quote!(#(#args),*),
+                    quote!({
+                        0 #( + #get_fields_len)*
+                    }),
+                    quote!({
+                        #(
+                            #serialize_field;
+                        )*
+                    }))
+            },
+            Fields::Unit => (quote! {}, quote! {1usize}, quote! {}),
+        };
+        quote! {
+            impl #ident {
+                pub fn #make_fn_ident(#args) -> Vec<u8> {
+                    let len = #get_len;
+                    let mut __buff = alloc::vec![0; len];
+                    let mut __pos = 0;
+                    #serialize
+                    __buff
+                }
+            }
+        }
+    });
+
+    let wrapped = if cfg!(feature = "wrapped_serializable") {
+        if let Some(wrapped_ident) = wrapped_ident {
+            Some(wrappable_struct(vis, ident, &fields, wrapped_ident))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+
+
+
+    let serialized_fields = fields.iter().map(|field| {
+        let ty = &field.field.ty;
+        quote! {
+            <#ty as MiniSerializable>::serialize(&self.#field, __buff, __pos)
+        }
+    });
+
+    let deserialized_fields = fields.iter().map(|field| {
+        let ty = &field.field.ty;
+        quote! {
+            #field: match <#ty as Serializable>::deserialize(__rest) {
+                Ok((v, rest)) => {
+                    __rest = rest;
+                    v
+                },
+                Err(err) => return Err(err)
+            }
+        }
+    });
+
+
+    quote! {
+        impl MiniSerializable for #ident {
+            fn get_serialized_length(&self) -> usize {
+                0 #(+ MiniSerializable::get_serialized_length(&self.#fields))*
+            }
+
+            fn serialize(&self, __buff: &mut [u8], __pos: &mut usize) {
+                #(
+                    #serialized_fields;
+                )*
+            }
+        }
+
+        impl Serializable for #ident {
+            fn deserialize(mut __rest: &[u8]) -> Result<(Self, &[u8]), &'static str> {
+                let this = Self {
+                    #(
+                        #deserialized_fields,
+                    )*
+                };
+                Ok((this, __rest))
+            }
+        }
+
+        #maker_fn
+
+        #wrapped
+
+        impl Makeable<'_> for #ident {
+            type ArgType = #ident;
+        }
+    }
+}
+
+fn wrappable_struct(
+    vis: &Visibility,
+    ident: &Ident,
+    fields: &[CustomFields],
+    wrapped_ident: &Wrapped,
+) -> TokenStream {
+    
+    let wrapped_ident = match wrapped_ident {
+        Wrapped::Ident(ident) => ident,
+        Wrapped::MaybeConst(_) => {
+            return quote! {
+                impl Wrappable for #ident {
+                    type Wrapped = MaybeConst<#ident>;
+                }
+            };
+        }
+    };
+
+    let struct_fields = fields.iter().map(|field| {
+        let ty = &field.field.ty;
+
+        quote!(pub #field: <#ty as Wrappable>::Wrapped)
+    });
+
+    quote! {
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        #vis struct #wrapped_ident {
+            #(
+                #struct_fields,
+            )*
+        }
+
+        impl WrappedSerializable for #wrapped_ident {
+            fn serialize_wrapped(&self) -> Vec<SerializedPart> {
+                let mut __parts = Vec::new();
+                #(
+                    __parts.extend(WrappedSerializable::serialize_wrapped(&self.#fields));
+                )*
+                __parts
+            }
+        }
+
+        impl Wrappable for #ident {
+            type Wrapped = #wrapped_ident;
+        }
+    }
+}

--- a/macros/src/derive_serializable.rs
+++ b/macros/src/derive_serializable.rs
@@ -76,11 +76,7 @@ fn derive_enum(
     wrapped_ident: Option<&Wrapped>,
 ) -> TokenStream {
 
-    let wrapped = if cfg!(feature = "wrapped_serializable") {
-        wrapped_ident.map(|wrapped_ident| wrappable_enum(vis, ident, data, wrapped_ident))
-    } else {
-        None
-    };
+    let wrapped = wrapped_ident.map(|wrapped_ident| wrappable_enum(vis, ident, data, wrapped_ident));
 
     let serialized_length_match_arms = data.variants.iter().map(|variant| {
         let variant_ident = &variant.ident;
@@ -578,11 +574,7 @@ fn derive_struct(vis: &Visibility, ident: &Ident, data: &DataStruct, wrapped_ide
         }
     });
 
-    let wrapped = if cfg!(feature = "wrapped_serializable") {
-        wrapped_ident.map(|wrapped_ident| wrappable_struct(vis, ident, &fields, wrapped_ident))
-    } else {
-        None
-    };
+    let wrapped = wrapped_ident.map(|wrapped_ident| wrappable_struct(vis, ident, &fields, wrapped_ident));
 
 
 

--- a/macros/src/derive_serializable.rs
+++ b/macros/src/derive_serializable.rs
@@ -194,7 +194,7 @@ fn derive_enum(
                     let fields = fields_names.clone();
                     quote! {
                         Self::#variant_ident { #(#fields_names,)* } => {
-                            __buff[0] = #discriminant;
+                            __buff[*__pos] = #discriminant;
                             *__pos += 1;
                             #(
                                 MiniSerializable::serialize(#fields, __buff, __pos);
@@ -212,7 +212,7 @@ fn derive_enum(
 
                     quote! {
                         Self::#variant_ident(#(#field_names),*) => {
-                            __buff[0] = #discriminant;
+                            __buff[*__pos] = #discriminant;
                             *__pos += 1;
                             #(
                                 MiniSerializable::serialize(#field_names, __buff, __pos);
@@ -222,7 +222,7 @@ fn derive_enum(
                 }
                 Fields::Unit => quote! {
                     Self::#variant_ident => {
-                        __buff[0] = #discriminant;
+                        __buff[*__pos] = #discriminant;
                         *__pos += 1;
                     }
                 },
@@ -272,7 +272,7 @@ fn derive_enum(
                             1 #( + #get_fields_len)*
                         }),
                         quote!({
-                            __buff[0] = #discriminant;
+                            __buff[__pos] = #discriminant;
                             __pos += 1;
                             #(
                                 #serialize_field;
@@ -302,7 +302,7 @@ fn derive_enum(
                             1 #( + #get_fields_len)*
                         }),
                         quote!({
-                            __buff[0] = #discriminant;
+                            __buff[__pos] = #discriminant;
                             __pos += 1;
                             #(
                                 #serialize_field;
@@ -314,7 +314,8 @@ fn derive_enum(
                     quote!(),
                     quote!(1usize),
                     quote! {
-                        __buff[0] = #discriminant;
+                        __buff[__pos] = #discriminant;
+                        __pos += 1;
                     },
                 ),
             };

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,12 @@
+use proc_macro::TokenStream;
+use proc_macro_error2::proc_macro_error;
+use syn::{DeriveInput, parse_macro_input};
+
+mod derive_serializable;
+
+#[proc_macro_derive(Serializable, attributes(maker, wrapped))]
+#[proc_macro_error]
+pub fn serializable(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_serializable::derive_serializable(input).into()
+}

--- a/vm/.vscode/settings.json
+++ b/vm/.vscode/settings.json
@@ -4,7 +4,7 @@
             "selectedDevice": "Nano S Plus",
             "selectedUseCase": "release",
         },
-        "dockerRunArgs": "-v '${workspaceFolder}/../common:/common'"
+        "dockerRunArgs": "-v '${workspaceFolder}/../common:/common' -v '${workspaceFolder}/../macros:/macros'"
     },
     "ledgerDevTools.appSettings": {
         "selectedDevice": "Nano S Plus",

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -12,7 +12,7 @@ use common::{
     },
     ecall_constants::{self, *},
     manifest::Manifest,
-    ux::Serializable,
+    ux::Deserializable,
     vm::{Cpu, CpuError, EcallHandler, MemoryError},
 };
 use ledger_device_sdk::hash::HashInit;


### PR DESCRIPTION
- Added a derive macro for the `Serializable`  trait
- made `MiniSerializable` a super trait of `Serializable` (maybe rename ?)
- remove macros for struct and enums

turns this:
```rust
define_serializable_enum! {
    Page {
        // A page showing a spinner and some text.
        0x01u8 => Spinner {
            text: String,
        } as (make_spinner, make_spinner_wrapped),
        // A page showing an icon (either success or failure) and some text.
        0x02u8 => Info {
            icon: Icon,
            text: String,
        } as (make_info, make_info_wrapped),
        // A page with a title, text, a "confirm" button, and a "reject" button.
        0x03u8 => ConfirmReject {
            title: String,
            text: String,
            confirm: String,
            reject: String,
        } as (make_confirm_reject, make_confirm_reject_wrapped),
        // A generic page with navigation, implementing a subset of the pages supported by nbgl_pageDrawGenericContent
        0x04u8 => GenericPage {
            navigation_info: Option<NavigationInfo>,
            page_content_info: PageContentInfo }
            as (make_generic_page, make_generic_page_wrapped),
    },
    wrapped: WrappedPage
}
```
into this
``` rust
#[derive(Debug, PartialEq, Eq, Clone, Serializable)]
#[wrapped(name = WrappedPage)]
pub enum Page {
    #[maker(make_spinner)]
    Spinner { text: String },
    #[maker(make_info)]
    Info { icon: Icon, text: String },
    #[maker(make_confirm_reject)]
    ConfirmReject {
        title: String,
        text: String,
        confirm: String,
        reject: String,
    },
    #[maker(make_generic_page)]
    GenericPage {
        navigation_info: Option<NavigationInfo>,
        page_content_info: PageContentInfo,
    },
}
``` 

Note:

did not port 
```rust
let mut buff = Vec::with_capacity(len);
unsafe { buff.set_len(len) };
``` 
as it can trigger UB.
for now the usage was ok as it was only *wrote* too, but if a read was introduce it would be UB.
` serialize`  being a safe function to implement, this is'nt really great...
For now just using 
```rust
let mut buff = vec![0; len];
```
If the init need to be more performent, consider either passing the vec instead of a slice buffer to ` serialize`  (doing this could also eliminate some bounds checks) or passing `&mut [MaybeUninit<u8>]` .