### PR TITLE
Don't use embedded-alloc on the native target

### DIFF
--- a/app-sdk/Cargo.toml
+++ b/app-sdk/Cargo.toml
@@ -6,14 +6,15 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 critical-section = "1.1.2"
-ctor = "0.2.8"
-embedded-alloc = "0.5.1"
 subtle = { version="2.6.1", default-features = false }
 hex-literal = "0.4.1"
 zeroize = "1.8.1"
 
 [build-dependencies]
 common = { path = "../common", features = ["wrapped_serializable"] }
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+embedded-alloc = "0.5.1"
 
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]
 bip32 = "0.5.2"

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -24,33 +24,25 @@ mod ecalls_native;
 mod ux_generated;
 
 use ecalls::{Ecall, EcallsInterface};
-use embedded_alloc::Heap;
 
-#[cfg(not(target_arch = "riscv32"))]
-use ctor;
+#[cfg(target_arch = "riscv32")]
+use embedded_alloc::Heap;
 
 #[cfg(target_arch = "riscv32")]
 const HEAP_SIZE: usize = 65536;
-
-#[cfg(not(target_arch = "riscv32"))]
-const HEAP_SIZE: usize = 33554432;
-
+#[cfg(target_arch = "riscv32")]
 static mut HEAP_MEM: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 
+#[cfg(target_arch = "riscv32")]
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
+#[cfg(target_arch = "riscv32")]
 fn init_heap() {
     unsafe {
-        HEAP.init(&raw mut HEAP_MEM as usize, HEAP_SIZE);
+        #[allow(static_mut_refs)]
+        HEAP.init(HEAP_MEM.as_mut_ptr() as usize, HEAP_SIZE);
     }
-}
-
-// On native targets, we use the ctor crate to call the initializer automatically at startup
-#[cfg(not(target_arch = "riscv32"))]
-#[ctor::ctor]
-fn init_head_wrapper() {
-    init_heap();
 }
 
 // embedded-alloc requires an implementation of critical_section::Impl


### PR DESCRIPTION
It was causing some problems because the `vlib-bitcoin` library uses the `vanadium-app-sdk` crate, and the global allocator is not thread-safe.

As the native target is compiled with the std library, it's pointless anyway.