### PR TITLE
Documentations and developer improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you are developing a V-App, adding a new folder under [apps](apps) is current
 
 Each app typically has at least a crate for the V-App, one for the client, and possibly other crates.
 
+The existing apps have a file with extension `.code-workspace` that opens all the relevant crates as a multi-root workspace.
+
 ## Vanadium developers
 
 In VSCode, opening the [vanadium.code-workspace](vanadium.code-workspace) is the most convenient way to work with this repository. This is a multi-root workspace that contains all the various crates of the Vanadium project.

--- a/README.md
+++ b/README.md
@@ -26,15 +26,23 @@ This repository is organized in a monorepo structure.
 * [app-sdk](app-sdk) <small>[<tt>riscv</tt>], no_std</small> - Vanadium V-App SDK. It is used by V-Apps to access all the system services.
 * [client-sdk](client-sdk) <small>[<tt>native</tt>]</small> - Vanadium V-App client SDK. V-App Clients use it as a base for their own client crates.
 * [common](common) <small>[<tt>arm|riscv|native</tt>], no_std</small> - Any code that is shared among two or more of the above crates.
-* [apps](apps) - Complete V-Apps, and their clients
+* [apps](apps) - Complete V-Apps, and their clients.
   * [test](apps/test) - Simple V-App to test the Vanadium VM, implementing various computational tasks.
   * [sadik](apps/sadik) - A V-App specifically designed to test the various functionality of the Vanadium V-App SDK, and particularly the ECALLs.
-  * [bitcoin](apps/bitcoin) - Grandiose things will happen here, but it's mostly empty at this stage.
-* [libs](libs) - General purpose libraries that can be used by V-Apps
-  * [bitcoin](libs/bitcoin) - A custom clone of the [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) library
+  * [bitcoin](apps/bitcoin) - A work-in-progess app for signing bitcoin transactions.
+* [libs](libs) - General purpose libraries that can be used by V-Apps.
+  * [bitcoin](libs/bitcoin) - A custom clone of the [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) library.
 
 
-In VSCode, opening the [vanadium.code-workspace](vanadium.code-workspace) is the most convenient way to work with this repository.
+## V-App developers
+
+If you are developing a V-App, adding a new folder under [apps](apps) is currently the recommended way.
+
+Each app typically has at least a crate for the V-App, one for the client, and possibly other crates.
+
+## Vanadium developers
+
+In VSCode, opening the [vanadium.code-workspace](vanadium.code-workspace) is the most convenient way to work with this repository. This is a multi-root workspace that contains all the various crates of the Vanadium project.
 
 ## License
 

--- a/apps/bitcoin/bitcoin.code-workspace
+++ b/apps/bitcoin/bitcoin.code-workspace
@@ -1,0 +1,16 @@
+{
+  "folders": [
+    {
+      "path": "app"
+    },
+    {
+      "path": "common"
+    },
+    {
+      "path": "client"
+    },
+    {
+      "path": "docs"
+    },
+  ],
+}

--- a/apps/sadik/client/tests/test_common/mod.rs
+++ b/apps/sadik/client/tests/test_common/mod.rs
@@ -17,7 +17,7 @@ pub struct TestSetup {
 impl TestSetup {
     async fn new() -> Self {
         let vanadium_binary = std::env::var("VANADIUM_BINARY")
-            .unwrap_or_else(|_| "../../../vm/build/nanos2/bin/app.elf".to_string());
+            .unwrap_or_else(|_| "../../../vm/target/flex/release/app-vanadium".to_string());
         let vapp_binary = std::env::var("VAPP_BINARY").unwrap_or_else(|_| {
             "../app/target/riscv32imc-unknown-none-elf/release/vnd-sadik".to_string()
         });

--- a/apps/sadik/sadik.code-workspace
+++ b/apps/sadik/sadik.code-workspace
@@ -1,0 +1,13 @@
+{
+  "folders": [
+    {
+      "path": "app"
+    },
+    {
+      "path": "common"
+    },
+    {
+      "path": "client"
+    },
+  ],
+}

--- a/apps/test/client/tests/common/mod.rs
+++ b/apps/test/client/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub struct TestSetup {
 impl TestSetup {
     async fn new() -> Self {
         let vanadium_binary = std::env::var("VANADIUM_BINARY")
-            .unwrap_or_else(|_| "../../../vm/build/nanos2/bin/app.elf".to_string());
+            .unwrap_or_else(|_| "../../../vm/target/flex/release/app-vanadium".to_string());
         let vapp_binary = std::env::var("VAPP_BINARY").unwrap_or_else(|_| {
             "../app/target/riscv32imc-unknown-none-elf/release/vnd-test".to_string()
         });

--- a/apps/test/test.code-workspace
+++ b/apps/test/test.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "app"
+    },
+    {
+      "path": "client"
+    },
+  ],
+}

--- a/vm/README.md
+++ b/vm/README.md
@@ -10,9 +10,22 @@ This is a boilerplate application written in Rust which can be forked to start a
 
 :warning: Nano S+ and Nano X support is in progress. For the time being, we recommend testing on the Flex and Stax targets.
 
-## Quick start guide
+# Quick start guide
 
-### With VS Code
+# Vanadium binaries
+
+You can download precompiled binaries, or compile them yourself as described below.
+
+## Precompiled binaries
+
+You can download the latest version of the binaries from GitHub by launching the `download_vanadium.sh` script in the `vm` folder:
+
+```bash
+$ cd vm
+$ bash download_vanadium.sh
+```
+
+## Build with the Ledger VS Code extension
 
 You can quickly setup a development environment on any platform (macOS, Linux or Windows) to build and test your application with [Ledger's VS Code extension](https://marketplace.visualstudio.com/items?itemName=LedgerHQ.ledger-dev-tools).
 
@@ -30,12 +43,12 @@ By using Ledger's own developer tools [Docker image](https://github.com/LedgerHQ
 
 We recommend not to run the Vanadium app from the VSCode extension. Instead, install the Speculos emulator locally.
 
-### Emulator
+## Emulator
 
-After building, you can run the app directly on the [Speculos emulator](https://github.com/LedgerHQ/speculos). For example, if you build the app for Flex:
+After downloading the binaries or building, you can run the app directly on the [Speculos emulator](https://github.com/LedgerHQ/speculos). For example, if you build the app for Flex:
 
 ```bash
-speculos build/flex/bin/app.elf
+speculos target/flex/release/app-vanadium
 ```
 
 If you use [just](https://github.com/casey/just), you can also run:

--- a/vm/download_vanadium.sh
+++ b/vm/download_vanadium.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Downloads the latest Vanadium binaries from GitHub and unzips them into the target folder,
+# in the same location as if they were built from source.
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if 'target' folder exists in the script's directory
+if [ -d "$SCRIPT_DIR/target" ]; then
+  echo "Error: 'target' folder already exists in $SCRIPT_DIR"
+  exit 1
+fi
+
+# Download the zip file to the script's directory
+curl -L -o "$SCRIPT_DIR/__vanadium_binaries_temp.zip" https://github.com/LedgerHQ/vanadium/releases/download/latest/vanadium_binaries.zip
+
+# Create target folder and unzip contents in the script's directory
+mkdir "$SCRIPT_DIR/target"
+unzip "$SCRIPT_DIR/__vanadium_binaries_temp.zip" -d "$SCRIPT_DIR/target"
+
+# Delete the zip file
+rm "$SCRIPT_DIR/__vanadium_binaries_temp.zip"

--- a/vm/justfile
+++ b/vm/justfile
@@ -1,18 +1,19 @@
 run:
-  speculos build/nanos2/bin/app.elf
+  speculos target/flex/release/app-vanadium
 
 run-nanox:
-  speculos build/nanox/bin/app.elf
+  speculos target/nanox/release/app-vanadium
 
 run-nanosplus:
-  speculos build/nanos2/bin/app.elf
+  speculos target/nanosplus/release/app-vanadium
 
 run-flex:
-  speculos build/flex/bin/app.elf
+  speculos target/flex/release/app-vanadium
 
 run-stax:
-  speculos build/stax/bin/app.elf
+  speculos target/stax/release/app-vanadium
 
+# note: the load-* commands only work after compiling with the VSCode extension
 
 load-nanosplus:
   python3 -m ledgerblue.runScript  --scp --fileName build/nanos2/bin/app.apdu --elfFile build/nanos2/bin/app.elf


### PR DESCRIPTION
Adds a bash script to download the Vanadium app binaries from github, using the release files produced in the CI after #118.
This allows people who want to just develop V-Apps to run the VM on speculos without needing all the Ledger build tools.