### PR TITLE
ecalls for memcpy and memset on riscv targets

### DIFF
--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -377,6 +377,8 @@ forward_to_ecall! {
     pub fn hash_init(hash_id: u32, ctx: *mut u8);
     pub fn hash_update(hash_id: u32, ctx: *mut u8, data: *const u8, len: usize) -> u32;
     pub fn hash_final(hash_id: u32, ctx: *mut u8, digest: *const u8) -> u32;
+    pub fn sys_memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
+    pub fn sys_memset(dest: *mut u8, ch: i32, n: usize) -> *mut u8;
 }
 
 #[cfg(test)]

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -46,6 +46,9 @@ delegate_ecall!(ecdsa_verify, u32, (curve: u32), (pubkey: *const u8), (msg_hash:
 delegate_ecall!(schnorr_sign, usize, (curve: u32), (mode: u32), (hash_id: u32), (privkey: *const u8), (msg: *const u8), (msg_len: usize), (signature: *mut u8), (entropy: *const [u8; 32]));
 delegate_ecall!(schnorr_verify, u32, (curve: u32), (mode: u32), (hash_id: u32), (pubkey: *const u8), (msg: *const u8), (msg_len: usize), (signature: *const u8), (signature_len: usize));
 
+delegate_ecall!(sys_memcpy, *mut u8, (dest: *mut u8), (src: *const u8), (n: usize));
+delegate_ecall!(sys_memset, *mut u8, (dest: *mut u8), (ch: i32), (n: usize));
+
 // The following ecalls are specific to this target
 delegate_ecall!(hash_init, (hash_id: u32), (ctx: *mut u8));
 delegate_ecall!(hash_update, u32, (hash_id: u32), (ctx: *mut u8), (data: *const u8), (len: usize));

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -159,3 +159,29 @@ macro_rules! bootstrap {
         use $crate::{print, println};
     };
 }
+
+#[no_mangle]
+#[inline(never)]
+#[cfg(target_arch = "riscv32")]
+pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    ecalls::sys_memcpy(dest, src, n)
+}
+
+#[no_mangle]
+#[inline(never)]
+#[cfg(target_arch = "riscv32")]
+pub unsafe extern "C" fn memset(dest: *mut u8, ch: i32, n: usize) -> *mut u8 {
+    ecalls::sys_memset(dest, ch, n)
+}
+
+// TODO: do we want to implement and replace memcpy/memset on native targets?
+//       It isn't really useful, but it could be worth reducing the difference
+//       between targets (or properly document the differences).
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_placeholder() {
+        assert_eq!(1 + 1, 2);
+    }
+}

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -4,6 +4,10 @@ pub const ECALL_XRECV: u32 = 3;
 pub const ECALL_EXIT: u32 = 4;
 pub const ECALL_PRINT: u32 = 5;
 
+// other system calls
+pub const ECALL_MEMCPY: u32 = 20;
+pub const ECALL_MEMSET: u32 = 21;
+
 // device handling, events, and UX
 
 pub const ECALL_GET_EVENT: u32 = 10;

--- a/ecalls/src/ecalls_impl.rs
+++ b/ecalls/src/ecalls_impl.rs
@@ -337,6 +337,9 @@ ecall2v!(xsend, ECALL_XSEND, (buffer: *const u8), (size: usize));
 ecall2!(xrecv, ECALL_XRECV, (buffer: *mut u8), (size: usize), usize);
 ecall2v!(print, ECALL_PRINT, (buffer: *const u8), (size: usize));
 
+ecall3!(sys_memset, ECALL_MEMSET, (dest: *mut u8), (ch: i32), (n: usize), *mut u8);
+ecall3!(sys_memcpy, ECALL_MEMCPY, (dest: *mut u8), (src: *const u8), (n: usize), *mut u8);
+
 ecall1!(get_event, ECALL_GET_EVENT, (data: *mut EventData), u32);
 ecall2!(show_page, ECALL_SHOW_PAGE, (page_desc: *const u8), (page_desc_len: usize), u32);
 ecall2!(show_step, ECALL_SHOW_STEP, (step_desc: *const u8), (step_desc_len: usize), u32);

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -2,6 +2,7 @@ use core::{
     cell::{RefCell, RefMut},
     cmp::min,
     fmt,
+    mem::MaybeUninit,
 };
 
 use alloc::{format, rc::Rc, string::String, vec, vec::Vec};
@@ -10,6 +11,7 @@ use common::{
         BufferType, Message, MessageDeserializationError, ReceiveBufferMessage,
         ReceiveBufferResponse, SendBufferContinuedMessage, SendBufferMessage,
     },
+    constants::PAGE_SIZE,
     ecall_constants::{self, *},
     ux::Deserializable,
     vm::{Cpu, CpuError, EcallHandler, MemoryError},
@@ -1377,6 +1379,58 @@ impl<'a, const N: usize> CommEcallHandler<'a, N> {
         Ok(res as u32)
     }
 
+    fn handle_memcpy<E: fmt::Debug>(
+        &self,
+        cpu: &mut Cpu<OutsourcedMemory<'_, N>>,
+        dest: GuestPointer,
+        src: GuestPointer,
+        len: usize,
+    ) -> Result<u32, CommEcallError> {
+        let mut buf: MaybeUninit<[u8; PAGE_SIZE]> = MaybeUninit::uninit();
+
+        // SAFETY: We will fully initialize any parts of the buffer we read.
+        let buf_slice: &mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, PAGE_SIZE) };
+
+        let mut offset = 0;
+        while offset < len {
+            let src_segment = cpu.get_segment::<E>(src.0)?;
+            let copy_size = min(PAGE_SIZE, len - offset);
+            src_segment.read_buffer(src.0 + offset as u32, &mut buf_slice[..copy_size])?;
+
+            let dest_segment = cpu.get_segment::<E>(dest.0)?;
+            dest_segment.write_buffer(dest.0 + offset as u32, &buf_slice[..copy_size])?;
+            offset += copy_size;
+        }
+        Ok(dest.0)
+    }
+
+    fn handle_memset<E: fmt::Debug>(
+        &self,
+        cpu: &mut Cpu<OutsourcedMemory<'_, N>>,
+        dest: GuestPointer,
+        ch: i32,
+        len: usize,
+    ) -> Result<u32, CommEcallError> {
+        let mut buf: MaybeUninit<[u8; PAGE_SIZE]> = MaybeUninit::uninit();
+
+        // SAFETY: We will fully initialize any parts of the buffer we write.
+        // TODO: maybe we should just use a static buffer for all the ecalls?
+        let buf_slice: &mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, PAGE_SIZE) };
+
+        let mut offset = 0;
+        while offset < len {
+            let copy_size = min(PAGE_SIZE, len - offset);
+            buf_slice[..copy_size].fill(ch as u8); // TODO: very redundant, optimize this
+
+            let dest_segment = cpu.get_segment::<E>(dest.0)?;
+            dest_segment.write_buffer(dest.0 + offset as u32, &buf_slice[..copy_size])?;
+            offset += copy_size;
+        }
+        Ok(dest.0)
+    }
+
     fn handle_get_event<E: fmt::Debug>(
         &self,
         cpu: &mut Cpu<OutsourcedMemory<'_, N>>,
@@ -1558,6 +1612,24 @@ impl<'a, const N: usize> EcallHandler for CommEcallHandler<'a, N> {
                 self.handle_print::<CommEcallError>(cpu, GPreg!(A0), reg!(A1) as usize)
                     .map_err(|_| CommEcallError::GenericError("print failed"))?;
                 reg!(A0) = 1;
+            }
+            ECALL_MEMCPY => {
+                crate::println!("@@@ memcpy, {} bytes", reg!(A2));
+                reg!(A0) = self.handle_memcpy::<CommEcallError>(
+                    cpu,
+                    GPreg!(A0),
+                    GPreg!(A1),
+                    reg!(A2) as usize,
+                )?;
+            }
+            ECALL_MEMSET => {
+                crate::println!("@@@ memset, {} bytes", reg!(A2));
+                reg!(A0) = self.handle_memset::<CommEcallError>(
+                    cpu,
+                    GPreg!(A0),
+                    reg!(A1) as i32,
+                    reg!(A2) as usize,
+                )?;
             }
             ECALL_GET_EVENT => {
                 reg!(A0) = self.handle_get_event::<CommEcallError>(cpu, GPreg!(A0))?;


### PR DESCRIPTION
So far it doesn't seem to improve by more than <10% on a complex flow like signing a transaction in the bitcoin app.

Keeping it open to profile it in the future, might not be worth doing at this time.

TODO:
- [ ] fix [UB](https://github.com/LedgerHQ/vanadium/pull/81#discussion_r2176756935)