### PR TITLE
BigNumMod optimizations

### DIFF
--- a/apps/sadik/client/src/client.rs
+++ b/apps/sadik/client/src/client.rs
@@ -70,13 +70,13 @@ impl SadikClient {
         operator: BigIntOperator,
         a: &[u8],
         b: &[u8],
-        modulus: &[u8],
+        modular: bool,
     ) -> Result<Vec<u8>, SadikClientError> {
         let cmd = Command::BigIntOperation {
             operator,
             a: a.to_vec(),
             b: b.to_vec(),
-            modulus: modulus.to_vec(),
+            modular,
         };
 
         let msg = postcard::to_allocvec(&cmd).expect("Serialization failed");

--- a/apps/sadik/client/tests/integration_test.rs
+++ b/apps/sadik/client/tests/integration_test.rs
@@ -21,39 +21,39 @@ async fn test_big_num() {
 
     // additions
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Add, &hex!("77989873"), &hex!("a4589234"), &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Add, &hex!("77989873"), &hex!("a4589234"), false).await.unwrap(),
         hex!("1bf12aa7")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Add, &hex!("47989873"), &hex!("a4589234"), &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Add, &hex!("47989873"), &hex!("a4589234"), false).await.unwrap(),
         hex!("ebf12aa7")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Add, &hex!("ffffffff"), &hex!("00000001"), &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Add, &hex!("ffffffff"), &hex!("00000001"), false).await.unwrap(),
         hex!("00000000")
     );
 
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Add, &minus_one_large, &one_large, &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Add, &minus_one_large, &one_large, false).await.unwrap(),
         zero_large
     );
 
     // subtractions
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("a4589234"), &hex!("77989873"), &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("a4589234"), &hex!("77989873"), false).await.unwrap(),
         hex!("2cbff9c1")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("77989873"), &hex!("a4589234"), &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("77989873"), &hex!("a4589234"), false).await.unwrap(),
         hex!("d340063f")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("00000000"), &hex!("00000001"), &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("00000000"), &hex!("00000001"), false).await.unwrap(),
         hex!("ffffffff")
     );
 
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Sub, &zero_large, &one_large, &[]).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Sub, &zero_large, &one_large, false).await.unwrap(),
         minus_one_large
     );
 }
@@ -63,6 +63,9 @@ async fn test_big_num() {
 async fn test_big_num_mod() {
     let mut setup = test_common::setup().await;
 
+    // all operations are modulo 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+    // (curve order of Secp256k1)
+
     let M: Vec<u8> = hex!("fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f").to_vec();
     let M2: Vec<u8> = hex!("3d4b0f9e4e4d5b6e5e5d6e7e8e8d9e9e8e8d9e9e8e8d9e9e8e8d9e9e8e8d9e9d").to_vec();
 
@@ -71,73 +74,73 @@ async fn test_big_num_mod() {
 
     // addition
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Add, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("7390984098209380980948098230840982340294098092384092834923840923"), &M).await.unwrap(),
-        hex!("15d7f1c4cab897b32c12c8a1b638879e023d5a9d8ca0da88d89bdb53a7b61679")
+        setup.client.bignum_operation(BigIntOperator::Add, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("7390984098209380980948098230840982340294098092384092834923840923"), true).await.unwrap(),
+        hex!("15d7f1c4cab897b32c12c8a1b638879f478e7db6dd583a4d18c97cc5d77fd167")
     );
 
     // subtraction
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("7390984098209380980948098230840982340294098092384092834923840923"), &M).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("7390984098209380980948098230840982340294098092384092834923840923"), true).await.unwrap(),
         hex!("2eb6c1439a7770b1fc00388eb1d77f8afdd55575799fb6185776d4c060ae0062")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("7390984098209380980948098230840982340294098092384092834923840923"), &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &M).await.unwrap(),
-        hex!("d1493ebc65888f4e03ffc7714e288075022aaa8a866049e7a8892b3e9f51fbcd")
+        setup.client.bignum_operation(BigIntOperator::Sub, &hex!("7390984098209380980948098230840982340294098092384092834923840923"), &hex!("a247598432980432940980983408039480095809832048509809580984320985"), true).await.unwrap(),
+        hex!("d1493ebc65888f4e03ffc7714e288073bcd9877135a8ea23685b89cc6f8840df")
     );
 
     // multiplication
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Mul, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &zero, &M).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Mul, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &zero, true).await.unwrap(),
         zero
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Mul, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &one, &M).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Mul, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &one, true).await.unwrap(),
         hex!("a247598432980432940980983408039480095809832048509809580984320985")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Mul, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("7390984098209380980948098230840982340294098092384092834923840923"), &M).await.unwrap(),
-        hex!("2d5daeb3ed823bef5a4480a2c5aa0708e8e37ed7302d2b21c9b442b244d48ce6")
+        setup.client.bignum_operation(BigIntOperator::Mul, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("7390984098209380980948098230840982340294098092384092834923840923"), true).await.unwrap(),
+        hex!("1657a819aad617cac89f35ff9d4890c66cc5675c70f2b66e974bc243b2e69116")
     );
 
-    // TODO: disabled until speculos is fixed as per https://github.com/LedgerHQ/speculos/pull/52
+    // TODO: disabled until speculos is fixed as per https://github.com/LedgerHQ/speculos/pull/529
     // powers: 0
     // assert_eq!(
-    //     setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("00"), &M2).await.unwrap(),
+    //     setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("00"), true).await.unwrap(),
     //     one
     // );
     // assert_eq!(
-    //     setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &zero, &M2).await.unwrap(),
+    //     setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &zero, true).await.unwrap(),
     //     one
     // );
 
     // powers: 1
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &one, &M).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &one, true).await.unwrap(),
         hex!("a247598432980432940980983408039480095809832048509809580984320985")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("01"), &M).await.unwrap(),
+        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("01"), true).await.unwrap(),
         hex!("a247598432980432940980983408039480095809832048509809580984320985")
     );
 
     // powers: 2
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("02"), &M2).await.unwrap(),
-        hex!("2378a937274b6304f12d26e7170d5d757087246a2db3d5c776faf10984d3331b")
+        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("02"), true).await.unwrap(),
+        hex!("4b3820d9706f0a26b136ea1c3df40a4836663a11be453dcbe1a7f8230e7dbe0e")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("00000002"), &M2).await.unwrap(),
-        hex!("2378a937274b6304f12d26e7170d5d757087246a2db3d5c776faf10984d3331b")
+        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("00000002"), true).await.unwrap(),
+        hex!("4b3820d9706f0a26b136ea1c3df40a4836663a11be453dcbe1a7f8230e7dbe0e")
     );
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("0000000000000000000000000000000000000000000000000000000000000002"), &M2).await.unwrap(),
-        hex!("2378a937274b6304f12d26e7170d5d757087246a2db3d5c776faf10984d3331b")
+        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("0000000000000000000000000000000000000000000000000000000000000002"), true).await.unwrap(),
+        hex!("4b3820d9706f0a26b136ea1c3df40a4836663a11be453dcbe1a7f8230e7dbe0e")
     );
 
     // powers: large
     assert_eq!(
-        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("22e0b80916f2f35efab04d6d61155f9d1aa9f8f0dff2a2b656cdee1bb7b6dcd722e0b80916f2f35efab04d6d61155f9d1aa9f8f0dff2a2b656cdee1bb7b6dcd7"), &M2).await.unwrap(),
-        hex!("3c0baee8c4e2f7220615013d7402fa5e69e43bc10e55500a5af4f8b966658846")
+        setup.client.bignum_operation(BigIntOperator::Pow, &hex!("a247598432980432940980983408039480095809832048509809580984320985"), &hex!("22e0b80916f2f35efab04d6d61155f9d1aa9f8f0dff2a2b656cdee1bb7b6dcd722e0b80916f2f35efab04d6d61155f9d1aa9f8f0dff2a2b656cdee1bb7b6dcd7"), true).await.unwrap(),
+        hex!("8d72fea89e5500398d2034bd3058cf82ebeec06c61a8ff83e7fbf2cbf5c9b647")
     );
 }
 

--- a/apps/sadik/common/src/lib.rs
+++ b/apps/sadik/common/src/lib.rs
@@ -31,7 +31,7 @@ pub enum Command {
         operator: BigIntOperator,
         a: Vec<u8>,
         b: Vec<u8>,
-        modulus: Vec<u8>, // if 0, not modular
+        modular: bool, // if false, not modular; otherwise, modulo the curve order of Secp256k1
     },
     Hash {
         hash_id: u32,

--- a/libs/secp256k1/src/constants.rs
+++ b/libs/secp256k1/src/constants.rs
@@ -83,11 +83,19 @@ pub const ONE: [u8; 32] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ];
 
-/// The curve Prime, represented as a Modulus from Vanadium's app-sdk
-pub const P: sdk::bignum::Modulus<32> = sdk::bignum::Modulus::<32>::from_be_bytes(FIELD_SIZE);
+/// The curve Prime, represented as a ModulusProvider from Vanadium's app-sdk
+#[derive(Debug, Clone, Copy)]
+pub struct P;
+impl sdk::bignum::ModulusProvider<32> for P {
+    const M: [u8; 32] = FIELD_SIZE;
+}
 
-/// The curve order, represented as a Modulus from Vanadium's app-sdk
-pub const N: sdk::bignum::Modulus<32> = sdk::bignum::Modulus::<32>::from_be_bytes(CURVE_ORDER);
+/// The curve order, represented as a ModulusProvider from Vanadium's app-sdk
+#[derive(Debug, Clone, Copy)]
+pub struct N;
+impl sdk::bignum::ModulusProvider<32> for N {
+    const M: [u8; 32] = CURVE_ORDER;
+}
 
 /// The curve generator, represented as a Secp256k1Point from Vanadium's app-sdk
 pub const G: sdk::curve::Secp256k1Point = sdk::curve::Secp256k1::get_generator();

--- a/libs/secp256k1/src/sdk_helpers.rs
+++ b/libs/secp256k1/src/sdk_helpers.rs
@@ -1,15 +1,24 @@
 use sdk::bignum::{BigNum, BigNumMod};
 
+use crate::constants::P;
 use crate::Error::{self, InvalidPublicKey};
+
+const ZERO: BigNumMod<32, P> = BigNumMod::<32, P>::from_be_bytes_noreduce([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+]);
+
+pub const SEVEN: BigNumMod<32, P> = BigNumMod::<32, P>::from_be_bytes_noreduce([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7,
+]);
 
 // helper function to compute the square root candidate
 // returns Some(y) if a square root (y) exists for x^3 + 7, otherwise None.
 #[inline(always)]
-fn secp256k1_compute_y_internal<'a>(x: &'a BigNumMod<'a, 32>) -> Option<BigNumMod<'a, 32>> {
-    let t = x * x * x + 7;
+fn secp256k1_compute_y_internal(x: &BigNumMod<32, P>) -> Option<BigNumMod<32, P>> {
+    let t = x * x * x + &SEVEN;
     let y = t.pow(&BigNum::from_be_bytes(crate::constants::SQR_EXPONENT));
 
-    if y * y == t {
+    if &y * &y == t {
         Some(y)
     } else {
         None
@@ -19,17 +28,17 @@ fn secp256k1_compute_y_internal<'a>(x: &'a BigNumMod<'a, 32>) -> Option<BigNumMo
 // Computes a y-coordinate using (x^3 + 7)^SQR_EXPONENT
 // It returns InvalidPublicKey if the x does not have a corresponding y on the curve
 #[inline]
-pub fn secp256k1_compute_y<'a>(x: &'a BigNumMod<'a, 32>) -> Result<BigNumMod<'a, 32>, Error> {
+pub fn secp256k1_compute_y(x: &BigNumMod<32, P>) -> Result<BigNumMod<32, P>, Error> {
     secp256k1_compute_y_internal(x).ok_or(InvalidPublicKey)
 }
 
 // Computes the y-coordinate using (x^3 + 7)^SQR_EXPONENT with the given parity
 // It returns InvalidPublicKey if the x does not have a corresponding y on the curve
 #[inline]
-pub fn secp256k1_compute_y_with_parity<'a>(
-    x: &'a BigNumMod<'a, 32>,
+pub fn secp256k1_compute_y_with_parity(
+    x: &BigNumMod<32, P>,
     parity: u8,
-) -> Result<BigNumMod<'a, 32>, Error> {
+) -> Result<BigNumMod<32, P>, Error> {
     if parity > 1 {
         panic!("This function must be called with parity equal to exactly 0 or 1");
     }
@@ -38,7 +47,7 @@ pub fn secp256k1_compute_y_with_parity<'a>(
 
     // if the last byte of y doesn't have the correct parity, negate it
     if y.as_be_bytes()[31] & 1 != parity {
-        y = -y;
+        y = ZERO - y;
     }
 
     Ok(y)


### PR DESCRIPTION
Modifies the BigNumMod interface to make it a zero-cost abstraction when possible, and be strongly typed against the modulus (so BigNumMod with with different modulus are actually incompatible types, avoiding runtime checks).