### PR TITLE
Add simple registration UX

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,7 @@ jobs:
     with:
       upload_app_binaries_artifact: "vanadium_binaries"
       builder: ledger-app-builder
+      cargo_ledger_build_args: "--features blind_registration"
 
   # build a custom binary for the Vanadium VM app only for the tests
   build_vanadium_app_for_tests:

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -27,6 +27,8 @@ lto = true
 default = []
 pending_review_screen = []
 
+blind_registration = [] # allows blindly registering V-Apps. Only to be used in the CI.
+
 metrics = [] # Enable collection of performance metrics during execution
 
 # Features only for speculos


### PR DESCRIPTION
Allows users to inspect app name, version and hash when registering.

Added a `blind_registration` feature to allow skipping this step in the CI.