### PR TITLE
Check Merkle proofs

### DIFF
--- a/app-sdk/src/hash.rs
+++ b/app-sdk/src/hash.rs
@@ -1,16 +1,4 @@
-pub trait Hasher<const DIGEST_SIZE: usize>: Sized {
-    fn new() -> Self;
-    fn update(&mut self, buffer: &[u8]) -> &mut Self;
-    fn digest(self, digest: &mut [u8; DIGEST_SIZE]);
-
-    fn hash(data: &[u8]) -> [u8; DIGEST_SIZE] {
-        let mut hasher = Self::new();
-        hasher.update(data);
-        let mut digest = [0u8; DIGEST_SIZE];
-        hasher.digest(&mut digest);
-        digest
-    }
-}
+pub use common::accumulator::Hasher;
 
 #[cfg(not(target_arch = "riscv32"))]
 mod hashers {

--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -1,4 +1,3 @@
-
 //! This module provides a generic framework, and a Merkle-tree based implementation,
 //! for vector accumulators. This allows a party (the verifier) to outsource the storage
 //! of the vector to another party (the prover). The verifier only maintains a single
@@ -9,8 +8,7 @@
 
 use alloc::{vec, vec::Vec};
 use core::{error::Error, fmt, marker::PhantomData};
-use serde::{Serialize, Deserialize, Serializer, Deserializer, de::DeserializeOwned};
-
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug)]
 pub enum AccumulatorError {
@@ -27,7 +25,6 @@ impl fmt::Display for AccumulatorError {
 
 impl Error for AccumulatorError {}
 
-
 /// A trait representing a cryptographic hasher that produces a fixed-size output.
 pub trait Hasher<const OUTPUT_SIZE: usize>: Sized {
     /// Creates a new instance of the hasher.
@@ -38,11 +35,11 @@ pub trait Hasher<const OUTPUT_SIZE: usize>: Sized {
     /// # Arguments
     ///
     /// * `data` - A slice of bytes to be hashed.
-    fn update(&mut self, data: &[u8]);
+    fn update(&mut self, data: &[u8]) -> &mut Self;
 
     /// Finalizes the hashing process and returns the output as an array of bytes.
-    fn finalize(self) -> [u8; OUTPUT_SIZE];
-    
+    fn digest(self, out: &mut [u8; OUTPUT_SIZE]);
+
     /// Convenience method to hash data in a single step.
     ///
     /// # Arguments
@@ -55,7 +52,9 @@ pub trait Hasher<const OUTPUT_SIZE: usize>: Sized {
     fn hash(data: &[u8]) -> [u8; OUTPUT_SIZE] {
         let mut hasher = Self::new();
         hasher.update(data);
-        hasher.finalize()
+        let mut out = [0u8; OUTPUT_SIZE];
+        hasher.digest(&mut out);
+        out
     }
 }
 
@@ -81,7 +80,9 @@ impl<'de, const N: usize> Deserialize<'de> for HashOutput<N> {
         D: Deserializer<'de>,
     {
         let slice: &[u8] = Deserialize::deserialize(deserializer)?;
-        let array: [u8; N] = slice.try_into().map_err(|_| serde::de::Error::custom("Incorrect length"))?;
+        let array: [u8; N] = slice
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("Incorrect length"))?;
         Ok(HashOutput(array))
     }
 }
@@ -125,7 +126,13 @@ pub trait VectorAccumulator<T: AsRef<[u8]> + Clone + Serialize + DeserializeOwne
     /// # Returns
     ///
     /// `true` if the proof is valid, `false` otherwise.
-    fn verify_inclusion_proof(root: &[u8], proof: &Self::InclusionProof, value: &T, index: usize, size: usize) -> bool;
+    fn verify_inclusion_proof(
+        root: &[u8],
+        proof: &Self::InclusionProof,
+        value: &T,
+        index: usize,
+        size: usize,
+    ) -> bool;
 
     /// Updates the accumulator by replacing the element at the given index.
     ///
@@ -165,13 +172,22 @@ pub trait VectorAccumulator<T: AsRef<[u8]> + Clone + Serialize + DeserializeOwne
 }
 
 /// A Merkle tree-based implementation of the `VectorAccumulator` trait.
-pub struct MerkleAccumulator<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned, const OUTPUT_SIZE: usize> {
+pub struct MerkleAccumulator<
+    H: Hasher<OUTPUT_SIZE>,
+    T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+    const OUTPUT_SIZE: usize,
+> {
     data: Vec<T>,
     tree: Vec<HashOutput<OUTPUT_SIZE>>,
     _marker: PhantomData<H>,
 }
 
-impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned, const OUTPUT_SIZE: usize> VectorAccumulator<T> for MerkleAccumulator<H, T, OUTPUT_SIZE> {
+impl<
+        H: Hasher<OUTPUT_SIZE>,
+        T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+        const OUTPUT_SIZE: usize,
+    > VectorAccumulator<T> for MerkleAccumulator<H, T, OUTPUT_SIZE>
+{
     type InclusionProof = Vec<HashOutput<OUTPUT_SIZE>>;
     type UpdateProof = (Self::InclusionProof, Vec<u8>);
 
@@ -233,10 +249,15 @@ impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwn
     }
 
     /// Verifies an inclusion proof for a given element and index
-    fn verify_inclusion_proof(root: &[u8], proof: &Self::InclusionProof, element: &T, index: usize, size: usize) -> bool {
+    fn verify_inclusion_proof(
+        root: &[u8],
+        proof: &Self::InclusionProof,
+        element: &T,
+        index: usize,
+        size: usize,
+    ) -> bool {
         let mut hash = Self::hash_leaf(element);
         let mut pos = size - 1 + index;
-    
         for sibling_hash in proof.iter() {
             let (left, right) = if pos % 2 == 0 {
                 (sibling_hash, &hash)
@@ -246,7 +267,6 @@ impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwn
             hash = Self::hash_internal_node(left, right);
             pos = (pos - 1) / 2;
         }
-    
         hash.0 == root
     }
 
@@ -267,7 +287,7 @@ impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwn
 
         let old_root = self.root();
 
-        let merkle_proof = self.prove(index)?;  // Capture proof before update
+        let merkle_proof = self.prove(index)?; // Capture proof before update
         self.data[index] = value;
         let n = self.data.len();
         let mut pos = n - 1 + index;
@@ -275,7 +295,8 @@ impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwn
 
         while pos > 0 {
             pos = (pos - 1) / 2;
-            self.tree[pos] = Self::hash_internal_node(&self.tree[2 * pos + 1], &self.tree[2 * pos + 2]);
+            self.tree[pos] =
+                Self::hash_internal_node(&self.tree[2 * pos + 1], &self.tree[2 * pos + 2]);
         }
 
         Ok((merkle_proof, old_root))
@@ -293,16 +314,25 @@ impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwn
         let (proof, old_root) = update_proof;
 
         // verify that the old value was correct, and that the same proof is correct for the new value (with the new root)
-        Self::verify_inclusion_proof(old_root, proof, old_value, index, size) &&
-        Self::verify_inclusion_proof(new_root, proof, new_value, index, size)
+        Self::verify_inclusion_proof(old_root, proof, old_value, index, size)
+            && Self::verify_inclusion_proof(new_root, proof, new_value, index, size)
     }
 }
 
-impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned, const OUTPUT_SIZE: usize> MerkleAccumulator<H, T, OUTPUT_SIZE> {
+impl<
+        H: Hasher<OUTPUT_SIZE>,
+        T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+        const OUTPUT_SIZE: usize,
+    > MerkleAccumulator<H, T, OUTPUT_SIZE>
+{
     /// Constructs the Merkle tree from the provided data.
     fn build_tree(&mut self) {
         let n = self.data.len();
-        let leaves = self.data.iter().map(|x| Self::hash_leaf(x)).collect::<Vec<_>>();
+        let leaves = self
+            .data
+            .iter()
+            .map(|x| Self::hash_leaf(x))
+            .collect::<Vec<_>>();
 
         self.tree = vec![HashOutput([0u8; OUTPUT_SIZE]); 2 * n - 1];
         self.tree[n - 1..].clone_from_slice(&leaves);
@@ -317,20 +347,26 @@ impl<H: Hasher<OUTPUT_SIZE>, T: AsRef<[u8]> + Clone + Serialize + DeserializeOwn
         let mut hasher = H::new();
         hasher.update(&[0x00]);
         hasher.update(data.as_ref());
-        HashOutput(hasher.finalize())
+        let mut digest = [0u8; OUTPUT_SIZE];
+        hasher.digest(&mut digest);
+        HashOutput(digest)
     }
 
     /// Computes the hash for an internal node. A 0x01 byte is prepended to the data before hashing the child nodes.
-    fn hash_internal_node(left: &HashOutput<OUTPUT_SIZE>, right: &HashOutput<OUTPUT_SIZE>) -> HashOutput<OUTPUT_SIZE> {
+    fn hash_internal_node(
+        left: &HashOutput<OUTPUT_SIZE>,
+        right: &HashOutput<OUTPUT_SIZE>,
+    ) -> HashOutput<OUTPUT_SIZE> {
         // prepend a 0x01 byte to the data before hashing internal nodes
         let mut hasher = H::new();
         hasher.update(&[0x01]);
         hasher.update(&left.0);
         hasher.update(&right.0);
-        HashOutput(hasher.finalize())
+        let mut digest = [0u8; OUTPUT_SIZE];
+        hasher.digest(&mut digest);
+        HashOutput(digest)
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -350,15 +386,14 @@ mod tests {
             }
         }
 
-        fn update(&mut self, data: &[u8]) {
+        fn update(&mut self, data: &[u8]) -> &mut Self {
             self.hasher.update(data);
+            self
         }
 
-        fn finalize(self) -> [u8; 32] {
+        fn digest(self, out: &mut [u8; 32]) {
             let result = self.hasher.finalize();
-            let mut hash = [0u8; 32];
-            hash.copy_from_slice(&result);
-            hash
+            out.copy_from_slice(&result);
         }
     }
 
@@ -373,79 +408,87 @@ mod tests {
     fn test_out_of_bounds_proof_generation() {
         let data = generate_test_data(3);
         let ma = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::new(data.clone());
-    
+
         // Trying to prove an element at an out-of-bounds index should return an error
         assert!(ma.prove(3).is_err());
     }
-    
+
     #[test]
     fn test_out_of_bounds_update() {
         let data = generate_test_data(3);
         let mut ma = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::new(data.clone());
-    
+
         // Trying to update an element at an out-of-bounds index should return an error
         assert!(ma.update(3, b"new_data".to_vec()).is_err());
     }
-    
+
     #[test]
     fn test_verify_incorrect_proof() {
         let data = generate_test_data(4);
-    
+
         let ma = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::new(data.clone());
         let root = ma.root();
-    
+
         // Generate a proof for one element and try to verify it with another
         let proof = ma.prove(0).unwrap();
-        assert!(!MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(
-            &root,
-            &proof,
-            &data[1],
-            1,
-            data.len()
-        ));
+        assert!(
+            !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(
+                &root,
+                &proof,
+                &data[1],
+                1,
+                data.len()
+            )
+        );
     }
-    
+
     #[test]
     fn test_update_proof_with_incorrect_values() {
         let data = generate_test_data(4);
-    
+
         let mut ma = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::new(data.clone());
         let old_root = ma.root();
-    
+
         // Update an element
         let new_data = b"new_data".to_vec();
         let update_proof = ma.update(2, new_data.clone()).unwrap();
         let new_root = ma.root();
-    
+
         // Verify update proof is false with incorrect old root
-        assert!(!MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
-            &old_root, // Incorrect old root
-            &update_proof,
-            &data[2],
-            &new_data,
-            2,
-            data.len()
-        ));
+        assert!(
+            !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
+                &old_root, // Incorrect old root
+                &update_proof,
+                &data[2],
+                &new_data,
+                2,
+                data.len()
+            )
+        );
 
         // Verify update proof is false with incorrect old value
-        assert!(!MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
-            &new_root,
-            &update_proof,
-            &data[0], // Incorrect old value
-            &new_data,
-            2,
-            data.len()
-        ));
-    
+        assert!(
+            !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
+                &new_root,
+                &update_proof,
+                &data[0], // Incorrect old value
+                &new_data,
+                2,
+                data.len()
+            )
+        );
+
         // Verify update proof is false with incorrect new value
-        assert!(!MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
-            &new_root,
-            &update_proof,
-            &data[2],
-            &data[0], // Incorrect new value
-            2,
-            data.len()
-        ));
+        assert!(
+            !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
+                &new_root,
+                &update_proof,
+                &data[2],
+                &data[0], // Incorrect new value
+                2,
+                data.len()
+            )
+        );
     }
 
     #[test]
@@ -462,7 +505,15 @@ mod tests {
         let root = ma.root();
 
         let proof = ma.prove(2).unwrap();
-        assert!(MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(&root, &proof, &data[2], 2, data.len()));
+        assert!(
+            MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(
+                &root,
+                &proof,
+                &data[2],
+                2,
+                data.len()
+            )
+        );
 
         // Update an element and check if root changes
         let new_data = b"new_data".to_vec();
@@ -471,25 +522,37 @@ mod tests {
         assert_ne!(root, new_root);
 
         let new_proof = ma.prove(2).unwrap();
-        assert!(MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(&new_root, &new_proof, &new_data, 2, data.len()));
+        assert!(
+            MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(
+                &new_root,
+                &new_proof,
+                &new_data,
+                2,
+                data.len()
+            )
+        );
 
         // Verify the update proof
-        assert!(MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
-            &new_root,
-            &update_proof,
-            &data[2],
-            &new_data,
-            2,
-            data.len()
-        ));
+        assert!(
+            MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
+                &new_root,
+                &update_proof,
+                &data[2],
+                &new_data,
+                2,
+                data.len()
+            )
+        );
 
         // Test that serializing/deserializing inclusion proofs and update proofs works
         let serialized_proof: Vec<u8> = postcard::to_allocvec(&proof).unwrap();
-        let deserialized_proof: Vec<HashOutput<32>> = postcard::from_bytes(&serialized_proof).unwrap();
+        let deserialized_proof: Vec<HashOutput<32>> =
+            postcard::from_bytes(&serialized_proof).unwrap();
         assert_eq!(proof, deserialized_proof);
 
         let serialized_update_proof = postcard::to_allocvec(&update_proof).unwrap();
-        let deserialized_update_proof: (Vec<HashOutput<32>>, Vec<u8>) = postcard::from_bytes(&serialized_update_proof).unwrap();
+        let deserialized_update_proof: (Vec<HashOutput<32>>, Vec<u8>) =
+            postcard::from_bytes(&serialized_update_proof).unwrap();
         assert_eq!(update_proof, deserialized_update_proof);
     }
 }

--- a/common/src/client_commands.rs
+++ b/common/src/client_commands.rs
@@ -59,11 +59,14 @@ pub trait Message: Sized {
 #[repr(u8)]
 pub enum ClientCommandCode {
     GetPage = 0,
-    CommitPage = 1,
-    CommitPageContent = 2,
-    SendBuffer = 3,
-    ReceiveBuffer = 4,
-    SendPanicBuffer = 5,
+    GetPageProof = 1,
+    GetPageProofContinued = 2,
+    CommitPage = 3,
+    CommitPageContent = 4,
+    CommitPageProofContinued = 5,
+    SendBuffer = 6,
+    ReceiveBuffer = 7,
+    SendPanicBuffer = 8,
 }
 
 impl TryFrom<u8> for ClientCommandCode {
@@ -72,11 +75,14 @@ impl TryFrom<u8> for ClientCommandCode {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(ClientCommandCode::GetPage),
-            1 => Ok(ClientCommandCode::CommitPage),
-            2 => Ok(ClientCommandCode::CommitPageContent),
-            3 => Ok(ClientCommandCode::SendBuffer),
-            4 => Ok(ClientCommandCode::ReceiveBuffer),
-            5 => Ok(ClientCommandCode::SendPanicBuffer),
+            1 => Ok(ClientCommandCode::GetPageProof),
+            2 => Ok(ClientCommandCode::GetPageProofContinued),
+            3 => Ok(ClientCommandCode::CommitPage),
+            4 => Ok(ClientCommandCode::CommitPageContent),
+            5 => Ok(ClientCommandCode::CommitPageProofContinued),
+            6 => Ok(ClientCommandCode::SendBuffer),
+            7 => Ok(ClientCommandCode::ReceiveBuffer),
+            8 => Ok(ClientCommandCode::SendPanicBuffer),
             _ => Err("Invalid value for ClientCommandCode"),
         }
     }
@@ -104,6 +110,209 @@ impl TryFrom<u8> for SectionKind {
 }
 
 // We use the _Message ending for messages from the VM to the host, and the _Response ending for messages from the host to the VM.
+
+/// Message sent by the VM to request a page from the host
+#[derive(Debug, Clone)]
+pub struct GetPageMessage {
+    pub command_code: ClientCommandCode,
+    pub section_kind: SectionKind,
+    pub page_index: u32,
+}
+
+impl GetPageMessage {
+    #[inline]
+    pub fn new(section_kind: SectionKind, page_index: u32) -> Self {
+        GetPageMessage {
+            command_code: ClientCommandCode::GetPage,
+            section_kind,
+            page_index,
+        }
+    }
+}
+
+impl Message for GetPageMessage {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.command_code as u8]);
+        f(&[self.section_kind as u8]);
+        f(&self.page_index.to_be_bytes());
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() != 6 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let command_code = ClientCommandCode::try_from(data[0])
+            .map_err(|_| MessageDeserializationError::InvalidClientCommandCode)?;
+        if !matches!(command_code, ClientCommandCode::GetPage) {
+            return Err(MessageDeserializationError::MismatchingClientCommandCode);
+        }
+        let section_kind = SectionKind::try_from(data[1])
+            .map_err(|_| MessageDeserializationError::InvalidSectionKind)?;
+        let page_index = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
+
+        Ok(GetPageMessage {
+            command_code,
+            section_kind,
+            page_index,
+        })
+    }
+}
+
+/// Message sent by the VM to request a proof after getting a page
+#[derive(Debug, Clone)]
+pub struct GetPageProofMessage {
+    pub command_code: ClientCommandCode,
+}
+
+impl GetPageProofMessage {
+    #[inline]
+    pub fn new() -> Self {
+        GetPageProofMessage {
+            command_code: ClientCommandCode::GetPageProof,
+        }
+    }
+}
+
+impl Message for GetPageProofMessage {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.command_code as u8]);
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() != 1 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let command_code = ClientCommandCode::try_from(data[0])
+            .map_err(|_| MessageDeserializationError::InvalidClientCommandCode)?;
+        if !matches!(command_code, ClientCommandCode::GetPageProof) {
+            return Err(MessageDeserializationError::MismatchingClientCommandCode);
+        }
+
+        Ok(GetPageProofMessage { command_code })
+    }
+}
+
+/// Message sent by client in response to the VM's GetPageProofMessage
+#[derive(Debug, Clone)]
+pub struct GetPageProofResponse {
+    pub n: u8,                // number of element in the proof
+    pub t: u8,                // number of proof elements in this message
+    pub proof: Vec<[u8; 32]>, // hashes of the proof
+}
+
+impl GetPageProofResponse {
+    #[inline]
+    pub fn new(n: u8, t: u8, proof: Vec<[u8; 32]>) -> Self {
+        GetPageProofResponse { n, t, proof }
+    }
+}
+
+impl Message for GetPageProofResponse {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.n]);
+        f(&[self.t]);
+        for p in &self.proof {
+            f(p);
+        }
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() < 2 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let n = data[0];
+        let t = data[1];
+        let proof = data[2..]
+            .chunks_exact(32)
+            .map(|chunk| {
+                let mut arr = [0; 32];
+                arr.copy_from_slice(chunk);
+                arr
+            })
+            .collect();
+
+        Ok(GetPageProofResponse { n, t, proof })
+    }
+}
+
+/// Message sent by the VM to request the rest of the proof, if it didn't fit
+/// in a single GetPageProofResponse
+#[derive(Debug, Clone)]
+pub struct GetPageProofContinuedMessage {
+    pub command_code: ClientCommandCode,
+}
+
+impl GetPageProofContinuedMessage {
+    #[inline]
+    pub fn new() -> Self {
+        GetPageProofContinuedMessage {
+            command_code: ClientCommandCode::GetPageProofContinued,
+        }
+    }
+}
+
+impl Message for GetPageProofContinuedMessage {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.command_code as u8]);
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() != 1 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let command_code = ClientCommandCode::try_from(data[0])
+            .map_err(|_| MessageDeserializationError::InvalidClientCommandCode)?;
+        if !matches!(command_code, ClientCommandCode::GetPageProofContinued) {
+            return Err(MessageDeserializationError::MismatchingClientCommandCode);
+        }
+
+        Ok(GetPageProofContinuedMessage { command_code })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetPageProofContinuedResponse {
+    pub t: u8,                // number of proof elements in this message
+    pub proof: Vec<[u8; 32]>, // hashes of the proof
+}
+
+impl GetPageProofContinuedResponse {
+    #[inline]
+    pub fn new(t: u8, proof: Vec<[u8; 32]>) -> Self {
+        GetPageProofContinuedResponse { t, proof }
+    }
+}
+
+impl Message for GetPageProofContinuedResponse {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.t]);
+        for p in &self.proof {
+            f(p);
+        }
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() < 1 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let t = data[0];
+        let proof = data[1..]
+            .chunks_exact(32)
+            .map(|chunk| {
+                let mut arr = [0; 32];
+                arr.copy_from_slice(chunk);
+                arr
+            })
+            .collect();
+
+        Ok(GetPageProofContinuedResponse { t, proof })
+    }
+}
 
 /// Message sent by the VM to commit a page to the host
 #[derive(Debug, Clone)]
@@ -198,51 +407,123 @@ impl Message for CommitPageContentMessage {
     }
 }
 
-/// Message sent by the VM to request a page from the host
+/// Message sent by client in response to the VM's CommitPageContentMessage
 #[derive(Debug, Clone)]
-pub struct GetPageMessage {
-    pub command_code: ClientCommandCode,
-    pub section_kind: SectionKind,
-    pub page_index: u32,
+pub struct CommitPageProofResponse {
+    pub n: u8,                // number of element in the proof
+    pub t: u8,                // number of proof elements in this message
+    pub proof: Vec<[u8; 32]>, // hashes of the proof
 }
 
-impl GetPageMessage {
+impl CommitPageProofResponse {
     #[inline]
-    pub fn new(section_kind: SectionKind, page_index: u32) -> Self {
-        GetPageMessage {
-            command_code: ClientCommandCode::GetPage,
-            section_kind,
-            page_index,
+    pub fn new(n: u8, t: u8, proof: Vec<[u8; 32]>) -> Self {
+        CommitPageProofResponse { n, t, proof }
+    }
+}
+
+impl Message for CommitPageProofResponse {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.n]);
+        f(&[self.t]);
+        for p in &self.proof {
+            f(p);
+        }
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() < 2 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let n = data[0];
+        let t = data[1];
+        let proof = data[2..]
+            .chunks_exact(32)
+            .map(|chunk| {
+                let mut arr = [0; 32];
+                arr.copy_from_slice(chunk);
+                arr
+            })
+            .collect();
+
+        Ok(CommitPageProofResponse { n, t, proof })
+    }
+}
+
+/// Message sent by the VM to request the rest of the proof, if it didn't fit
+/// in a single CommitPageProofResponse
+#[derive(Debug, Clone)]
+pub struct CommitPageProofContinuedMessage {
+    pub command_code: ClientCommandCode,
+}
+
+impl CommitPageProofContinuedMessage {
+    #[inline]
+    pub fn new() -> Self {
+        CommitPageProofContinuedMessage {
+            command_code: ClientCommandCode::CommitPageProofContinued,
         }
     }
 }
 
-impl Message for GetPageMessage {
+impl Message for CommitPageProofContinuedMessage {
     #[inline]
     fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
         f(&[self.command_code as u8]);
-        f(&[self.section_kind as u8]);
-        f(&self.page_index.to_be_bytes());
     }
 
     fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
-        if data.len() != 6 {
+        if data.len() != 1 {
             return Err(MessageDeserializationError::InvalidDataLength);
         }
         let command_code = ClientCommandCode::try_from(data[0])
             .map_err(|_| MessageDeserializationError::InvalidClientCommandCode)?;
-        if !matches!(command_code, ClientCommandCode::GetPage) {
+        if !matches!(command_code, ClientCommandCode::CommitPageProofContinued) {
             return Err(MessageDeserializationError::MismatchingClientCommandCode);
         }
-        let section_kind = SectionKind::try_from(data[1])
-            .map_err(|_| MessageDeserializationError::InvalidSectionKind)?;
-        let page_index = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
 
-        Ok(GetPageMessage {
-            command_code,
-            section_kind,
-            page_index,
-        })
+        Ok(CommitPageProofContinuedMessage { command_code })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CommitPageProofContinuedResponse {
+    pub t: u8,                // number of proof elements in this message
+    pub proof: Vec<[u8; 32]>, // hashes of the proof
+}
+
+impl CommitPageProofContinuedResponse {
+    #[inline]
+    pub fn new(t: u8, proof: Vec<[u8; 32]>) -> Self {
+        CommitPageProofContinuedResponse { t, proof }
+    }
+}
+
+impl Message for CommitPageProofContinuedResponse {
+    #[inline]
+    fn serialize_with<F: FnMut(&[u8])>(&self, mut f: F) {
+        f(&[self.t]);
+        for p in &self.proof {
+            f(p);
+        }
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, MessageDeserializationError> {
+        if data.len() < 1 {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+        let t = data[0];
+        let proof = data[1..]
+            .chunks_exact(32)
+            .map(|chunk| {
+                let mut arr = [0; 32];
+                arr.copy_from_slice(chunk);
+                arr
+            })
+            .collect();
+
+        Ok(CommitPageProofContinuedResponse { t, proof })
     }
 }
 

--- a/common/src/manifest.rs
+++ b/common/src/manifest.rs
@@ -96,14 +96,14 @@ impl Manifest {
 
     #[inline]
     pub fn n_code_pages(&self) -> u32 {
-        (self.code_end - self.code_start + (PAGE_SIZE as u32) - 1) / (PAGE_SIZE as u32)
+        (self.code_end - self.code_start).div_ceil(PAGE_SIZE as u32)
     }
     #[inline]
     pub fn n_data_pages(&self) -> u32 {
-        (self.data_end - self.data_start + (PAGE_SIZE as u32) - 1) / (PAGE_SIZE as u32)
+        (self.data_end - self.data_start).div_ceil(PAGE_SIZE as u32)
     }
     #[inline]
     pub fn n_stack_pages(&self) -> u32 {
-        (self.stack_end - self.stack_start + (PAGE_SIZE as u32) - 1) / (PAGE_SIZE as u32)
+        (self.stack_end - self.stack_start).div_ceil(PAGE_SIZE as u32)
     }
 }

--- a/common/src/manifest.rs
+++ b/common/src/manifest.rs
@@ -1,5 +1,7 @@
 use serde::{self, Deserialize, Serialize};
 
+use crate::constants::PAGE_SIZE;
+
 const APP_NAME_LEN: usize = 32; // Define a suitable length
 const APP_VERSION_LEN: usize = 32; // Define a suitable length
 
@@ -15,12 +17,13 @@ pub struct Manifest {
     pub bss: u32,
     pub code_start: u32,
     pub code_end: u32,
+    pub code_merkle_root: [u8; 32],
     pub stack_start: u32,
     pub stack_end: u32,
+    pub stack_merkle_root: [u8; 32],
     pub data_start: u32,
     pub data_end: u32,
-    pub mt_root_hash: [u8; 32],
-    pub mt_size: u32,
+    pub data_merkle_root: [u8; 32],
 }
 
 impl Manifest {
@@ -34,12 +37,13 @@ impl Manifest {
         bss: u32,
         code_start: u32,
         code_end: u32,
+        code_merkle_root: [u8; 32],
         stack_start: u32,
         stack_end: u32,
+        stack_merkle_root: [u8; 32],
         data_start: u32,
         data_end: u32,
-        mt_root_hash: [u8; 32],
-        mt_size: u32,
+        data_merkle_root: [u8; 32],
     ) -> Result<Self, &'static str> {
         if app_name.len() > APP_NAME_LEN {
             return Err("app_name is too long");
@@ -66,12 +70,13 @@ impl Manifest {
             bss,
             code_start,
             code_end,
+            code_merkle_root,
             stack_start,
             stack_end,
+            stack_merkle_root,
             data_start,
             data_end,
-            mt_root_hash,
-            mt_size,
+            data_merkle_root,
         })
     }
 
@@ -87,5 +92,18 @@ impl Manifest {
             &self.app_version[..self.app_version.iter().position(|&c| c == 0).unwrap_or(32)],
         )
         .unwrap() // doesn't fail, as the new() function creates it from a valid string
+    }
+
+    #[inline]
+    pub fn n_code_pages(&self) -> u32 {
+        (self.code_end - self.code_start + (PAGE_SIZE as u32) - 1) / (PAGE_SIZE as u32)
+    }
+    #[inline]
+    pub fn n_data_pages(&self) -> u32 {
+        (self.data_end - self.data_start + (PAGE_SIZE as u32) - 1) / (PAGE_SIZE as u32)
+    }
+    #[inline]
+    pub fn n_stack_pages(&self) -> u32 {
+        (self.stack_end - self.stack_start + (PAGE_SIZE as u32) - 1) / (PAGE_SIZE as u32)
     }
 }

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -1,11 +1,16 @@
 use core::cell::RefCell;
 
 use alloc::{rc::Rc, vec, vec::Vec};
+use common::accumulator::{HashOutput, Hasher, MerkleAccumulator, VectorAccumulator};
 use common::vm::{Page, PagedMemory};
+use ledger_device_sdk::hash::HashInit;
 use ledger_device_sdk::io;
 
 use common::client_commands::{
-    CommitPageContentMessage, CommitPageMessage, GetPageMessage, Message, SectionKind,
+    CommitPageContentMessage, CommitPageMessage, CommitPageProofContinuedMessage,
+    CommitPageProofContinuedResponse, CommitPageProofResponse, GetPageMessage,
+    GetPageProofContinuedMessage, GetPageProofContinuedResponse, GetPageProofMessage,
+    GetPageProofResponse, Message, SectionKind,
 };
 use common::constants::PAGE_SIZE;
 
@@ -13,10 +18,11 @@ use crate::{AppSW, Instruction};
 
 #[derive(Clone, Debug)]
 struct CachedPage {
-    idx: u32,           // Page index
-    page: Page,         // Page data
-    usage_counter: u32, // For LRU tracking
-    valid: bool,        // Indicates if the slot contains a valid page
+    idx: u32,                  // Page index
+    page: Page,                // Page data
+    page_hash: HashOutput<32>, // Hash of the page data when loaded (before any changes)
+    usage_counter: u32,        // For LRU tracking
+    valid: bool,               // Indicates if the slot contains a valid page
 }
 
 impl Default for CachedPage {
@@ -26,33 +32,10 @@ impl Default for CachedPage {
             page: Page {
                 data: [0; PAGE_SIZE],
             },
+            page_hash: [0; 32].into(),
             usage_counter: 0,
             valid: false,
         }
-    }
-}
-
-pub struct OutsourcedMemory<'c> {
-    comm: Rc<RefCell<&'c mut io::Comm>>,
-    pages: Vec<CachedPage>,
-    is_readonly: bool,
-    section_kind: SectionKind,
-    usage_counter: u32,
-    #[cfg(feature = "metrics")]
-    pub n_page_loads: usize,
-    #[cfg(feature = "metrics")]
-    pub n_page_commits: usize,
-}
-
-impl<'c> core::fmt::Debug for OutsourcedMemory<'c> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OutsourcedMemory")
-            .field("comm", &"...")
-            .field("pages", &self.pages)
-            .field("is_readonly", &self.is_readonly)
-            .field("section_kind", &self.section_kind)
-            .field("usage_counter", &self.usage_counter)
-            .finish()
     }
 }
 
@@ -132,17 +115,62 @@ where
     }
 }
 
+struct Sha256Hasher(ledger_device_sdk::hash::sha2::Sha2_256);
+impl Hasher<32> for Sha256Hasher {
+    fn new() -> Self {
+        Self(ledger_device_sdk::hash::sha2::Sha2_256::new())
+    }
+
+    fn update(&mut self, data: &[u8]) -> &mut Self {
+        self.0.update(data).unwrap();
+        self
+    }
+
+    fn digest(mut self, out: &mut [u8; 32]) {
+        self.0.finalize(out).unwrap();
+    }
+}
+
+pub struct OutsourcedMemory<'c> {
+    comm: Rc<RefCell<&'c mut io::Comm>>,
+    cached_pages: Vec<CachedPage>,
+    n_pages: u32,
+    merkle_root: HashOutput<32>,
+    is_readonly: bool,
+    section_kind: SectionKind,
+    usage_counter: u32,
+    #[cfg(feature = "metrics")]
+    pub n_page_loads: usize,
+    #[cfg(feature = "metrics")]
+    pub n_page_commits: usize,
+}
+
+impl<'c> core::fmt::Debug for OutsourcedMemory<'c> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OutsourcedMemory")
+            .field("comm", &"...")
+            .field("cached_pages", &self.cached_pages)
+            .field("is_readonly", &self.is_readonly)
+            .field("section_kind", &self.section_kind)
+            .field("usage_counter", &self.usage_counter)
+            .finish()
+    }
+}
+
 impl<'c> OutsourcedMemory<'c> {
     pub fn new(
         comm: Rc<RefCell<&'c mut io::Comm>>,
-        max_pages: usize,
+        max_pages_in_cache: usize,
         is_readonly: bool,
         section_kind: SectionKind,
+        n_pages: u32,
+        merkle_root: HashOutput<32>,
     ) -> Self {
-        let pages = vec![CachedPage::default(); max_pages];
         Self {
             comm,
-            pages,
+            cached_pages: vec![CachedPage::default(); max_pages_in_cache],
+            n_pages,
+            merkle_root,
             is_readonly,
             section_kind,
             usage_counter: 0,
@@ -154,8 +182,10 @@ impl<'c> OutsourcedMemory<'c> {
     }
 
     fn commit_page_at(&mut self, index: usize) -> Result<(), common::vm::MemoryError> {
-        let page = &self.pages[index];
-        assert!(page.valid, "Trying to commit an invalid page");
+        let cached_page = &self.cached_pages[index];
+        assert!(cached_page.valid, "Trying to commit an invalid page");
+
+        let page_hash_old = &cached_page.page_hash;
 
         #[cfg(feature = "metrics")]
         {
@@ -163,7 +193,7 @@ impl<'c> OutsourcedMemory<'c> {
         }
 
         let mut comm = self.comm.borrow_mut();
-        CommitPageMessage::new(self.section_kind, page.idx).serialize_to_comm(&mut comm);
+        CommitPageMessage::new(self.section_kind, cached_page.idx).serialize_to_comm(&mut comm);
 
         let Instruction::Continue(p1, p2) = io_exchange(&mut comm, AppSW::InterruptedExecution)
         else {
@@ -175,8 +205,8 @@ impl<'c> OutsourcedMemory<'c> {
             return Err(common::vm::MemoryError::GenericError("Wrong P1/P2"));
         }
 
-        // Second message: communicate the page content
-        CommitPageContentMessage::new(page.page.data.to_vec()).serialize_to_comm(&mut comm);
+        // Second message: communicate the updated page content
+        CommitPageContentMessage::new(cached_page.page.data.to_vec()).serialize_to_comm(&mut comm);
 
         let Instruction::Continue(p1, p2) = io_exchange(&mut comm, AppSW::InterruptedExecution)
         else {
@@ -187,11 +217,85 @@ impl<'c> OutsourcedMemory<'c> {
         if (p1, p2) != (0, 0) {
             return Err(common::vm::MemoryError::GenericError("Wrong P1/P2"));
         }
+
+        // Decode the proof
+        let proof_data = comm.get_data().map_err(|_| {
+            common::vm::MemoryError::GenericError("Wrong APDU length in proof response")
+        })?;
+
+        let proof_response = CommitPageProofResponse::deserialize(&proof_data)
+            .map_err(|_| common::vm::MemoryError::GenericError("Invalid proof data"))?;
+
+        let n = proof_response.n; // Total number of elements in the proof
+        let mut proof_elements = proof_response.proof;
+        let new_root: HashOutput<32> = proof_response.new_root.into();
+
+        // If we need more elements, request them
+        while proof_elements.len() < n as usize {
+            CommitPageProofContinuedMessage::new().serialize_to_comm(&mut comm);
+
+            let Instruction::Continue(p1, p2) = io_exchange(&mut comm, AppSW::InterruptedExecution)
+            else {
+                return Err(common::vm::MemoryError::GenericError(
+                    "INS not supported during continued proof request",
+                ));
+            };
+
+            if (p1, p2) != (0, 0) {
+                return Err(common::vm::MemoryError::GenericError(
+                    "Wrong P1/P2 in continued proof response",
+                ));
+            }
+
+            let continued_proof_data = comm.get_data().map_err(|_| {
+                common::vm::MemoryError::GenericError(
+                    "Wrong APDU length in continued proof response",
+                )
+            })?;
+
+            let continued_response = CommitPageProofContinuedResponse::deserialize(
+                &continued_proof_data,
+            )
+            .map_err(|_| common::vm::MemoryError::GenericError("Invalid continued proof data"))?;
+
+            proof_elements.extend_from_slice(&continued_response.proof);
+        }
+
+        // Convert proof elements to HashOutput format
+        let proof_elements: Vec<HashOutput<32>> =
+            proof_elements.into_iter().map(Into::into).collect();
+
+        // Create update proof (InclusionProof, new_root)
+        let update_proof = (proof_elements, new_root.clone());
+
+        // Calculate hashes for verification
+        let new_page_hash =
+            MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::hash_element(&cached_page.page.data);
+
+        // Verify the update proof
+        if !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
+            &self.merkle_root,
+            &update_proof,
+            page_hash_old,
+            &new_page_hash,
+            cached_page.idx as usize,
+            self.n_pages as usize,
+        ) {
+            return Err(common::vm::MemoryError::GenericError(
+                "Merkle update verification failed",
+            ));
+        }
+
+        // Update the root to the new root
+        self.merkle_root = new_root;
 
         Ok(())
     }
 
-    fn load_page(&mut self, page_index: u32) -> Result<Page, common::vm::MemoryError> {
+    fn load_page(
+        &mut self,
+        page_index: u32,
+    ) -> Result<(Page, HashOutput<32>), common::vm::MemoryError> {
         #[cfg(feature = "metrics")]
         {
             self.n_page_loads += 1;
@@ -221,7 +325,84 @@ impl<'c> OutsourcedMemory<'c> {
         data[0..PAGE_SIZE - 1].copy_from_slice(&fetched_data);
         data[PAGE_SIZE - 1] = p1;
 
-        Ok(Page { data })
+        // Request the Merkle proof for the page
+        GetPageProofMessage::new().serialize_to_comm(&mut comm);
+
+        let Instruction::Continue(p1, p2) = io_exchange(&mut comm, AppSW::InterruptedExecution)
+        else {
+            return Err(common::vm::MemoryError::GenericError(
+                "INS not supported during proof request",
+            ));
+        };
+
+        if (p1, p2) != (0, 0) {
+            return Err(common::vm::MemoryError::GenericError(
+                "Wrong P1/P2 in proof response",
+            ));
+        }
+
+        // Decode the proof
+        let proof_data = comm.get_data().map_err(|_| {
+            common::vm::MemoryError::GenericError("Wrong APDU length in proof response")
+        })?;
+
+        let proof_response = GetPageProofResponse::deserialize(&proof_data)
+            .map_err(|_| common::vm::MemoryError::GenericError("Invalid proof data"))?;
+
+        let n = proof_response.n; // Total number of elements in the proof
+        let mut proof_elements = proof_response.proof;
+
+        // If we need more elements, request them
+        while proof_elements.len() < n as usize {
+            GetPageProofContinuedMessage::new().serialize_to_comm(&mut comm);
+
+            let Instruction::Continue(p1, p2) = io_exchange(&mut comm, AppSW::InterruptedExecution)
+            else {
+                return Err(common::vm::MemoryError::GenericError(
+                    "INS not supported during continued proof request",
+                ));
+            };
+
+            if (p1, p2) != (0, 0) {
+                return Err(common::vm::MemoryError::GenericError(
+                    "Wrong P1/P2 in continued proof response",
+                ));
+            }
+
+            let continued_proof_data = comm.get_data().map_err(|_| {
+                common::vm::MemoryError::GenericError(
+                    "Wrong APDU length in continued proof response",
+                )
+            })?;
+
+            let continued_response = GetPageProofContinuedResponse::deserialize(
+                &continued_proof_data,
+            )
+            .map_err(|_| common::vm::MemoryError::GenericError("Invalid continued proof data"))?;
+
+            proof_elements.extend_from_slice(&continued_response.proof);
+        }
+
+        // Verify the Merkle proof
+        let proof_elements: Vec<HashOutput<32>> =
+            proof_elements.into_iter().map(Into::into).collect();
+
+        let page = Page { data };
+        let page_hash = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::hash_element(&page.data);
+
+        if !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(
+            &self.merkle_root,
+            &proof_elements,
+            &page_hash,
+            page_index as usize,
+            self.n_pages as usize,
+        ) {
+            return Err(common::vm::MemoryError::GenericError(
+                "Merkle inclusion verification failed",
+            ));
+        }
+
+        Ok((Page { data }, page_hash))
     }
 }
 
@@ -236,21 +417,21 @@ impl<'c> PagedMemory for OutsourcedMemory<'c> {
         self.usage_counter = self.usage_counter.wrapping_add(1);
 
         // Search for the page in cache
-        for i in 0..self.pages.len() {
-            if self.pages[i].valid && self.pages[i].idx == page_index {
+        for i in 0..self.cached_pages.len() {
+            if self.cached_pages[i].valid && self.cached_pages[i].idx == page_index {
                 // Update usage_counter for LRU
-                self.pages[i].usage_counter = self.usage_counter;
+                self.cached_pages[i].usage_counter = self.usage_counter;
 
                 // Return mutable reference to the page
-                return Ok(&mut self.pages[i].page);
+                return Ok(&mut self.cached_pages[i].page);
             }
         }
 
         // Page not found in cache
         // Find a free slot
         let mut slot: Option<usize> = None;
-        for i in 0..self.pages.len() {
-            if !self.pages[i].valid {
+        for i in 0..self.cached_pages.len() {
+            if !self.cached_pages[i].valid {
                 slot = Some(i);
                 break;
             }
@@ -260,9 +441,9 @@ impl<'c> PagedMemory for OutsourcedMemory<'c> {
         if slot.is_none() {
             let mut oldest_usage = u32::MAX;
             let mut evict_index = 0;
-            for i in 0..self.pages.len() {
-                if self.pages[i].usage_counter < oldest_usage {
-                    oldest_usage = self.pages[i].usage_counter;
+            for i in 0..self.cached_pages.len() {
+                if self.cached_pages[i].usage_counter < oldest_usage {
+                    oldest_usage = self.cached_pages[i].usage_counter;
                     evict_index = i;
                 }
             }
@@ -273,22 +454,23 @@ impl<'c> PagedMemory for OutsourcedMemory<'c> {
             }
 
             // Invalidate the evicted page
-            self.pages[evict_index].valid = false;
+            self.cached_pages[evict_index].valid = false;
             slot = Some(evict_index);
         }
 
         let slot = slot.unwrap();
 
         // Load the page into the slot
-        let page_data = self.load_page(page_index)?;
-        self.pages[slot] = CachedPage {
+        let (page_data, page_hash) = self.load_page(page_index)?;
+        self.cached_pages[slot] = CachedPage {
             idx: page_index,
             page: page_data,
+            page_hash,
             usage_counter: self.usage_counter,
             valid: true,
         };
 
         // Return mutable reference to the page
-        Ok(&mut self.pages[slot].page)
+        Ok(&mut self.cached_pages[slot].page)
     }
 }

--- a/vm/src/handlers/start_vapp.rs
+++ b/vm/src/handlers/start_vapp.rs
@@ -32,7 +32,14 @@ pub fn handler_start_vapp(comm: &mut io::Comm) -> Result<Vec<u8>, AppSW> {
 
     let comm = Rc::new(RefCell::new(comm));
 
-    let mut code_mem = OutsourcedMemory::new(comm.clone(), 12, true, SectionKind::Code);
+    let mut code_mem = OutsourcedMemory::new(
+        comm.clone(),
+        12,
+        true,
+        SectionKind::Code,
+        manifest.n_code_pages(),
+        manifest.code_merkle_root.into(),
+    );
     let code_seg = MemorySegment::<OutsourcedMemory>::new(
         manifest.code_start,
         manifest.code_end - manifest.code_start,
@@ -40,7 +47,14 @@ pub fn handler_start_vapp(comm: &mut io::Comm) -> Result<Vec<u8>, AppSW> {
     )
     .unwrap();
 
-    let mut data_mem = OutsourcedMemory::new(comm.clone(), 12, false, SectionKind::Data);
+    let mut data_mem = OutsourcedMemory::new(
+        comm.clone(),
+        12,
+        false,
+        SectionKind::Data,
+        manifest.n_data_pages(),
+        manifest.data_merkle_root.into(),
+    );
     let data_seg = MemorySegment::<OutsourcedMemory>::new(
         manifest.data_start,
         manifest.data_end - manifest.data_start,
@@ -48,7 +62,14 @@ pub fn handler_start_vapp(comm: &mut io::Comm) -> Result<Vec<u8>, AppSW> {
     )
     .unwrap();
 
-    let mut stack_mem = OutsourcedMemory::new(comm.clone(), 12, false, SectionKind::Stack);
+    let mut stack_mem = OutsourcedMemory::new(
+        comm.clone(),
+        12,
+        false,
+        SectionKind::Stack,
+        manifest.n_stack_pages(),
+        manifest.stack_merkle_root.into(),
+    );
     let stack_seg = MemorySegment::<OutsourcedMemory>::new(
         manifest.stack_start,
         manifest.stack_end - manifest.stack_start,


### PR DESCRIPTION
Adds the verification of Merkle proofs for page loads (inclusion proofs) and page commits (update proofs).

The Merkle roots for the various segments at V-App startup were also added to the Manifest.

Also adds a marker to check if pages have been modified since being loaded, avoiding unnecessary page commits if a page was only read despite being in a writable segment.

Closes: #17