### PR TITLE
Bitcoin app: Accounts in PSBT

### DIFF
--- a/apps/bitcoin/common/Cargo.toml
+++ b/apps/bitcoin/common/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitcoin = { package = "vlib-bitcoin", path = "../../../libs/bitcoin", features = ["serde"] }
+bitcoin = { package = "vlib-bitcoin", path = "../../../libs/bitcoin", features = ["serde", "base64"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.219", default-features = false, features = ["alloc"] }

--- a/apps/bitcoin/common/src/account.rs
+++ b/apps/bitcoin/common/src/account.rs
@@ -1,5 +1,11 @@
 use alloc::string::{String, ToString};
+use alloc::{vec, vec::Vec};
+use bitcoin::bip32::{ChildNumber, Xpub};
+use bitcoin::consensus::{encode, Decodable, Encodable};
+use bitcoin::io::Read;
+use bitcoin::VarInt;
 
+use crate::bip388::KeyOrigin;
 // re-export, as we use this both as a message and as an internal data type
 pub use crate::message::WalletPolicyCoordinates;
 
@@ -10,12 +16,39 @@ use bitcoin::{params::Params, Address};
 
 use crate::script::ToScript;
 
+// TODO: maybe we can modify the serialize() methods to use bitcoin::io::Write instead
+
+pub trait AccountCoordinates: Sized {
+    fn serialize(&self) -> Vec<u8>;
+
+    fn deserialize<R: Read + ?Sized>(bytes: &mut R) -> Result<Self, encode::Error>;
+}
+
+impl AccountCoordinates for WalletPolicyCoordinates {
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::with_capacity(5);
+        result.push(if self.is_change { 1 } else { 0 });
+        result.extend_from_slice(&self.address_index.to_le_bytes());
+        result
+    }
+
+    fn deserialize<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(WalletPolicyCoordinates {
+            is_change: bool::consensus_decode(r)?,
+            address_index: u32::consensus_decode(r)?,
+        })
+    }
+}
+
 /// A generic trait for "accounts", parameterized by the type of coordinates.
 ///
 /// Each implementer will define how to turn its coordinates into an address.
 ///
-pub trait Account {
-    type Coordinates;
+pub trait Account: Sized {
+    type Coordinates: AccountCoordinates;
+
+    fn serialize(&self) -> Vec<u8>;
+    fn deserialize<R: Read + ?Sized>(bytes: &mut R) -> Result<Self, encode::Error>;
 
     fn get_address(&self, coords: &Self::Coordinates) -> Result<String, &'static str>;
 }
@@ -23,6 +56,94 @@ pub trait Account {
 // Implement the generic trait for `WalletPolicy` with its corresponding coordinates.
 impl Account for WalletPolicy {
     type Coordinates = WalletPolicyCoordinates;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::<u8>::new();
+
+        let len = VarInt(self.descriptor_template_raw().len() as u64);
+        len.consensus_encode(&mut result).unwrap();
+        result.extend_from_slice(self.descriptor_template_raw().as_bytes());
+
+        // number of keys
+        VarInt(self.key_information.len() as u64)
+            .consensus_encode(&mut result)
+            .unwrap();
+        for key_info in &self.key_information {
+            // serialize key information
+            match &key_info.origin_info {
+                None => {
+                    result.push(0);
+                }
+                Some(k) => {
+                    result.push(1);
+                    result.extend_from_slice(&k.fingerprint.to_be_bytes());
+                    result.push(k.derivation_path.len() as u8);
+                    for step in k.derivation_path.iter() {
+                        result.extend_from_slice(&u32::from(*step).to_le_bytes());
+                    }
+                }
+            }
+            // serialize pubkey
+            result.extend_from_slice(&key_info.pubkey.encode());
+        }
+
+        result
+    }
+
+    fn deserialize<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        // Deserialize descriptor template.
+        let VarInt(desc_len) = VarInt::consensus_decode(r)?;
+        let mut desc_bytes = vec![0u8; desc_len as usize];
+        r.read_exact(&mut desc_bytes)?;
+        let descriptor_template_str = String::from_utf8(desc_bytes)
+            .map_err(|_| encode::Error::ParseFailed("Invalid UTF-8 in descriptor"))?;
+
+        // Deserialize key_information vector.
+        let VarInt(key_count) = VarInt::consensus_decode(r)?;
+        let mut key_information = Vec::with_capacity(key_count as usize);
+        for _ in 0..key_count {
+            let mut flag = [0u8; 1];
+            r.read_exact(&mut flag)?;
+            let origin_info = match flag[0] {
+                0 => None,
+                1 => {
+                    let mut fp_buf = [0; 4];
+                    r.read_exact(&mut fp_buf)?;
+                    let fingerprint = u32::from_be_bytes(fp_buf);
+                    let mut len_buf = [0u8; 1];
+                    r.read_exact(&mut len_buf)?;
+                    let dp_len = len_buf[0] as usize;
+                    let mut derivation_path = Vec::with_capacity(dp_len);
+                    for _ in 0..dp_len {
+                        let mut step_bytes = [0u8; 4];
+                        r.read_exact(&mut step_bytes)?;
+                        derivation_path.push(ChildNumber::from(u32::from_le_bytes(step_bytes)));
+                    }
+                    Some(KeyOrigin {
+                        fingerprint,
+                        derivation_path,
+                    })
+                }
+                _ => {
+                    return Err(encode::Error::ParseFailed("Invalid key information flag"));
+                }
+            };
+            // Deserialize pubkey.
+            let mut xpub_bytes = vec![0u8; 78];
+            r.read_exact(&mut xpub_bytes)?;
+
+            key_information.push(KeyInformation {
+                origin_info,
+                pubkey: Xpub::decode(&xpub_bytes)
+                    .map_err(|_| encode::Error::ParseFailed("Invalid xpub"))?,
+            });
+        }
+        Ok(
+            WalletPolicy::new(&descriptor_template_str, key_information).map_err(|_| {
+                encode::Error::ParseFailed("Invalid descriptor template or key information")
+            })?,
+        )
+    }
+
     fn get_address(&self, coords: &WalletPolicyCoordinates) -> Result<String, &'static str> {
         let script = self
             .to_script(coords.is_change, coords.address_index)
@@ -32,3 +153,5 @@ impl Account for WalletPolicy {
             .map_err(|_| "Failed to derive address")
     }
 }
+
+// TODO: add some tests

--- a/apps/bitcoin/common/src/lib.rs
+++ b/apps/bitcoin/common/src/lib.rs
@@ -1,9 +1,10 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 
 pub mod account;
 pub mod bip388;
 pub mod message;
+pub mod psbt;
 pub mod script;
 pub mod taproot;

--- a/apps/bitcoin/common/src/message/mod.rs
+++ b/apps/bitcoin/common/src/message/mod.rs
@@ -32,6 +32,15 @@ pub struct WalletPolicyCoordinates {
     pub address_index: u32,
 }
 
+impl WalletPolicyCoordinates {
+    pub fn new(is_change: bool, address_index: u32) -> Self {
+        Self {
+            is_change,
+            address_index,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum Account {
     WalletPolicy(WalletPolicy),

--- a/apps/bitcoin/common/src/psbt.rs
+++ b/apps/bitcoin/common/src/psbt.rs
@@ -1,0 +1,637 @@
+use crate::{
+    account::{Account, AccountCoordinates, WalletPolicy, WalletPolicyCoordinates},
+    bip388::{KeyOrigin, KeyPlaceholder},
+};
+
+use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
+use bitcoin::{
+    bip32::{DerivationPath, Fingerprint},
+    consensus::Encodable,
+    psbt::{self, raw::ProprietaryKey, Psbt},
+    TapLeafHash,
+};
+
+/// Proprietary key prefix for account-related data in PSBT fields
+pub const PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER: [u8; 7] = *b"ACCOUNT";
+
+pub const PSBT_ACCOUNT_GLOBAL_ACCOUNT_DESCRIPTOR: u8 = 0x00;
+pub const PSBT_ACCOUNT_GLOBAL_ACCOUNT_NAME: u8 = 0x01;
+pub const PSBT_ACCOUNT_GLOBAL_ACCOUNT_POR: u8 = 0x02;
+
+pub const PSBT_ACCOUNT_IN_COORDINATES: u8 = 0x00;
+pub const PSBT_ACCOUNT_OUT_COORDINATES: u8 = 0x00;
+
+fn is_valid_account_name(value: &[u8]) -> bool {
+    value.len() >= 1 // not too short
+        && value.len() <= 64 // not too long
+        && value[0] != b' ' // doesn't start with space
+        && value[value.len() - 1] != b' ' // doesn't end with space
+        && value.iter().all(|&c| c >= 0x20 && c <= 0x7E) // no disallowed characters
+}
+
+#[derive(Debug, Clone)]
+pub enum PsbtAccount {
+    WalletPolicy(WalletPolicy),
+    // other account types will be added here
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PsbtAccountCoordinates {
+    WalletPolicy(WalletPolicyCoordinates),
+    // coordinates for other account types will be added here
+}
+
+pub trait PsbtAccountGlobal {
+    fn get_accounts(&self) -> Result<Vec<PsbtAccount>, &'static str>;
+    fn get_account(&self, id: u32) -> Result<Option<PsbtAccount>, &'static str>;
+    fn set_account(&mut self, id: u32, account: PsbtAccount) -> Result<(), &'static str>;
+    fn set_accounts(&mut self, accounts: Vec<PsbtAccount>) -> Result<(), &'static str> {
+        for (i, account) in accounts.into_iter().enumerate() {
+            self.set_account(i as u32, account)?;
+        }
+        Ok(())
+    }
+    fn get_account_name(&self, id: u32) -> Result<Option<String>, &'static str>;
+    fn set_account_name(&mut self, id: u32, name: &str) -> Result<(), &'static str>;
+    fn get_account_proof_of_registration(&self, id: u32) -> Result<Option<Vec<u8>>, &'static str>;
+    fn set_account_proof_of_registration(
+        &mut self,
+        id: u32,
+        por: &[u8],
+    ) -> Result<(), &'static str>;
+}
+
+pub trait PsbtAccountInput {
+    fn get_account_coordinates(
+        &self,
+        id: u32,
+    ) -> Result<Option<PsbtAccountCoordinates>, &'static str>;
+    fn set_account_coordinates(
+        &mut self,
+        id: u32,
+        coordinates: PsbtAccountCoordinates,
+    ) -> Result<(), &'static str>;
+}
+
+pub trait PsbtAccountOutput {
+    fn get_account_coordinates(
+        &self,
+        id: u32,
+    ) -> Result<Option<PsbtAccountCoordinates>, &'static str>;
+    fn set_account_coordinates(
+        &mut self,
+        id: u32,
+        coordinates: PsbtAccountCoordinates,
+    ) -> Result<(), &'static str>;
+}
+
+impl PsbtAccountGlobal for Psbt {
+    // Get all accounts from the global section of the PSBT.
+    // Unknown account types are ignored.
+    fn get_accounts(&self) -> Result<Vec<PsbtAccount>, &'static str> {
+        let mut id = 0u32;
+        let mut res = Vec::new();
+
+        // Keep trying to get accounts with increasing IDs until we find none
+        loop {
+            match self.get_account(id)? {
+                Some(account) => {
+                    res.push(account);
+                    id += 1;
+                }
+                None => break, // No more accounts at this ID
+            }
+        }
+
+        Ok(res)
+    }
+
+    // Get the account with the specific id. Returns None if not found
+    // Unknown account types are ignored.
+    fn get_account(&self, id: u32) -> Result<Option<PsbtAccount>, &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_GLOBAL_ACCOUNT_DESCRIPTOR,
+            key: id_raw,
+        };
+
+        if let Some(value) = self.proprietary.get(&key) {
+            if value.len() < 1 {
+                return Err("Empty account value");
+            }
+            match value[0] {
+                0 => {
+                    let wp = WalletPolicy::deserialize(&mut &value[1..])
+                        .map_err(|_| "Failed to deserialize WalletPolicy")?;
+                    Ok(Some(PsbtAccount::WalletPolicy(wp)))
+                }
+                _ => Err("Unknown account type"),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn set_account(&mut self, id: u32, account: PsbtAccount) -> Result<(), &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_GLOBAL_ACCOUNT_DESCRIPTOR,
+            key: id_raw,
+        };
+
+        match account {
+            PsbtAccount::WalletPolicy(wp) => {
+                let ser_wp = wp.serialize();
+                let mut res = Vec::with_capacity(1 + ser_wp.len());
+                res.push(0x00);
+                res.extend_from_slice(&ser_wp);
+                self.proprietary.insert(key, res);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_account_name(&self, id: u32) -> Result<Option<String>, &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_GLOBAL_ACCOUNT_NAME,
+            key: id_raw,
+        };
+
+        if let Some(value) = self.proprietary.get(&key) {
+            if !is_valid_account_name(&value) {
+                return Err("Invalid account name");
+            }
+
+            Ok(Some(String::from_utf8(value.to_vec()).unwrap()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn set_account_name(&mut self, id: u32, name: &str) -> Result<(), &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_GLOBAL_ACCOUNT_NAME,
+            key: id_raw,
+        };
+
+        if !is_valid_account_name(name.as_bytes()) {
+            return Err("Invalid account name");
+        }
+        self.proprietary.insert(key, name.as_bytes().to_vec());
+
+        Ok(())
+    }
+
+    fn get_account_proof_of_registration(&self, id: u32) -> Result<Option<Vec<u8>>, &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_GLOBAL_ACCOUNT_POR,
+            key: id_raw,
+        };
+
+        if let Some(value) = self.proprietary.get(&key) {
+            if value.len() < 1 {
+                return Err("Empty account value");
+            }
+            Ok(Some(value.to_vec()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn set_account_proof_of_registration(
+        &mut self,
+        id: u32,
+        por: &[u8],
+    ) -> Result<(), &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_GLOBAL_ACCOUNT_POR,
+            key: id_raw,
+        };
+
+        if por.len() < 1 {
+            return Err("Empty account value");
+        }
+
+        self.proprietary.insert(key, por.to_vec());
+
+        Ok(())
+    }
+}
+
+impl PsbtAccountInput for psbt::Input {
+    fn get_account_coordinates(
+        &self,
+        id: u32,
+    ) -> Result<Option<PsbtAccountCoordinates>, &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_IN_COORDINATES,
+            key: id_raw,
+        };
+
+        if let Some(value) = self.proprietary.get(&key) {
+            if value.len() < 1 {
+                return Err("Empty account value");
+            }
+            match value[0] {
+                0 => {
+                    let coords = AccountCoordinates::deserialize(&mut &value[1..])
+                        .map_err(|_| "Failed to deserialize AccountCoordinates")?;
+                    Ok(Some(PsbtAccountCoordinates::WalletPolicy(coords)))
+                }
+                _ => Err("Unknown account type"),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn set_account_coordinates(
+        &mut self,
+        id: u32,
+        coordinates: PsbtAccountCoordinates,
+    ) -> Result<(), &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_IN_COORDINATES,
+            key: id_raw,
+        };
+
+        match coordinates {
+            PsbtAccountCoordinates::WalletPolicy(coords) => {
+                let serialized_coords = coords.serialize();
+                let mut serialized_coords_with_tag =
+                    Vec::with_capacity(1 + serialized_coords.len());
+                serialized_coords_with_tag.push(0); // tag
+                serialized_coords_with_tag.extend_from_slice(&serialized_coords);
+                self.proprietary.insert(key, serialized_coords_with_tag);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl PsbtAccountOutput for psbt::Output {
+    fn get_account_coordinates(
+        &self,
+        id: u32,
+    ) -> Result<Option<PsbtAccountCoordinates>, &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_OUT_COORDINATES,
+            key: id_raw,
+        };
+
+        if let Some(value) = self.proprietary.get(&key) {
+            if value.len() < 1 {
+                return Err("Empty account value");
+            }
+            match value[0] {
+                0 => {
+                    let coords = AccountCoordinates::deserialize(&mut &value[1..])
+                        .map_err(|_| "Failed to deserialize AccountCoordinates")?;
+                    Ok(Some(PsbtAccountCoordinates::WalletPolicy(coords)))
+                }
+                _ => Err("Unknown account type"),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn set_account_coordinates(
+        &mut self,
+        id: u32,
+        coordinates: PsbtAccountCoordinates,
+    ) -> Result<(), &'static str> {
+        let mut id_raw = Vec::with_capacity(1); // unlikely to be more than 1 byte
+        let _ = id.consensus_encode(&mut id_raw).unwrap();
+        let key = ProprietaryKey {
+            prefix: PSBT_ACCOUNT_PROPRIETARY_IDENTIFIER.to_vec(),
+            subtype: PSBT_ACCOUNT_OUT_COORDINATES,
+            key: id_raw,
+        };
+
+        match coordinates {
+            PsbtAccountCoordinates::WalletPolicy(coords) => {
+                let serialized_coords = coords.serialize();
+                let mut serialized_coords_with_tag =
+                    Vec::with_capacity(1 + serialized_coords.len());
+                serialized_coords_with_tag.push(0); // tag
+                serialized_coords_with_tag.extend_from_slice(&serialized_coords);
+                self.proprietary.insert(key, serialized_coords_with_tag);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Helper function to get wallet policy coordinates from a PSBT input or output
+fn get_wallet_policy_coordinates(
+    bip32_derivation: &BTreeMap<bitcoin::secp256k1::PublicKey, (Fingerprint, DerivationPath)>,
+    tap_bip32_derivation: &BTreeMap<
+        bitcoin::secp256k1::XOnlyPublicKey,
+        (Vec<TapLeafHash>, (Fingerprint, DerivationPath)),
+    >,
+    key_orig_info: &KeyOrigin,
+    key_placeholder: &KeyPlaceholder,
+) -> Option<WalletPolicyCoordinates> {
+    // iterate over all derivations; if it's a key derived from the internal key,
+    // deduce the coordinates and insert them
+    for (_, (fpr, der)) in bip32_derivation.iter() {
+        if *fpr != key_orig_info.fingerprint.to_be_bytes().into() {
+            continue;
+        }
+        if key_orig_info.derivation_path.len() + 2 != der.len() {
+            continue;
+        }
+        let change_step: u32 = der[der.len() - 2].into();
+        let is_change = match change_step {
+            n if n == key_placeholder.num1 => false,
+            n if n == key_placeholder.num2 => true,
+            _ => continue, // this could only happen in case of a fingerprint collision
+        };
+        let address_index: u32 = der[der.len() - 1].into();
+        return Some(WalletPolicyCoordinates {
+            is_change,
+            address_index,
+        });
+    }
+
+    // do the same for the tap_bip32_derivations
+    // TODO: we might want to avoid the code duplication
+    for (_, (_, (fpr, der))) in tap_bip32_derivation.iter() {
+        if *fpr != key_orig_info.fingerprint.to_be_bytes().into() {
+            continue;
+        }
+        if key_orig_info.derivation_path.len() + 2 != der.len() {
+            continue;
+        }
+        let change_step: u32 = der[der.len() - 2].into();
+        let is_change = match change_step {
+            n if n == key_placeholder.num1 => false,
+            n if n == key_placeholder.num2 => true,
+            _ => continue, // this could only happen in case of a fingerprint collision
+        };
+        let address_index: u32 = der[der.len() - 1].into();
+        return Some(WalletPolicyCoordinates {
+            is_change,
+            address_index,
+        });
+    }
+
+    None
+}
+
+// Given a PSBT and a wallet policy, and one of the placeholders, fills the psbt with the following fields:
+// - Global: account descriptor, account name (if given), proof of registration (if given)
+// - Input: account coordinates
+// - Output: account coordinates
+// Coordinates are deduced from the bip32 derivations in the PSBT, only using keys with
+// full key origin information in the wallet policy.
+pub fn fill_psbt_with_bip388_coordinates(
+    psbt: &mut Psbt,
+    wallet_policy: &WalletPolicy,
+    name: Option<&str>,
+    proof_of_registrations: Option<&[u8]>,
+    key_placeholder: &KeyPlaceholder,
+    account_id: u32,
+) -> Result<(), &'static str> {
+    psbt.set_account(account_id, PsbtAccount::WalletPolicy(wallet_policy.clone()))?;
+    if let Some(name) = name {
+        psbt.set_account_name(account_id, name)?;
+    }
+    if let Some(por) = proof_of_registrations {
+        psbt.set_account_proof_of_registration(account_id, por)?;
+    }
+
+    // we will look for keys derived from this
+    let key_expr = &wallet_policy.key_information[key_placeholder.key_index as usize];
+    let Some(ref key_orig_info) = key_expr.origin_info else {
+        return Err("Key expression has no origin info");
+    };
+
+    // Fill input coordinates
+    for input in psbt.inputs.iter_mut() {
+        if let Some(coords) = get_wallet_policy_coordinates(
+            &input.bip32_derivation,
+            &input.tap_key_origins,
+            key_orig_info,
+            key_placeholder,
+        ) {
+            input.set_account_coordinates(
+                account_id,
+                PsbtAccountCoordinates::WalletPolicy(coords),
+            )?;
+        }
+    }
+
+    // Fill output coordinates
+    for output in psbt.outputs.iter_mut() {
+        if let Some(coords) = get_wallet_policy_coordinates(
+            &output.bip32_derivation,
+            &output.tap_key_origins,
+            key_orig_info,
+            key_placeholder,
+        ) {
+            output.set_account_coordinates(
+                account_id,
+                PsbtAccountCoordinates::WalletPolicy(coords),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    const TEST_PSBT: &'static str = "cHNidP8BAFUCAAAAAVEiws3mgj5VdUF1uSycV6Co4ayDw44Xh/06H/M0jpUTAQAAAAD9////AXhBDwAAAAAAGXapFBPX1YFmlGw+wCKTQGbYwNER0btBiKwaBB0AAAEA+QIAAAAAAQHsIw5TCVJWBSokKCcO7ASYlEsQ9vHFePQxwj0AmLSuWgEAAAAXFgAUKBU5gg4t6XOuQbpgBLQxySHE2G3+////AnJydQAAAAAAF6kUyLkGrymMcOYDoow+/C+uGearKA+HQEIPAAAAAAAZdqkUy65bUM+Tnm9TG4prer14j+FLApeIrAJHMEQCIDfstCSDYar9T4wR5wXw+npfvc1ZUXL81WQ/OxG+/11AAiACDG0yb2w31jzsra9OszX67ffETgX17x0raBQLAjvRPQEhA9rIL8Cs/Pw2NI1KSKRvAc6nfyuezj+MO0yZ0LCy+ZXShPIcACIGAu6GCCB+IQKEJvaedkR9fj1eB3BJ9eaDwxNsIxR2KkcYGPWswv0sAACAAQAAgAAAAIAAAAAAAAAAAAAA";
+
+    #[test]
+    fn test_set_and_get_account_name() {
+        let mut psbt = Psbt::from_str(TEST_PSBT).unwrap();
+        let account_id = 0;
+        let valid_name = "TestAccount";
+        assert!(psbt.set_account_name(account_id, valid_name).is_ok());
+        let ret = psbt.get_account_name(account_id).unwrap();
+        assert_eq!(ret, Some(valid_name.to_string()));
+    }
+
+    #[test]
+    fn test_invalid_account_name() {
+        // setting invalid account names should fail
+        let mut psbt = Psbt::from_str(TEST_PSBT).unwrap();
+        let account_id = 0;
+
+        let long_name = "a".repeat(65);
+
+        let invalid_names = [
+            "",                 // too short
+            long_name.as_str(), // too long
+            " Invalid",         // starts with space
+            "Invalid ",         // ends with a space
+            "Invàlid",          // contains disallowed character
+        ];
+        for invalid_name in invalid_names.iter() {
+            assert!(psbt.set_account_name(account_id, invalid_name).is_err());
+        }
+    }
+
+    #[test]
+    fn test_set_and_get_proof_of_registration() {
+        let mut psbt = Psbt::from_str(TEST_PSBT).unwrap();
+        let account_id = 0;
+        let por: Vec<u8> = vec![1, 2, 3, 4];
+        assert!(psbt
+            .set_account_proof_of_registration(account_id, &por)
+            .is_ok());
+        let ret = psbt.get_account_proof_of_registration(account_id).unwrap();
+        assert_eq!(ret, Some(por));
+    }
+
+    #[test]
+    fn test_set_and_get_account() {
+        let mut psbt = Psbt::from_str(TEST_PSBT).unwrap();
+        let wallet_policy = WalletPolicy::new(
+            "pkh(@0/**)",
+            [
+                "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"
+                    .try_into()
+                    .unwrap()
+            ]
+            .to_vec()
+        )
+        .unwrap();
+        let account_id = 0;
+        assert!(psbt
+            .set_account(account_id, PsbtAccount::WalletPolicy(wallet_policy.clone()))
+            .is_ok());
+        let retrieved = psbt.get_account(account_id).unwrap();
+        match retrieved {
+            Some(PsbtAccount::WalletPolicy(ref wp)) => {
+                assert_eq!(wp.serialize(), wallet_policy.serialize());
+            }
+            _ => panic!("Unexpected or missing account type"),
+        }
+    }
+
+    #[test]
+    fn test_get_nonexistent_account() {
+        let psbt = Psbt::from_str(TEST_PSBT).unwrap();
+        let retrieved = psbt.get_account(99).unwrap();
+        assert!(retrieved.is_none());
+    }
+
+    #[test]
+    fn test_set_and_get_input_coordinates() {
+        use super::*;
+        let mut input = psbt::Input::default();
+        let account_id = 0;
+        let coords = PsbtAccountCoordinates::WalletPolicy(WalletPolicyCoordinates {
+            is_change: false,
+            address_index: 5,
+        });
+        input
+            .set_account_coordinates(account_id, coords.clone())
+            .unwrap();
+        let retrieved = input.get_account_coordinates(account_id).unwrap();
+        assert_eq!(retrieved, Some(coords));
+    }
+
+    #[test]
+    fn test_set_and_get_output_coordinates() {
+        use super::*;
+        let mut output = psbt::Output::default();
+        let account_id = 0;
+        let coords = PsbtAccountCoordinates::WalletPolicy(WalletPolicyCoordinates {
+            is_change: true,
+            address_index: 10,
+        });
+        output
+            .set_account_coordinates(account_id, coords.clone())
+            .unwrap();
+        let retrieved = output.get_account_coordinates(account_id).unwrap();
+        assert_eq!(retrieved, Some(coords));
+    }
+
+    #[test]
+    fn test_fill_psbt_with_bip388_coordinates() {
+        let wallet_policy = WalletPolicy::new("wpkh(@0/**)", [
+            "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P".try_into().unwrap()
+        ].to_vec()).unwrap();
+        let psbt_str = "cHNidP8BAKYCAAAAAp4s/ifwrYe3iiN9XXQF1KMGZso2HVhaRnsN/kImK020AQAAAAD9////r7+uBlkPdB/xr1m2rEYRJjNqTEqC21U99v76tzesM/MAAAAAAP3///8CqDoGAAAAAAAWABTrOPqbgSj4HybpXtsMX/rqg2kP5OCTBAAAAAAAIgAgP6lmyd3Nwv2W5KXhvHZbn69s6LPrTxEEqta993Mk5b4AAAAAAAEAcQIAAAABk2qy4BBy95PP5Ml3VN4bYf4D59tlNsiy8h3QtXQsSEUBAAAAAP7///8C3uHHAAAAAAAWABTreNfEC/EGOw4/zinDVltonIVZqxAnAAAAAAAAFgAUIxjWb4T+9cSHX5M7A43GODH42hP5lx4AAQEfECcAAAAAAAAWABQjGNZvhP71xIdfkzsDjcY4MfjaEyIGA0Ve587cl7C6Q1uABm/JLJY6NMYAMXmB0TUzDE7kOsejGPWswv1UAACAAQAAgAAAAIAAAAAAAQAAAAABAHEBAAAAAQ5HHvTpLBrLUe/IZg+NP2mTbqnJsr/3L/m8gcUe/PRkAQAAAAAAAAAAAmCuCgAAAAAAFgAUNcbg3W08hLFrqIXcpzrIY9C1k+yvBjIAAAAAABYAFNwobgzS5r03zr6ew0n7XwiQVnL8AAAAAAEBH2CuCgAAAAAAFgAUNcbg3W08hLFrqIXcpzrIY9C1k+wiBgJxtbd5rYcIOFh3l7z28MeuxavnanCdck9I0uJs+HTwoBj1rML9VAAAgAEAAIAAAACAAQAAAAAAAAAAIgICKexHcnEx7SWIogxG7amrt9qm9J/VC6/nC5xappYcTswY9azC/VQAAIABAACAAAAAgAEAAAAKAAAAAAA=";
+        let mut psbt = Psbt::from_str(psbt_str).unwrap();
+
+        let placeholders: Vec<KeyPlaceholder> = wallet_policy
+            .descriptor_template
+            .placeholders()
+            .map(|(k, _)| k.clone())
+            .collect();
+        assert!(placeholders.len() == 1);
+        let key_placeholder = placeholders[0];
+
+        let result = fill_psbt_with_bip388_coordinates(
+            &mut psbt,
+            &wallet_policy,
+            None,
+            None,
+            &key_placeholder,
+            0,
+        );
+
+        assert!(result.is_ok());
+
+        let accounts = psbt.get_accounts().unwrap();
+        assert_eq!(accounts.len(), 1);
+
+        assert_eq!(
+            psbt.inputs[0].get_account_coordinates(0).unwrap(),
+            Some(PsbtAccountCoordinates::WalletPolicy(
+                WalletPolicyCoordinates::new(false, 1)
+            ))
+        );
+        assert_eq!(
+            psbt.inputs[1].get_account_coordinates(0).unwrap(),
+            Some(PsbtAccountCoordinates::WalletPolicy(
+                WalletPolicyCoordinates::new(true, 0)
+            ))
+        );
+        assert_eq!(
+            psbt.outputs[0].get_account_coordinates(0).unwrap(),
+            Some(PsbtAccountCoordinates::WalletPolicy(
+                WalletPolicyCoordinates::new(true, 10)
+            ))
+        );
+        assert_eq!(psbt.outputs[1].get_account_coordinates(0).unwrap(), None);
+    }
+}

--- a/apps/bitcoin/docs/PSBT.md
+++ b/apps/bitcoin/docs/PSBT.md
@@ -1,0 +1,64 @@
+This document details the specifications of extensions to the PSBT format for signers with an account-based signing flow.
+
+The additional fields are defined using the proprietary fields defined by the [PSBT](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki) (with key types `PSBT_{GLOBAL,IN,OUT}_PROPRIETARY` in the global, per-input or per-output maps, respectively), using the proprietary identifier `ACCOUNT` (all capital letters).
+
+
+## Accounts and coordinates
+
+An _account_ identifies a collection of outputs/addresses that logically belong to the same accounting unit.
+
+For each account, the corresponding _coordinates_ identify the exact an output/address.
+
+The specifications of each account type must detail how the account description and the coordinates are serialized.
+
+Each of the different types of accounts has a single `account_tag`, implemented as a single unsigned byte.
+
+### Wallet policy ([BIP-388](https://github.com/bitcoin/bips/blob/master/bip-0388.mediawiki))
+
+`account_tag` is 0 for wallet policies (and their coordinates).
+
+- Account: A valid BIP-388 wallet policy
+- Coordinates: a `(is_change, address_index)` pair, where `is_change` is a boolean, and `address_index` is a number between 0 and 2147483647.
+
+The wallet policy is serialized as the concatenation of:
+- The compact-size length of the descriptor template
+- The descriptor template
+- The compact size number _n_ of key expressions
+- Repeat for each of the _n_ keys
+  - If there is no key origin information, a single byte 0, followed by a 78-byte serialized xpub
+  - If there is key origin information, the concatenation of
+    - a single byte 1
+    - 4 bytes: key fingerprint
+    - 1 byte: length _k_ of the key origin derivation
+    - 4 * _k_ bytes: the concatenation of each derivation step, each represented as a 4-byte little-endian number.
+
+The coordinates are serialized as:
+- a single byte 0 if not change, 1 if change
+- followed by 4 byte little-endian address index.
+
+### Silent Payments Address ([BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki))
+
+TODO
+
+## Global subkey types
+
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeytype>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeydata>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeydata>` Description | `<valuedata>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<valuedata>`&nbsp;Description&nbsp;&nbsp; | Versions Requiring Inclusion | Versions Requiring Exclusion | Versions Allowing Inclusion | Parent BIP |
+|-----------------------|-------------------------------------------------|-----------------------------|----------------|-------------------------------------|---------------------------------------------------------------------------------------|------|-|------|--------|
+| Account Description   | `PSBT_ACCOUNT_GLOBAL_ACCOUNT_DESCRIPTOR = 0x00` | `<compact size account ID>` | The account ID | `<byte account_tag> <bytes serialized account>`        | The single byte account tag, followed by the full description of the account, serialized as per the rules of that account type | 0, 2 | | 0, 2 | No BIP |
+| Account Name          | `PSBT_ACCOUNT_GLOBAL_ACCOUNT_NAME = 0x01`       | `<compact size account ID>` | The account ID | `<compact size name length> <name>` | The non-zero length of the name, followed by the name of the account                  |      | | 0, 2 | No BIP |
+| Proof of Registration | `PSBT_ACCOUNT_GLOBAL_ACCOUNT_POR = 0x02`        | `<compact size account ID>` | The account ID | `<bytes>`                           | If required by the signer, the _Proof of Registration_ for the account                |      | | 0, 2 | No BIP |
+
+
+### Per-input subkey types
+
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeytype>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeydata>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeydata>` Description | `<valuedata>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<valuedata>`&nbsp;Description&nbsp;&nbsp; | Versions Requiring Inclusion | Versions Requiring Exclusion | Versions Allowing Inclusion | Parent BIP |
+|---------------------|--------------------------------------|-----------------------------|----------------|----------------------------------|---------------------------------------------------------------------|-|-|------|--------|
+| Account Coordinates | `PSBT_ACCOUNT_IN_COORDINATES = 0x00` | `<compact size account ID>` | The account ID | `<byte account_tag> <bytes serialized coordinates>` | The single byte account tag, followed by the coordinates, serialized as per the specification of the account | | | 0, 2 | No BIP |
+
+
+### Per-output subkey types
+
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeytype>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeydata>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<subkeydata>` Description | `<valuedata>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| `<valuedata>`&nbsp;Description&nbsp;&nbsp; | Versions Requiring Inclusion | Versions Requiring Exclusion | Versions Allowing Inclusion | Parent BIP |
+|---------------------|---------------------------------------|-----------------------------|----------------|----------------------------------|---------------------------------------------------------------------|-|-|------|--------|
+| Account Coordinates | `PSBT_ACCOUNT_OUT_COORDINATES = 0x00` | `<compact size account ID>` | The account ID | `<byte account_tag> <bytes serialized coordinates>` | The single byte account tag, followed by the coordinates, serialized as per the specification of the account | | | 0, 2 | No BIP |
+

--- a/libs/bitcoin/src/lib.rs
+++ b/libs/bitcoin/src/lib.rs
@@ -64,9 +64,9 @@ pub extern crate ordered;
 
 // We do not re-export vlib-secp256k1, as it is only a partial implementation of the rust-secp256k1
 // and it should only be used in vlib-bitcoin at this time.
-// However, we need to at least export the Secp256k1 type as it is part of the public API of vlib-bitcoin.
+// However, we need to at least export a few types that are part of the public API of vlib-bitcoin.
 pub mod secp256k1 {
-    pub use secp256k1::Secp256k1;
+    pub use secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Adds to the Bitcoin app:
- specs for how to encode accounts and coordinates in proprietary keys of PSBTs
- code for encoding/decoding of proprietary keys in PSBT
- utilities to correctly fill the proprietary types in a PSBT for a wallet policy