### PR TITLE
Manifest management and app registration

### DIFF
--- a/client-sdk/src/hash.rs
+++ b/client-sdk/src/hash.rs
@@ -1,0 +1,24 @@
+use common::accumulator::Hasher;
+use sha2::{Digest, Sha256};
+
+pub struct Sha256Hasher {
+    hasher: Sha256,
+}
+
+impl Hasher<32> for Sha256Hasher {
+    fn new() -> Self {
+        Sha256Hasher {
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn update(&mut self, data: &[u8]) -> &mut Self {
+        self.hasher.update(data);
+        self
+    }
+
+    fn digest(self, out: &mut [u8; 32]) {
+        let result = self.hasher.finalize();
+        out.copy_from_slice(&result);
+    }
+}

--- a/client-sdk/src/lib.rs
+++ b/client-sdk/src/lib.rs
@@ -1,4 +1,6 @@
 mod apdu;
+mod hash;
+
 pub mod elf;
 pub mod memory;
 

--- a/client-sdk/src/memory.rs
+++ b/client-sdk/src/memory.rs
@@ -1,34 +1,11 @@
 use common::constants::page_start;
 use common::constants::PAGE_SIZE;
 use common::vm::MemoryError;
-use sha2::{Digest, Sha256};
 use std::cmp::min;
 
-use common::accumulator::{
-    AccumulatorError, HashOutput, Hasher, MerkleAccumulator, VectorAccumulator,
-};
+use common::accumulator::{AccumulatorError, HashOutput, MerkleAccumulator, VectorAccumulator};
 
-pub struct Sha256Hasher {
-    hasher: Sha256,
-}
-
-impl Hasher<32> for Sha256Hasher {
-    fn new() -> Self {
-        Sha256Hasher {
-            hasher: Sha256::new(),
-        }
-    }
-
-    fn update(&mut self, data: &[u8]) -> &mut Self {
-        self.hasher.update(data);
-        self
-    }
-
-    fn digest(self, out: &mut [u8; 32]) {
-        let result = self.hasher.finalize();
-        out.copy_from_slice(&result);
-    }
-}
+use crate::hash::Sha256Hasher;
 
 // Serializes a page in the format expected for the content of the leaf in the MerkleAccumulator, as follows:
 // - Clear-text pages are serialized as a 0 byte, followed by 12 0 bytes, followed by PAGE_SIZE bytes (page plaintext).

--- a/common/src/manifest.rs
+++ b/common/src/manifest.rs
@@ -1,17 +1,18 @@
+use alloc::string::{String, ToString};
 use serde::{self, Deserialize, Serialize};
 
 use crate::constants::{page_start, PAGE_SIZE};
 
-const APP_NAME_LEN: usize = 32; // Define a suitable length
-const APP_VERSION_LEN: usize = 32; // Define a suitable length
+const APP_NAME_MAX_LEN: usize = 32;
+const APP_VERSION_MAX_LEN: usize = 32;
 
 // TODO: copied from vanadium-legacy without much thought; fields are subject to change
 /// The manifest contains all the required info that the application needs in order to execute a V-App.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Manifest {
     pub manifest_version: u32,
-    pub app_name: [u8; APP_NAME_LEN],
-    pub app_version: [u8; APP_VERSION_LEN],
+    pub app_name: String,
+    pub app_version: String,
     pub entrypoint: u32,
     pub code_start: u32,
     pub code_end: u32,
@@ -41,26 +42,38 @@ impl Manifest {
         stack_end: u32,
         stack_merkle_root: [u8; 32],
     ) -> Result<Self, &'static str> {
-        if app_name.len() > APP_NAME_LEN {
+        if app_name.len() > APP_NAME_MAX_LEN {
             return Err("app_name is too long");
         }
-        if app_version.len() > APP_VERSION_LEN {
+        if app_version.len() > APP_VERSION_MAX_LEN {
             return Err("app_version is too long");
         }
-
-        let mut app_name_arr = [0u8; APP_NAME_LEN];
-        let mut app_version_arr = [0u8; APP_VERSION_LEN];
-
-        let name_bytes = app_name.as_bytes();
-        let version_bytes = app_version.as_bytes();
-
-        app_name_arr[..name_bytes.len()].copy_from_slice(name_bytes);
-        app_version_arr[..version_bytes.len()].copy_from_slice(version_bytes);
+        if entrypoint < code_start || entrypoint >= code_end {
+            return Err("entrypoint must be within the code section");
+        }
+        if entrypoint % 2 != 0 {
+            return Err("entrypoint must be 2-byte aligned");
+        }
+        if !app_name.chars().all(|c| c.is_ascii_graphic() || c == ' ') {
+            return Err("app_name contains non-printable ASCII characters");
+        }
+        if !app_version
+            .chars()
+            .all(|c| c.is_ascii_graphic() || c == ' ')
+        {
+            return Err("app_version contains non-printable ASCII characters");
+        }
+        if app_name.starts_with(' ') || app_name.ends_with(' ') {
+            return Err("app_name must not start or end with a space");
+        }
+        if app_version.starts_with(' ') || app_version.ends_with(' ') {
+            return Err("app_version must not start or end with a space");
+        }
 
         Ok(Self {
             manifest_version,
-            app_name: app_name_arr,
-            app_version: app_version_arr,
+            app_name: app_name.to_string(),
+            app_version: app_version.to_string(),
             entrypoint,
             code_start,
             code_end,
@@ -75,17 +88,11 @@ impl Manifest {
     }
 
     pub fn get_app_name(&self) -> &str {
-        core::str::from_utf8(
-            &self.app_name[..self.app_name.iter().position(|&c| c == 0).unwrap_or(32)],
-        )
-        .unwrap() // doesn't fail, as the new() function creates it from a valid string
+        &self.app_name
     }
 
     pub fn get_app_version(&self) -> &str {
-        core::str::from_utf8(
-            &self.app_version[..self.app_version.iter().position(|&c| c == 0).unwrap_or(32)],
-        )
-        .unwrap() // doesn't fail, as the new() function creates it from a valid string
+        &self.app_version
     }
 
     #[inline]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -17,6 +17,7 @@ zeroize = "1.8.1"
 ledger_device_sdk = { version = "1.21.0", features = ["debug"] }
 spin = "0.9.8"
 hex-literal = "0.4.1"
+subtle = { version = "2.6.0", default-features = false }
 
 [profile.release]
 opt-level = 3

--- a/vm/src/handlers/lib/mod.rs
+++ b/vm/src/handlers/lib/mod.rs
@@ -1,2 +1,3 @@
 pub mod ecall;
 pub mod outsourced_mem;
+pub mod vapp;

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -3,7 +3,6 @@ use core::cell::RefCell;
 use alloc::{rc::Rc, vec, vec::Vec};
 use common::accumulator::{HashOutput, Hasher, MerkleAccumulator, VectorAccumulator};
 use common::vm::{Page, PagedMemory};
-use ledger_device_sdk::hash::HashInit;
 use ledger_device_sdk::io;
 
 use common::client_commands::{
@@ -15,6 +14,7 @@ use common::client_commands::{
 use common::constants::PAGE_SIZE;
 
 use crate::aes::AesCtr;
+use crate::hash::Sha256Hasher;
 use crate::{AppSW, Instruction};
 
 #[derive(Clone, Debug)]
@@ -115,25 +115,6 @@ where
         if let io::Event::Command(ins) = res {
             return ins;
         }
-    }
-}
-
-struct Sha256Hasher(ledger_device_sdk::hash::sha2::Sha2_256);
-impl Hasher<32> for Sha256Hasher {
-    #[inline]
-    fn new() -> Self {
-        Self(ledger_device_sdk::hash::sha2::Sha2_256::new())
-    }
-
-    #[inline]
-    fn update(&mut self, data: &[u8]) -> &mut Self {
-        self.0.update(data).unwrap();
-        self
-    }
-
-    #[inline]
-    fn digest(mut self, out: &mut [u8; 32]) {
-        self.0.finalize(out).unwrap();
     }
 }
 

--- a/vm/src/handlers/lib/vapp.rs
+++ b/vm/src/handlers/lib/vapp.rs
@@ -1,0 +1,22 @@
+use common::manifest::Manifest;
+use ledger_device_sdk::hmac::{self, HMACInit};
+
+use crate::hash::Sha256Hasher;
+
+/// Computes the HMAC for the V-App.
+///
+/// SECURITY: The caller is responsible for ensuring that comparisons involving the
+/// result of this function run in constant time, in order to prevent timing attacks.
+pub fn get_vapp_hmac(manifest: &Manifest) -> [u8; 32] {
+    let vapp_hash: [u8; 32] = manifest.get_vapp_hash::<Sha256Hasher, 32>();
+
+    // TODO: derive a key using SLIP-21, or otherwise initialize it elsewhere.
+    let hmac_key = [42u8; 32];
+
+    let mut sha2 = hmac::sha2::Sha2_256::new(&hmac_key);
+    sha2.update(&vapp_hash).expect("Should never fail");
+    let mut vapp_hmac = [0u8; 32];
+    sha2.finalize(&mut vapp_hmac).expect("Should never fail");
+
+    vapp_hmac
+}

--- a/vm/src/handlers/lib/vapp.rs
+++ b/vm/src/handlers/lib/vapp.rs
@@ -3,6 +3,64 @@ use ledger_device_sdk::hmac::{self, HMACInit};
 
 use crate::hash::Sha256Hasher;
 
+use ledger_device_sdk::nvm::*;
+use ledger_device_sdk::NVMData;
+
+/// Encapsulates the key used for the V-App registration.
+/// It is generated on first use, and stored in the NVM.
+pub struct VappRegistrationKey;
+
+impl Default for VappRegistrationKey {
+    fn default() -> Self {
+        VappRegistrationKey
+    }
+}
+
+// We use the initial value (all zeros) to mark the key as uninitialized.
+// We generate a new random key at first use.
+
+#[link_section = ".nvm_data"]
+static mut VAPP_REGISTRATION_KEY: NVMData<AtomicStorage<[u8; 32]>> =
+    NVMData::new(AtomicStorage::new(&[0u8; 32]));
+
+// check whether the key is all zeros with a constant time comparison
+fn is_all_zeros_ct(data: &[u8]) -> bool {
+    let mut data_or = 0u8;
+    for &byte in data.iter() {
+        data_or |= byte;
+    }
+    data_or == 0
+}
+
+impl VappRegistrationKey {
+    fn ensure_initialized() {
+        // if the key is all zeros, initialize it with 32 random bytes
+        let nvm_key = &raw mut VAPP_REGISTRATION_KEY;
+        unsafe {
+            let storage = (*nvm_key).get_mut();
+
+            // check whether the key is all zeros with a constant time comparison
+            if is_all_zeros_ct(storage.get_ref().as_slice()) {
+                let mut new_key = [0u8; 32];
+                ledger_device_sdk::random::rand_bytes(&mut new_key);
+                storage.update(&new_key);
+            }
+        }
+    }
+
+    #[inline(never)]
+    pub fn get_ref(&mut self) -> &AtomicStorage<[u8; 32]> {
+        Self::ensure_initialized();
+
+        let data = &raw const VAPP_REGISTRATION_KEY;
+        unsafe { (*data).get_ref() }
+    }
+
+    pub fn get_key(&mut self) -> &[u8; 32] {
+        self.get_ref().get_ref()
+    }
+}
+
 /// Computes the HMAC for the V-App.
 ///
 /// SECURITY: The caller is responsible for ensuring that comparisons involving the
@@ -10,10 +68,9 @@ use crate::hash::Sha256Hasher;
 pub fn get_vapp_hmac(manifest: &Manifest) -> [u8; 32] {
     let vapp_hash: [u8; 32] = manifest.get_vapp_hash::<Sha256Hasher, 32>();
 
-    // TODO: derive a key using SLIP-21, or otherwise initialize it elsewhere.
-    let hmac_key = [42u8; 32];
+    let mut vapp_key = VappRegistrationKey;
 
-    let mut sha2 = hmac::sha2::Sha2_256::new(&hmac_key);
+    let mut sha2 = hmac::sha2::Sha2_256::new(vapp_key.get_key());
     sha2.update(&vapp_hash).expect("Should never fail");
     let mut vapp_hmac = [0u8; 32];
     sha2.finalize(&mut vapp_hmac).expect("Should never fail");

--- a/vm/src/handlers/register_vapp.rs
+++ b/vm/src/handlers/register_vapp.rs
@@ -1,14 +1,28 @@
-use crate::AppSW;
+use crate::handlers::lib::vapp::get_vapp_hmac;
+use crate::{hash::Sha256Hasher, AppSW};
 use alloc::{vec, vec::Vec};
+use common::manifest::Manifest;
 use ledger_device_sdk::io;
 
 pub fn handler_register_vapp(comm: &mut io::Comm) -> Result<Vec<u8>, AppSW> {
-    let _manifest_raw = comm.get_data().map_err(|_| AppSW::WrongApduLength)?;
+    let data_raw = comm.get_data().map_err(|_| AppSW::WrongApduLength)?;
 
-    // TODO: check manifest, ask user confirmation, compute hmac
+    let (manifest, rest) =
+        postcard::take_from_bytes::<Manifest>(data_raw).map_err(|_| AppSW::IncorrectData)?;
 
-    let hmac = [0x42u8; 32];
-    comm.append(&hmac);
+    if rest.len() != 0 {
+        return Err(AppSW::IncorrectData); // extra data
+    }
+
+    let vapp_hash = manifest.get_vapp_hash::<Sha256Hasher, 32>();
+
+    // TODO: show vapp_hash to user for confirmation
+
+    crate::println!("Registering V-App with Manifest: {:?}", manifest);
+    crate::println!("V-App hash: {:?}", vapp_hash);
+
+    let vapp_hmac = get_vapp_hmac(&manifest);
+    comm.append(&vapp_hmac);
 
     Ok(vec![])
 }

--- a/vm/src/hash.rs
+++ b/vm/src/hash.rs
@@ -1,0 +1,22 @@
+use common::accumulator::Hasher;
+use ledger_device_sdk::hash::HashInit;
+
+pub struct Sha256Hasher(ledger_device_sdk::hash::sha2::Sha2_256);
+
+impl Hasher<32> for Sha256Hasher {
+    #[inline]
+    fn new() -> Self {
+        Self(ledger_device_sdk::hash::sha2::Sha2_256::new())
+    }
+
+    #[inline]
+    fn update(&mut self, data: &[u8]) -> &mut Self {
+        self.0.update(data).unwrap();
+        self
+    }
+
+    #[inline]
+    fn digest(mut self, out: &mut [u8; 32]) {
+        self.0.finalize(out).unwrap();
+    }
+}

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -21,6 +21,7 @@
 mod aes;
 mod app_ui;
 mod handlers;
+mod hash;
 
 mod settings;
 


### PR DESCRIPTION
Improves the management of the `.manifest` section added by `cargo-vnd` by making it fixed length. This avoids that changes in the manifest change the section length, which sometimes caused some failures after #106 despite the recomputation of the section.

Adds the registration of the app using HMAC-SHA256. The HMAC key is randomly generated at first use, and stored in the NVRam.

Currently, V-App registration is missing the UX and will blindly accept registering the app. Left for a separate PR so we can first do the NBGL porting of the UI code.