### PR TITLE
Boilerplate improvements

### DIFF
--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -1,17 +1,24 @@
 use alloc::vec::Vec;
 
+/// A Handler is a function that is called when a message is received from the host, and
+/// returns the app's response.
 pub type Handler = fn(&mut App, &[u8]) -> Vec<u8>;
 
+/// The App struct represents the context of the application.
 pub struct App {
     handler: Handler,
 }
 
 impl App {
+    /// Creates a new App instance with the given handler.
     pub fn new(handler: Handler) -> Self {
         App { handler }
     }
 
-    pub fn run(&mut self) {
+    /// This function shows the dashboard, then enters the core loop of the app.
+    /// It never returns, as it keeps the app running until sdk::exit() is called,
+    /// or a fatal error occurs.
+    pub fn run(&mut self) -> ! {
         crate::ux::ux_idle();
         loop {
             // TODO: can we handle the error any better?
@@ -22,6 +29,7 @@ impl App {
         }
     }
 
+    /// This is only useful to produce a valid app instance in tests.
     pub fn singleton() -> Self {
         App::new(|_app, _msg| Vec::new())
     }

--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -1,0 +1,28 @@
+use alloc::vec::Vec;
+
+pub type Handler = fn(&mut App, &[u8]) -> Vec<u8>;
+
+pub struct App {
+    handler: Handler,
+}
+
+impl App {
+    pub fn new(handler: Handler) -> Self {
+        App { handler }
+    }
+
+    pub fn run(&mut self) {
+        crate::ux::ux_idle();
+        loop {
+            // TODO: can we handle the error any better?
+            //       Aborting in Vanadium might be necessary anyway, if communication breaks.
+            let req_msg = crate::comm::receive_message().expect("Communication error");
+            let resp_msg = (self.handler)(self, &req_msg);
+            crate::comm::send_message(&resp_msg);
+        }
+    }
+
+    pub fn singleton() -> Self {
+        App::new(|_app, _msg| Vec::new())
+    }
+}

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -7,11 +7,14 @@ extern crate lazy_static;
 
 use alloc::vec::Vec;
 
+pub mod app;
 pub mod bignum;
 pub mod comm;
 pub mod curve;
 pub mod hash;
 pub mod ux;
+
+pub use app::App;
 
 mod ecalls;
 

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -82,6 +82,22 @@ pub fn exit(status: i32) -> ! {
     Ecall::exit(status);
 }
 
+#[cfg(target_arch = "riscv32")]
+#[panic_handler]
+fn my_panic(info: &core::panic::PanicInfo) -> ! {
+    let message = if let Some(location) = info.location() {
+        alloc::format!(
+            "Panic occurred in file '{}' at line {}: {}",
+            location.file(),
+            location.line(),
+            info.message()
+        )
+    } else {
+        alloc::format!("Panic occurred: {}", info.message())
+    };
+    fatal(&message); // does not return
+}
+
 pub fn xrecv(size: usize) -> Vec<u8> {
     // We allocate a buffer with the requested size, but we don't initialize its content.
     // xrecv guarantees that recv_size have been overwritten with the received data, and we

--- a/apps/bitcoin/app/src/handlers/get_address.rs
+++ b/apps/bitcoin/app/src/handlers/get_address.rs
@@ -32,6 +32,7 @@ fn display_address(_account_name: Option<&str>, _addr: &str) -> bool {
 }
 
 pub fn handle_get_address(
+    _app: &mut sdk::App,
     name: Option<&str>,
     account: &common::message::Account,
     _hmac: Option<&[u8; 32]>,
@@ -91,6 +92,7 @@ mod tests {
         });
 
         let resp = handle_get_address(
+            &mut sdk::App::singleton(),
             None,
             &account,
             None,

--- a/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
+++ b/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
@@ -50,6 +50,7 @@ fn display_xpub(_xpub: &str, _path: &[u32]) -> bool {
 }
 
 pub fn handle_get_extended_pubkey(
+    _app: &mut sdk::App,
     bip32_path: &common::message::Bip32Path,
     display: bool,
 ) -> Result<Response, &'static str> {
@@ -167,6 +168,7 @@ mod tests {
             // decode the derivation path into a Vec<u32>
 
             let response = handle_get_extended_pubkey(
+                &mut sdk::App::singleton(),
                 &common::message::Bip32Path(parse_derivation_path(path).unwrap()),
                 false,
             )

--- a/apps/bitcoin/app/src/handlers/get_master_fingerprint.rs
+++ b/apps/bitcoin/app/src/handlers/get_master_fingerprint.rs
@@ -1,7 +1,7 @@
 use common::message::Response;
 use sdk::curve::Curve;
 
-pub fn handle_get_master_fingerprint() -> Result<Response, &'static str> {
+pub fn handle_get_master_fingerprint(_app: &mut sdk::App) -> Result<Response, &'static str> {
     Ok(Response::MasterFingerprint(
         sdk::curve::Secp256k1::get_master_fingerprint(),
     ))
@@ -13,7 +13,7 @@ mod tests {
 
     #[test]
     fn test_handle_get_master_fingerprint() {
-        let response = handle_get_master_fingerprint().unwrap();
+        let response = handle_get_master_fingerprint(&mut sdk::App::singleton()).unwrap();
         assert_eq!(response, Response::MasterFingerprint(0xf5acc2fdu32));
     }
 }

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -39,6 +39,7 @@ fn my_panic(info: &core::panic::PanicInfo) -> ! {
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {
+    sdk::rust_init_heap();
     main()
 }
 
@@ -77,8 +78,6 @@ fn process_message() -> Result<Response, Box<dyn core::error::Error>> {
 }
 
 pub fn main() {
-    sdk::rust_init_heap();
-
     sdk::ux::ux_idle();
     loop {
         let response = match process_message() {

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -13,11 +13,6 @@ use alloc::{string::ToString, vec::Vec};
 use common::message::{Request, Response};
 use sdk::App;
 
-// Temporary to force the creation of a data section
-#[used]
-#[no_mangle]
-pub static mut APP_NAME: [u8; 32] = *b"Bitcoin\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -13,12 +13,7 @@ use alloc::{string::ToString, vec::Vec};
 use common::message::{Request, Response};
 use sdk::App;
 
-#[cfg(target_arch = "riscv32")]
-#[no_mangle]
-pub fn _start() {
-    sdk::rust_init_heap();
-    main()
-}
+sdk::bootstrap!();
 
 fn handle_request(app: &mut App, request: &Request) -> Result<Response, &'static str> {
     match request {

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(target_arch = "riscv32", no_std, no_main)]
 
-#[cfg(target_arch = "riscv32")]
-use sdk::fatal;
-
 extern crate alloc;
 
 mod constants;
@@ -11,9 +8,10 @@ mod merkle;
 
 use handlers::*;
 
-use alloc::{boxed::Box, string::ToString};
+use alloc::{string::ToString, vec::Vec};
 
 use common::message::{Request, Response};
+use sdk::App;
 
 // Temporary to force the creation of a data section
 #[used]
@@ -33,7 +31,7 @@ fn my_panic(info: &core::panic::PanicInfo) -> ! {
     } else {
         alloc::format!("Panic occurred: {}", info.message())
     };
-    fatal(&message); // does not return
+    sdk::fatal(&message); // does not return
 }
 
 #[cfg(target_arch = "riscv32")]
@@ -43,12 +41,14 @@ pub fn _start() {
     main()
 }
 
-fn handle_request(request: &Request) -> Result<Response, &'static str> {
+fn handle_request(app: &mut App, request: &Request) -> Result<Response, &'static str> {
     match request {
         Request::GetVersion => todo!(),
         Request::Exit => sdk::exit(0),
-        Request::GetMasterFingerprint => handle_get_master_fingerprint(),
-        Request::GetExtendedPubkey { path, display } => handle_get_extended_pubkey(path, *display),
+        Request::GetMasterFingerprint => handle_get_master_fingerprint(app),
+        Request::GetExtendedPubkey { path, display } => {
+            handle_get_extended_pubkey(app, path, *display)
+        }
         Request::RegisterAccount(_account) => todo!(),
         Request::GetAddress {
             name,
@@ -64,27 +64,20 @@ fn handle_request(request: &Request) -> Result<Response, &'static str> {
                 _ => return Err("Invalid HMAC length"),
             };
 
-            handle_get_address(name.as_deref(), account, hmac, coordinates, *display)
+            handle_get_address(app, name.as_deref(), account, hmac, coordinates, *display)
         }
         Request::SignPsbt { psbt: _ } => todo!(),
     }
 }
 
-fn process_message() -> Result<Response, Box<dyn core::error::Error>> {
-    let req_msg = sdk::comm::receive_message()?;
-    let request: Request = postcard::from_bytes(&req_msg)?;
-    let response = handle_request(&request)?;
-    Ok(response)
+fn process_message(app: &mut App, request: &[u8]) -> Vec<u8> {
+    let Ok(request) = postcard::from_bytes(request) else {
+        return postcard::to_allocvec(&Response::Error("Invalid request".to_string())).unwrap();
+    };
+    let response = handle_request(app, &request).unwrap_or_else(|e| Response::Error(e.to_string()));
+    postcard::to_allocvec(&response).unwrap()
 }
 
 pub fn main() {
-    sdk::ux::ux_idle();
-    loop {
-        let response = match process_message() {
-            Ok(response) => response,
-            Err(e) => Response::Error(e.to_string()),
-        };
-        let resp_msg = postcard::to_allocvec(&response).unwrap();
-        sdk::comm::send_message(&resp_msg);
-    }
+    App::new(process_message).run();
 }

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -19,22 +19,6 @@ use sdk::App;
 pub static mut APP_NAME: [u8; 32] = *b"Bitcoin\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
 #[cfg(target_arch = "riscv32")]
-#[panic_handler]
-fn my_panic(info: &core::panic::PanicInfo) -> ! {
-    let message = if let Some(location) = info.location() {
-        alloc::format!(
-            "Panic occurred in file '{}' at line {}: {}",
-            location.file(),
-            location.line(),
-            info.message()
-        )
-    } else {
-        alloc::format!("Panic occurred: {}", info.message())
-    };
-    sdk::fatal(&message); // does not return
-}
-
-#[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {
     sdk::rust_init_heap();

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -11,12 +11,7 @@ extern crate alloc;
 use alloc::{string::ToString, vec, vec::Vec};
 use common::{Command, Curve, ECPointOperation, HashId};
 
-#[cfg(target_arch = "riscv32")]
-#[no_mangle]
-pub fn _start() {
-    sdk::rust_init_heap();
-    main()
-}
+sdk::bootstrap!();
 
 /// The curve order of the Secp256k1 curve, represented as a ModulusProvider from Vanadium's app-sdk
 #[derive(Debug, Clone, Copy)]

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -4,11 +4,12 @@ use sdk::{
     bignum::{BigNum, BigNumMod, ModulusProvider},
     curve::{Curve as _, EcfpPrivateKey, EcfpPublicKey, Secp256k1Point},
     hash::Hasher,
+    App,
 };
 
 extern crate alloc;
 
-use alloc::{string::ToString, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 use common::{Command, Curve, ECPointOperation, HashId};
 
 sdk::bootstrap!();
@@ -38,244 +39,230 @@ fn parse_pubkey(pubkey: &[u8]) -> EcfpPublicKey<sdk::curve::Secp256k1, 32> {
     )
 }
 
-pub fn main() {
-    sdk::ux::ux_idle();
-    loop {
-        let msg = match sdk::comm::receive_message() {
-            Ok(msg) => msg,
-            Err(e) => {
-                let error_string = e.to_string();
-                panic!("Error receiving message: {}", error_string);
-            }
-        };
+fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
+    let command: Command = postcard::from_bytes(&msg).expect("Deserialization failed");
 
-        let command: Command = postcard::from_bytes(&msg).expect("Deserialization failed");
-
-        let response: Vec<u8> = match command {
-            Command::Hash { hash_id, msg } => {
-                let hash_id = HashId::try_from(hash_id).expect("Invalid hash ID");
-                match hash_id {
-                    HashId::Ripemd160 => {
-                        let mut digest: [u8; 20] = [0u8; 20];
-                        let mut hasher = sdk::hash::Ripemd160::new();
-                        hasher.update(&msg);
-                        hasher.digest(&mut digest);
-                        digest.to_vec()
-                    }
-                    HashId::Sha256 => {
-                        let mut hasher = sdk::hash::Sha256::new();
-                        hasher.update(&msg);
-                        let mut digest = [0u8; 32];
-                        hasher.digest(&mut digest);
-                        digest.to_vec()
-                    }
-                    HashId::Sha512 => {
-                        let mut hasher = sdk::hash::Sha512::new();
-                        hasher.update(&msg);
-                        let mut digest = [0u8; 64];
-                        hasher.digest(&mut digest);
-                        digest.to_vec()
-                    }
+    let response: Vec<u8> = match command {
+        Command::Hash { hash_id, msg } => {
+            let hash_id = HashId::try_from(hash_id).expect("Invalid hash ID");
+            match hash_id {
+                HashId::Ripemd160 => {
+                    let mut digest: [u8; 20] = [0u8; 20];
+                    let mut hasher = sdk::hash::Ripemd160::new();
+                    hasher.update(&msg);
+                    hasher.digest(&mut digest);
+                    digest.to_vec()
+                }
+                HashId::Sha256 => {
+                    let mut hasher = sdk::hash::Sha256::new();
+                    hasher.update(&msg);
+                    let mut digest = [0u8; 32];
+                    hasher.digest(&mut digest);
+                    digest.to_vec()
+                }
+                HashId::Sha512 => {
+                    let mut hasher = sdk::hash::Sha512::new();
+                    hasher.update(&msg);
+                    let mut digest = [0u8; 64];
+                    hasher.digest(&mut digest);
+                    digest.to_vec()
                 }
             }
-            Command::BigIntOperation {
-                operator,
-                a,
-                b,
-                modular,
-            } => {
-                if !modular {
-                    macro_rules! impl_bignum_processing {
-                        ($len:expr, $a:expr, $b:expr, $operator:expr) => {{
-                            let a: BigNum<$len> =
-                                BigNum::from_be_bytes($a.as_slice().try_into().unwrap());
-                            let b: BigNum<$len> =
-                                BigNum::from_be_bytes($b.as_slice().try_into().unwrap());
+        }
+        Command::BigIntOperation {
+            operator,
+            a,
+            b,
+            modular,
+        } => {
+            if !modular {
+                macro_rules! impl_bignum_processing {
+                    ($len:expr, $a:expr, $b:expr, $operator:expr) => {{
+                        let a: BigNum<$len> =
+                            BigNum::from_be_bytes($a.as_slice().try_into().unwrap());
+                        let b: BigNum<$len> =
+                            BigNum::from_be_bytes($b.as_slice().try_into().unwrap());
 
-                            match $operator {
-                                common::BigIntOperator::Add => (&a + &b).to_be_bytes().to_vec(),
-                                common::BigIntOperator::Sub => (&a - &b).to_be_bytes().to_vec(),
-                                common::BigIntOperator::Mul => {
-                                    panic!(
-                                        "Multiplication is only supported for modular big numbers"
-                                    )
-                                }
-                                common::BigIntOperator::Pow => {
-                                    panic!(
-                                        "Exponentiation is only supported for modular big numbers"
-                                    )
-                                }
+                        match $operator {
+                            common::BigIntOperator::Add => (&a + &b).to_be_bytes().to_vec(),
+                            common::BigIntOperator::Sub => (&a - &b).to_be_bytes().to_vec(),
+                            common::BigIntOperator::Mul => {
+                                panic!("Multiplication is only supported for modular big numbers")
                             }
+                            common::BigIntOperator::Pow => {
+                                panic!("Exponentiation is only supported for modular big numbers")
+                            }
+                        }
+                    }};
+                }
+
+                if a.len() != b.len() {
+                    panic!("Big numbers must have the same length");
+                }
+
+                match a.len() {
+                    4 => impl_bignum_processing!(4, a, b, operator),
+                    32 => impl_bignum_processing!(32, a, b, operator),
+                    64 => impl_bignum_processing!(64, a, b, operator),
+                    _ => panic!("Unsupported big number length in sadik"),
+                }
+            } else {
+                // modular
+
+                if let common::BigIntOperator::Pow = operator {
+                    if a.len() != 32 {
+                        panic!("Only modular big numbers of length 32 are supported in sadik");
+                    }
+                    let a: BigNumMod<32, N> =
+                        BigNumMod::from_be_bytes(a.as_slice().try_into().unwrap());
+
+                    macro_rules! impl_modular_pow {
+                        ($len:expr, $b:expr, $a:expr) => {{
+                            let b =
+                                BigNum::<$len>::from_be_bytes($b.as_slice().try_into().unwrap());
+                            $a.pow(&b).to_be_bytes().to_vec()
                         }};
                     }
 
-                    if a.len() != b.len() {
-                        panic!("Big numbers must have the same length");
-                    }
-
-                    match a.len() {
-                        4 => impl_bignum_processing!(4, a, b, operator),
-                        32 => impl_bignum_processing!(32, a, b, operator),
-                        64 => impl_bignum_processing!(64, a, b, operator),
-                        _ => panic!("Unsupported big number length in sadik"),
+                    match b.len() {
+                        1 => impl_modular_pow!(1, b, a),
+                        4 => impl_modular_pow!(4, b, a),
+                        32 => impl_modular_pow!(32, b, a),
+                        64 => impl_modular_pow!(64, b, a),
+                        _ => {
+                            panic!("Unsupported length for the exponent in sadik");
+                        }
                     }
                 } else {
-                    // modular
+                    if a.len() != 32 || b.len() != 32 {
+                        panic!("Only modular big numbers of length 32 are supported in sadik");
+                    }
 
-                    if let common::BigIntOperator::Pow = operator {
-                        if a.len() != 32 {
-                            panic!("Only modular big numbers of length 32 are supported in sadik");
-                        }
-                        let a: BigNumMod<32, N> =
-                            BigNumMod::from_be_bytes(a.as_slice().try_into().unwrap());
+                    let a: BigNumMod<32, N> =
+                        BigNumMod::from_be_bytes(a.as_slice().try_into().unwrap());
+                    let b: BigNumMod<32, N> =
+                        BigNumMod::from_be_bytes(b.as_slice().try_into().unwrap());
 
-                        macro_rules! impl_modular_pow {
-                            ($len:expr, $b:expr, $a:expr) => {{
-                                let b = BigNum::<$len>::from_be_bytes(
-                                    $b.as_slice().try_into().unwrap(),
-                                );
-                                $a.pow(&b).to_be_bytes().to_vec()
-                            }};
-                        }
-
-                        match b.len() {
-                            1 => impl_modular_pow!(1, b, a),
-                            4 => impl_modular_pow!(4, b, a),
-                            32 => impl_modular_pow!(32, b, a),
-                            64 => impl_modular_pow!(64, b, a),
-                            _ => {
-                                panic!("Unsupported length for the exponent in sadik");
-                            }
-                        }
-                    } else {
-                        if a.len() != 32 || b.len() != 32 {
-                            panic!("Only modular big numbers of length 32 are supported in sadik");
-                        }
-
-                        let a: BigNumMod<32, N> =
-                            BigNumMod::from_be_bytes(a.as_slice().try_into().unwrap());
-                        let b: BigNumMod<32, N> =
-                            BigNumMod::from_be_bytes(b.as_slice().try_into().unwrap());
-
-                        match operator {
-                            common::BigIntOperator::Add => (&a + &b).to_be_bytes().to_vec(),
-                            common::BigIntOperator::Sub => (&a - &b).to_be_bytes().to_vec(),
-                            common::BigIntOperator::Mul => (&a * &b).to_be_bytes().to_vec(),
-                            common::BigIntOperator::Pow => panic!("Unreachable code"),
-                        }
+                    match operator {
+                        common::BigIntOperator::Add => (&a + &b).to_be_bytes().to_vec(),
+                        common::BigIntOperator::Sub => (&a - &b).to_be_bytes().to_vec(),
+                        common::BigIntOperator::Mul => (&a * &b).to_be_bytes().to_vec(),
+                        common::BigIntOperator::Pow => panic!("Unreachable code"),
                     }
                 }
             }
-            Command::GetMasterFingerprint { curve } => match curve {
-                Curve::Secp256k1 => sdk::curve::Secp256k1::get_master_fingerprint()
-                    .to_be_bytes()
-                    .to_vec(),
-            },
-            Command::DeriveHdNode { curve, path } => match curve {
-                // returns the concatenation of the chaincode and private key
-                Curve::Secp256k1 => {
-                    let node = sdk::curve::Secp256k1::derive_hd_node(&path).unwrap();
-                    let mut result = node.chaincode.to_vec();
-                    result.extend_from_slice(&node.privkey[..]);
-                    result
-                }
-            },
-            Command::ECPointOperation { curve, operation } => match curve {
-                Curve::Secp256k1 => match operation {
-                    ECPointOperation::Add(p, q) => {
-                        let p = Secp256k1Point::from_bytes(p.as_slice().try_into().unwrap());
-                        let q = Secp256k1Point::from_bytes(q.as_slice().try_into().unwrap());
-                        (p + q).to_bytes().to_vec()
-                    }
-                    ECPointOperation::ScalarMult(p, k) => {
-                        let p = Secp256k1Point::from_bytes(p.as_slice().try_into().unwrap());
-                        let k: [u8; 32] = k.as_slice().try_into().unwrap();
-                        (p * &k).to_bytes().to_vec()
-                    }
-                },
-            },
-            Command::EcdsaSign {
-                curve,
-                privkey,
-                msg_hash,
-            } => match curve {
-                Curve::Secp256k1 => {
-                    let msg_hash: [u8; 32] = msg_hash
-                        .as_slice()
-                        .try_into()
-                        .expect("hash must be 32 bytes");
-                    let privkey: EcfpPrivateKey<sdk::curve::Secp256k1, 32> = EcfpPrivateKey::new(
-                        privkey.as_slice().try_into().expect("invalid privkey"),
-                    );
-
-                    privkey.ecdsa_sign_hash(&msg_hash).unwrap()
-                }
-            },
-            Command::EcdsaVerify {
-                curve,
-                msg_hash,
-                pubkey,
-                signature,
-            } => match curve {
-                Curve::Secp256k1 => {
-                    let pubkey = parse_pubkey(&pubkey);
-                    let msg_hash: [u8; 32] = msg_hash
-                        .as_slice()
-                        .try_into()
-                        .expect("hash must be 32 bytes");
-
-                    if pubkey.ecdsa_verify_hash(&msg_hash, &signature).is_ok() {
-                        vec![1]
-                    } else {
-                        vec![0]
-                    }
-                }
-            },
-            Command::SchnorrSign {
-                curve,
-                privkey,
-                msg,
-            } => match curve {
-                Curve::Secp256k1 => {
-                    let privkey: EcfpPrivateKey<sdk::curve::Secp256k1, 32> = EcfpPrivateKey::new(
-                        privkey.as_slice().try_into().expect("invalid privkey"),
-                    );
-                    privkey.schnorr_sign(&msg).unwrap()
-                }
-            },
-            Command::SchnorrVerify {
-                curve,
-                pubkey,
-                msg,
-                signature,
-            } => match curve {
-                Curve::Secp256k1 => {
-                    let pubkey: EcfpPublicKey<sdk::curve::Secp256k1, 32> = parse_pubkey(&pubkey);
-                    if pubkey.schnorr_verify(&msg, &signature).is_ok() {
-                        vec![1]
-                    } else {
-                        vec![0]
-                    }
-                }
-            },
-            Command::Sleep { n_ticks } => {
-                let mut count = 0;
-                loop {
-                    match sdk::ux::get_event() {
-                        sdk::ux::Event::Ticker => {
-                            count += 1;
-                            if count == n_ticks {
-                                break;
-                            }
-                        }
-                        _ => (), // ignore any other type of event
-                    }
-                }
-
-                vec![]
+        }
+        Command::GetMasterFingerprint { curve } => match curve {
+            Curve::Secp256k1 => sdk::curve::Secp256k1::get_master_fingerprint()
+                .to_be_bytes()
+                .to_vec(),
+        },
+        Command::DeriveHdNode { curve, path } => match curve {
+            // returns the concatenation of the chaincode and private key
+            Curve::Secp256k1 => {
+                let node = sdk::curve::Secp256k1::derive_hd_node(&path).unwrap();
+                let mut result = node.chaincode.to_vec();
+                result.extend_from_slice(&node.privkey[..]);
+                result
             }
-        };
+        },
+        Command::ECPointOperation { curve, operation } => match curve {
+            Curve::Secp256k1 => match operation {
+                ECPointOperation::Add(p, q) => {
+                    let p = Secp256k1Point::from_bytes(p.as_slice().try_into().unwrap());
+                    let q = Secp256k1Point::from_bytes(q.as_slice().try_into().unwrap());
+                    (p + q).to_bytes().to_vec()
+                }
+                ECPointOperation::ScalarMult(p, k) => {
+                    let p = Secp256k1Point::from_bytes(p.as_slice().try_into().unwrap());
+                    let k: [u8; 32] = k.as_slice().try_into().unwrap();
+                    (p * &k).to_bytes().to_vec()
+                }
+            },
+        },
+        Command::EcdsaSign {
+            curve,
+            privkey,
+            msg_hash,
+        } => match curve {
+            Curve::Secp256k1 => {
+                let msg_hash: [u8; 32] = msg_hash
+                    .as_slice()
+                    .try_into()
+                    .expect("hash must be 32 bytes");
+                let privkey: EcfpPrivateKey<sdk::curve::Secp256k1, 32> =
+                    EcfpPrivateKey::new(privkey.as_slice().try_into().expect("invalid privkey"));
 
-        sdk::comm::send_message(&response);
-    }
+                privkey.ecdsa_sign_hash(&msg_hash).unwrap()
+            }
+        },
+        Command::EcdsaVerify {
+            curve,
+            msg_hash,
+            pubkey,
+            signature,
+        } => match curve {
+            Curve::Secp256k1 => {
+                let pubkey = parse_pubkey(&pubkey);
+                let msg_hash: [u8; 32] = msg_hash
+                    .as_slice()
+                    .try_into()
+                    .expect("hash must be 32 bytes");
+
+                if pubkey.ecdsa_verify_hash(&msg_hash, &signature).is_ok() {
+                    vec![1]
+                } else {
+                    vec![0]
+                }
+            }
+        },
+        Command::SchnorrSign {
+            curve,
+            privkey,
+            msg,
+        } => match curve {
+            Curve::Secp256k1 => {
+                let privkey: EcfpPrivateKey<sdk::curve::Secp256k1, 32> =
+                    EcfpPrivateKey::new(privkey.as_slice().try_into().expect("invalid privkey"));
+                privkey.schnorr_sign(&msg).unwrap()
+            }
+        },
+        Command::SchnorrVerify {
+            curve,
+            pubkey,
+            msg,
+            signature,
+        } => match curve {
+            Curve::Secp256k1 => {
+                let pubkey: EcfpPublicKey<sdk::curve::Secp256k1, 32> = parse_pubkey(&pubkey);
+                if pubkey.schnorr_verify(&msg, &signature).is_ok() {
+                    vec![1]
+                } else {
+                    vec![0]
+                }
+            }
+        },
+        Command::Sleep { n_ticks } => {
+            let mut count = 0;
+            loop {
+                match sdk::ux::get_event() {
+                    sdk::ux::Event::Ticker => {
+                        count += 1;
+                        if count == n_ticks {
+                            break;
+                        }
+                    }
+                    _ => (), // ignore any other type of event
+                }
+            }
+
+            vec![]
+        }
+    };
+
+    response
+}
+
+pub fn main() {
+    App::new(process_message).run();
 }

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -38,6 +38,7 @@ fn my_panic(info: &core::panic::PanicInfo) -> ! {
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {
+    sdk::rust_init_heap();
     main()
 }
 
@@ -67,8 +68,6 @@ fn parse_pubkey(pubkey: &[u8]) -> EcfpPublicKey<sdk::curve::Secp256k1, 32> {
 }
 
 pub fn main() {
-    sdk::rust_init_heap();
-
     sdk::ux::ux_idle();
     loop {
         let msg = match sdk::comm::receive_message() {

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -11,11 +11,6 @@ extern crate alloc;
 use alloc::{string::ToString, vec, vec::Vec};
 use common::{Command, Curve, ECPointOperation, HashId};
 
-// Temporary to force the creation of a data section
-#[used]
-#[no_mangle]
-pub static mut APP_NAME: [u8; 32] = *b"Sadik\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(target_arch = "riscv32", no_std, no_main)]
 
-#[cfg(target_arch = "riscv32")]
-use sdk::fatal;
-
 use sdk::{
     bignum::{BigNum, BigNumMod, ModulusProvider},
     curve::{Curve as _, EcfpPrivateKey, EcfpPublicKey, Secp256k1Point},
@@ -18,22 +15,6 @@ use common::{Command, Curve, ECPointOperation, HashId};
 #[used]
 #[no_mangle]
 pub static mut APP_NAME: [u8; 32] = *b"Sadik\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-
-#[cfg(target_arch = "riscv32")]
-#[panic_handler]
-fn my_panic(info: &core::panic::PanicInfo) -> ! {
-    let message = if let Some(location) = info.location() {
-        alloc::format!(
-            "Panic occurred in file '{}' at line {}: {}",
-            location.file(),
-            location.line(),
-            info.message()
-        )
-    } else {
-        alloc::format!("Panic occurred: {}", info.message())
-    };
-    fatal(&message); // does not return
-}
 
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -8,12 +8,7 @@ mod handlers;
 use commands::Command;
 use handlers::*;
 
-#[cfg(target_arch = "riscv32")]
-#[no_mangle]
-pub fn _start() {
-    sdk::rust_init_heap();
-    main()
-}
+sdk::bootstrap!();
 
 pub fn main() {
     sdk::ux::ux_idle();

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(target_arch = "riscv32", no_std, no_main)]
 
-#[cfg(target_arch = "riscv32")]
-use sdk::fatal;
-
 extern crate alloc;
 
 mod commands;
@@ -15,22 +12,6 @@ use handlers::*;
 #[used]
 #[no_mangle]
 pub static mut APP_NAME: [u8; 32] = *b"Test\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-
-#[cfg(target_arch = "riscv32")]
-#[panic_handler]
-fn my_panic(info: &core::panic::PanicInfo) -> ! {
-    let message = if let Some(location) = info.location() {
-        alloc::format!(
-            "Panic occurred in file '{}' at line {}: {}",
-            location.file(),
-            location.line(),
-            info.message()
-        )
-    } else {
-        alloc::format!("Panic occurred: {}", info.message())
-    };
-    fatal(&message); // does not return
-}
 
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -35,17 +35,11 @@ fn my_panic(info: &core::panic::PanicInfo) -> ! {
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {
-    app_main()
-}
-
-#[cfg(not(target_arch = "riscv32"))]
-fn main() {
-    app_main();
-}
-
-pub fn app_main() {
     sdk::rust_init_heap();
+    main()
+}
 
+pub fn main() {
     sdk::ux::ux_idle();
 
     loop {

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -8,11 +8,6 @@ mod handlers;
 use commands::Command;
 use handlers::*;
 
-// Temporary to force the creation of a data section
-#[used]
-#[no_mangle]
-pub static mut APP_NAME: [u8; 32] = *b"Test\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub fn _start() {

--- a/vm/src/app_ui/menu.rs
+++ b/vm/src/app_ui/menu.rs
@@ -76,13 +76,14 @@ pub fn ui_menu_main(comm: &mut Comm) -> Event<Instruction> {
 #[cfg(any(target_os = "stax", target_os = "flex"))]
 pub fn ui_menu_main(_: &mut Comm) -> NbglHomeAndSettings {
     // Load glyph from 64x64 4bpp gif file with include_gif macro. Creates an NBGL compatible glyph.
-    const FERRIS: NbglGlyph = NbglGlyph::from_include(include_gif!("vanadium_64x64.gif", NBGL));
+    const VANADIUM_ICON: NbglGlyph =
+        NbglGlyph::from_include(include_gif!("vanadium_64x64.gif", NBGL));
 
     let settings_strings = [["Display Memo", "Allow display of transaction memo."]];
     let mut settings: Settings = Default::default();
     // Display the home screen.
     NbglHomeAndSettings::new()
-        .glyph(&FERRIS)
+        .glyph(&VANADIUM_ICON)
         .settings(settings.get_mut(), &settings_strings)
         .infos(
             "Vanadium",


### PR DESCRIPTION
Adds to the Sdk a new `App` struct that incorporates the `busy-loop` logic, and will also be useful to keep any persisting state that the SDK will need in the future (for example for the state of the UX).

Also, moves the panic handler to the sdk, and adds a new `bootstrap!()` macro to contain any other boilerplate common to all the apps.

The test apps have been refactored accordingly.
