### PR TITLE
Fix usage of set_len to avoid UB

### DIFF
--- a/app-sdk/build_utils/mod.rs
+++ b/app-sdk/build_utils/mod.rs
@@ -134,9 +134,12 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                         file,
                         "
         let next_len = {};
-        let slice_content = {};
-        for i in 0..next_len {{
-            serialized[cur + i].write(slice_content[i]);
+        unsafe {{
+            core::ptr::copy_nonoverlapping(
+                {}.as_ptr(),
+                serialized[cur..].as_mut_ptr() as *mut u8,
+                next_len
+            );
         }}
         cur += next_len;",
                         vec.len(),
@@ -185,9 +188,12 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                         file,
                         "
         let next_len = {};
-        let slice_content = {};
-        for i in 0..next_len {{
-            slice[cur + i].write(slice_content[i]);
+        unsafe {{
+            core::ptr::copy_nonoverlapping(
+                {}.as_ptr(),
+                slice[cur..].as_mut_ptr() as *mut u8,
+                next_len
+            );
         }}
         cur += next_len;",
                         vec.len(),

--- a/app-sdk/build_utils/mod.rs
+++ b/app-sdk/build_utils/mod.rs
@@ -83,7 +83,10 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
             }
         }
 
+        // Note: We could use core::mem::MaybeUninit::slice_assume_init_ref, but it requires the unstable feature maybe_uninit_slice
+        // https://github.com/rust-lang/rust/issues/63569
         writeln!(file, "    let bytes = unsafe {{ core::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(&serialized[0..total_len]) }};").expect("Could not write");
+
         writeln!(file, "    show_page_raw(bytes);").expect("Could not write");
     } else {
         writeln!(file, "    let mut total_len: usize = 0;").expect("Could not write");
@@ -156,7 +159,10 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
             }
         }
 
+        // Note: We could use core::mem::MaybeUninit::slice_assume_init_ref, but it requires the unstable feature maybe_uninit_slice
+        // https://github.com/rust-lang/rust/issues/63569
         writeln!(file, "        let bytes = unsafe {{ core::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(&serialized[0..total_len]) }};").expect("Could not write");
+
         writeln!(file, "        show_page_raw(bytes);").expect("Could not write");
 
         writeln!(file, "    }} else {{").expect("Could not write");

--- a/app-sdk/build_utils/mod.rs
+++ b/app-sdk/build_utils/mod.rs
@@ -74,18 +74,17 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                     file,
                     "    let total_len: usize = {}.get_serialized_length();
     let mut serialized = Vec::<u8>::with_capacity(total_len);
-    unsafe {{
-        serialized.set_len(total_len);
-    }}
+    let slice = serialized.spare_capacity_mut();
     let mut cur: usize = 0;
-    {}.serialize(&mut serialized, &mut cur);",
+    {}.serialize(slice, &mut cur);",
                     arg_name, arg_name
                 )
                 .expect("Could not write");
             }
         }
 
-        writeln!(file, "    show_page_raw(&serialized);").expect("Could not write");
+        writeln!(file, "    let bytes = unsafe {{ core::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(&serialized[0..total_len]) }};").expect("Could not write");
+        writeln!(file, "    show_page_raw(bytes);").expect("Could not write");
     } else {
         writeln!(file, "    let mut total_len: usize = 0;").expect("Could not write");
 
@@ -119,9 +118,8 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
 
         writeln!(
             file,
-            "        let mut buffer: MaybeUninit<[u8; MAX_STATIC_LEN]> = MaybeUninit::uninit();
-        let buffer_ptr = buffer.as_mut_ptr() as *mut u8;
-        let mut serialized = unsafe {{ core::slice::from_raw_parts_mut(buffer_ptr, MAX_STATIC_LEN) }};
+            "        let mut serialized: [MaybeUninit<u8>; MAX_STATIC_LEN] = [MaybeUninit::uninit(); MAX_STATIC_LEN];
+        
         let mut cur: usize = 0;"
         )
         .expect("Could not write");
@@ -133,7 +131,10 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                         file,
                         "
         let next_len = {};
-        serialized[cur..cur + next_len].copy_from_slice(&{});
+        let slice_content = {};
+        for i in 0..next_len {{
+            serialized[cur + i].write(slice_content[i]);
+        }}
         cur += next_len;",
                         vec.len(),
                         gen_u8_slice(&vec)
@@ -155,8 +156,8 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
             }
         }
 
-        writeln!(file, "        show_page_raw(&serialized[0..total_len]);")
-            .expect("Could not write");
+        writeln!(file, "        let bytes = unsafe {{ core::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(&serialized[0..total_len]) }};").expect("Could not write");
+        writeln!(file, "        show_page_raw(bytes);").expect("Could not write");
 
         writeln!(file, "    }} else {{").expect("Could not write");
 
@@ -165,9 +166,7 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
         writeln!(
             file,
             "        let mut serialized = Vec::<u8>::with_capacity(total_len);
-        unsafe {{
-            serialized.set_len(total_len);
-        }}
+        let slice = serialized.spare_capacity_mut();
 
         let mut cur: usize = 0;"
         )
@@ -180,7 +179,10 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                         file,
                         "
         let next_len = {};
-        serialized[cur..cur + next_len].copy_from_slice(&{});
+        let slice_content = {};
+        for i in 0..next_len {{
+            slice[cur + i].write(slice_content[i]);
+        }}
         cur += next_len;",
                         vec.len(),
                         gen_u8_slice(&vec)
@@ -194,14 +196,15 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                     writeln!(
                         file,
                         "
-        {}.serialize(&mut serialized, &mut cur);\n",
+        {}.serialize(slice, &mut cur);\n",
                         arg_name
                     )
                     .expect("Could not write");
                 }
             }
         }
-
+        writeln!(file, "        unsafe {{ serialized.set_len(total_len); }}")
+            .expect("Could not write");
         writeln!(file, "        show_page_raw(&serialized);").expect("Could not write");
         writeln!(file, "    }}").expect("Could not write");
     }
@@ -239,10 +242,7 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
     writeln!(
         file,
         "    let mut serialized = Vec::<u8>::with_capacity(total_len);
-    unsafe {{
-        serialized.set_len(total_len);
-    }}
-
+    let slice = serialized.spare_capacity_mut();
     let mut cur: usize = 0;"
     )
     .expect("Could not write");
@@ -254,7 +254,10 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                     file,
                     "
     let next_len = {};
-    serialized[cur..cur + next_len].copy_from_slice(&{});
+    let slice_content = {};
+    for i in 0..next_len {{
+        slice[cur + i].write(slice_content[i]);
+    }}
     cur += next_len;",
                     vec.len(),
                     gen_u8_slice(&vec)
@@ -268,13 +271,14 @@ pub fn make_page_maker(file: &mut File, parts: &[SerializedPart], fn_name: &str)
                 writeln!(
                     file,
                     "
-    {}.serialize(&mut serialized, &mut cur);\n",
+    {}.serialize(slice, &mut cur);\n",
                     arg_name
                 )
                 .expect("Could not write");
             }
         }
     }
+    writeln!(file, "    unsafe {{ serialized.set_len(total_len); }}").expect("Could not write");
     writeln!(file, "    serialized").expect("Could not write");
     writeln!(file, "}}\n").expect("Could not write");
 }

--- a/common/src/ux/codec.rs
+++ b/common/src/ux/codec.rs
@@ -2,7 +2,17 @@ use alloc::{string::String, vec::Vec};
 use core::{convert::TryInto, mem::MaybeUninit};
 
 pub trait Serializable {
+    /// Returns the length of the serialized representation of this value.
     fn get_serialized_length(&self) -> usize;
+
+    /// Serializes the value into the provided buffer, starting at the position indicated by `pos`.
+    /// The position is updated to reflect the new position after serialization.
+    /// Implementations must guarantee that exactly `get_serialized_length()` bytes will be written to the buffer,
+    /// starting from the position indicated by `pos`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `is a valid index into the buffer, and that the buffer has enough space to hold
+    /// the serialized data.
     fn serialize(&self, buf: &mut [MaybeUninit<u8>], pos: &mut usize);
 
     #[inline(always)]

--- a/common/src/ux/codec.rs
+++ b/common/src/ux/codec.rs
@@ -264,10 +264,13 @@ impl Serializable for str {
             panic!("slice too long");
         };
         Serializable::serialize(&casted_len, buf, pos);
-        for (i, &byte) in bytes.iter().enumerate() {
-            buf[*pos + i].write(byte);
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                buf.as_mut_ptr().add(*pos) as *mut u8,
+                len,
+            );
         }
-
         *pos += len;
     }
 }


### PR DESCRIPTION
The interface of Serializable::serialize was inherently unsafe as it was expected to be called with uninitialized buffers, but this was not reflected in the type of the `buf` argument.

The procedural macros and UX code in app-sdk are updated accordingly.

Closes: #133