### PR TITLE
Add get_random_bytes ECALL

### DIFF
--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -196,6 +196,17 @@ pub(crate) trait EcallsInterface {
     /// 1 on success, 0 on error.
     fn ecfp_scalar_mult(curve: u32, r: *mut u8, p: *const u8, k: *const u8, k_len: usize) -> u32;
 
+    /// Generates `size` random bytes using a cryptographically secure random number generator,
+    /// and writes them to the provided buffer.
+    ///
+    /// # Parameters
+    /// - `buffer`: Pointer to the buffer where the random bytes will be written.
+    /// - `size`: The number of random bytes to generate.
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
+    fn get_random_bytes(buffer: *mut u8, size: usize) -> u32;
+
     /// Signs a message hash using ECDSA.
     ///
     /// # Warning

--- a/app-sdk/src/ecalls_native.rs
+++ b/app-sdk/src/ecalls_native.rs
@@ -611,6 +611,26 @@ impl EcallsInterface for Ecall {
         1
     }
 
+    fn get_random_bytes(buffer: *mut u8, size: usize) -> u32 {
+        if size == 0 {
+            return 1;
+        }
+        if size > 256 {
+            panic!("size is too large");
+        }
+
+        let mut rng = rand::rngs::OsRng::default();
+        let mut random_bytes = [0u8; 256];
+        rng.try_fill_bytes(&mut random_bytes[..size])
+            .expect("Failed to generate random bytes");
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(random_bytes.as_ptr(), buffer, size);
+        }
+
+        1
+    }
+
     fn ecdsa_sign(
         curve: u32,
         mode: u32,

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -419,6 +419,8 @@ impl EcallsInterface for Ecall {
     ecall4!(ecfp_add_point, ECALL_ECFP_ADD_POINT, (curve: u32), (r: *mut u8), (p: *const u8), (q: *const u8), u32);
     ecall5!(ecfp_scalar_mult, ECALL_ECFP_SCALAR_MULT, (curve: u32), (r: *mut u8), (p: *const u8), (k: *const u8), (k_len: usize), u32);
 
+    ecall2!(get_random_bytes, ECALL_GET_RANDOM_BYTES, (buffer: *mut u8), (size: usize), u32);
+
     ecall6!(ecdsa_sign, ECALL_ECDSA_SIGN, (curve: u32), (mode: u32), (hash_id: u32), (privkey: *const u8), (msg_hash: *const u8), (signature: *mut u8), usize);
     ecall5!(ecdsa_verify, ECALL_ECDSA_VERIFY, (curve: u32), (pubkey: *const u8), (msg_hash: *const u8), (signature: *const u8), (signature_len: usize), u32);
     ecall7!(schnorr_sign, ECALL_SCHNORR_SIGN, (curve: u32), (mode: u32), (hash_id: u32), (privkey: *const u8), (msg: *const u8), (msg_len: usize), (signature: *mut u8), usize);

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bignum;
 pub mod comm;
 pub mod curve;
 pub mod hash;
+pub mod rand;
 pub mod ux;
 
 pub use app::App;

--- a/app-sdk/src/rand.rs
+++ b/app-sdk/src/rand.rs
@@ -1,0 +1,38 @@
+use alloc::{vec, vec::Vec};
+
+use crate::{Ecall, EcallsInterface};
+
+/// Generates cryptographically secure random bytes.
+pub fn random_bytes(len: usize) -> Vec<u8> {
+    let mut bytes = vec![0u8; len];
+    // generate randomness in chunks of at most 256 bytes
+    let max_chunk_size = 256;
+    let mut offset = 0;
+    while offset < len {
+        let size = usize::min(max_chunk_size, len - offset);
+        let res = Ecall::get_random_bytes(bytes[offset..].as_mut_ptr(), size);
+        if res == 0 {
+            panic!("Failed to generate random bytes");
+        }
+        offset += size
+    }
+    bytes
+}
+
+// tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_random_bytes() {
+        let len = 64;
+        let random_bytes = random_bytes(len);
+        assert_eq!(random_bytes.len(), len);
+        // Check that every chunk of 8 bytes is not all zeroes
+        // (which would be unlikely in a reasonable random generator)
+        for chunk in random_bytes.chunks(8) {
+            assert!(!chunk.iter().all(|&b| b == 0), "Found all zeroes in chunk");
+        }
+    }
+}

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -57,6 +57,10 @@ pub const ECALL_HASH_DIGEST: u32 = 152;
 pub const ECALL_ECFP_ADD_POINT: u32 = 160;
 pub const ECALL_ECFP_SCALAR_MULT: u32 = 161;
 
+// Random number generation
+pub const ECALL_GET_RANDOM_BYTES: u32 = 170;
+
+// Signatures
 pub const ECALL_ECDSA_SIGN: u32 = 180;
 pub const ECALL_ECDSA_VERIFY: u32 = 181;
 pub const ECALL_SCHNORR_SIGN: u32 = 182;


### PR DESCRIPTION
Gives access to the randomness from the TRNG in V-Apps, or `OsRng` if compiling for the native target.