### PR TITLE
Add GET_DEVICE_PROPERTY ecall

### DIFF
--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -63,6 +63,15 @@ pub(crate) trait EcallsInterface {
     /// 1 on success, 0 on error.
     fn show_page(page_desc: *const u8, page_desc_len: usize) -> u32;
 
+    /// Retrieves device information based on the requested property type.
+    ///
+    /// # Parameters
+    /// - `property_id`: The property identifier
+    ///
+    /// # Returns
+    /// The requested property value. It will panic if the property is not supported.
+    fn get_device_property(property_id: u32) -> u32;
+
     /// Computes the remainder of dividing `n` by `m`, storing the result in `r`.
     ///
     /// # Parameters

--- a/app-sdk/src/ecalls_native.rs
+++ b/app-sdk/src/ecalls_native.rs
@@ -347,6 +347,17 @@ impl EcallsInterface for Ecall {
         1
     }
 
+    fn get_device_property(property: u32) -> u32 {
+        match property {
+            common::ecall_constants::DEVICE_PROPERTY_ID => 0,
+            common::ecall_constants::DEVICE_PROPERTY_SCREEN_SIZE => {
+                0 // TODO: what to return when executing in a shell?
+            }
+            common::ecall_constants::DEVICE_PROPERTY_FEATURES => 0,
+            _ => panic!("Unsupported device property: {}", property),
+        }
+    }
+
     fn bn_modm(r: *mut u8, n: *const u8, len: usize, m: *const u8, len_m: usize) -> u32 {
         if len > MAX_BIGNUMBER_SIZE || len_m > MAX_BIGNUMBER_SIZE {
             return 0;

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -26,6 +26,7 @@ impl EcallsInterface for Ecall {
 
     delegate_ecall!(get_event, u32, (data: *mut EventData));
     delegate_ecall!(show_page, u32, (page_desc: *const u8), (page_desc_len: usize));
+    delegate_ecall!(get_device_property, u32, (property: u32));
 
     delegate_ecall!(bn_modm, u32, (r: *mut u8), (n: *const u8), (len: usize), (m: *const u8), (len_m: usize));
     delegate_ecall!(bn_addm, u32, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize));
@@ -53,4 +54,3 @@ impl Ecall {
     delegate_ecall!(pub hash_update, u32, (hash_id: u32), (ctx: *mut u8), (data: *const u8), (len: usize));
     delegate_ecall!(pub hash_final, u32, (hash_id: u32), (ctx: *mut u8), (digest: *const u8));
 }
-

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -113,6 +113,10 @@ pub fn xsend(buffer: &[u8]) {
     Ecall::xsend(buffer.as_ptr(), buffer.len() as usize)
 }
 
+pub fn get_device_property(property_id: u32) -> u32 {
+    Ecall::get_device_property(property_id)
+}
+
 /// Initialization boilerplate for the application that is called before the main function, for
 /// targets that need it.
 #[macro_export]

--- a/apps/test/app/src/commands.rs
+++ b/apps/test/app/src/commands.rs
@@ -9,6 +9,7 @@ pub enum Command {
     Sha256,
     CountPrimes,
     ShowUxScreen = 0x80,
+    DeviceProp = 0x81,
     Panic = 0xff,
 }
 
@@ -23,6 +24,7 @@ impl TryFrom<u8> for Command {
             0x03 => Ok(Command::Sha256),
             0x04 => Ok(Command::CountPrimes),
             0x80 => Ok(Command::ShowUxScreen),
+            0x81 => Ok(Command::DeviceProp),
             0xff => Ok(Command::Panic),
             _ => Err(()),
         }

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -45,6 +45,13 @@ pub fn main() {
             Command::Sha256 => handle_sha256(&msg[1..]),
             Command::CountPrimes => handle_count_primes(&msg[1..]),
             Command::ShowUxScreen => handle_show_ux_screen(&msg[1..]),
+            Command::DeviceProp => {
+                if msg.len() != 5 {
+                    panic!("Invalid input for device properties");
+                }
+                let property_id = u32::from_be_bytes([msg[1], msg[2], msg[3], msg[4]]);
+                sdk::get_device_property(property_id).to_be_bytes().to_vec()
+            }
             Command::Panic => {
                 let panic_msg = core::str::from_utf8(&msg[1..]).unwrap();
                 panic!("{}", panic_msg);

--- a/apps/test/client/src/client.rs
+++ b/apps/test/client/src/client.rs
@@ -109,6 +109,19 @@ impl TestClient {
         Ok(())
     }
 
+    pub async fn device_props(&mut self, property_id: u32) -> Result<u32, TestClientError> {
+        let mut msg: Vec<u8> = Vec::new();
+        msg.extend_from_slice(&[Command::DeviceProp as u8]);
+        msg.extend_from_slice(&property_id.to_be_bytes());
+
+        let result_raw = self.app_client.send_message(&msg).await?;
+
+        if result_raw.len() != 4 {
+            return Err("Invalid response length".into());
+        }
+        Ok(u32::from_be_bytes(result_raw.try_into().unwrap()))
+    }
+
     pub async fn panic(&mut self, panic_msg: &str) -> Result<(), TestClientError> {
         let mut msg: Vec<u8> = Vec::new();
         msg.extend_from_slice(&[Command::Panic as u8]);

--- a/apps/test/client/src/commands.rs
+++ b/apps/test/client/src/commands.rs
@@ -9,6 +9,7 @@ pub enum Command {
     Sha256,
     CountPrimes,
     ShowUxScreen = 0x80,
+    DeviceProp = 0x81,
     Panic = 0xff,
 }
 
@@ -23,6 +24,7 @@ impl TryFrom<u8> for Command {
             0x03 => Ok(Command::Sha256),
             0x04 => Ok(Command::CountPrimes),
             0x80 => Ok(Command::ShowUxScreen),
+            0x81 => Ok(Command::DeviceProp),
             0xff => Ok(Command::Panic),
             _ => Err(()),
         }

--- a/apps/test/client/src/main.rs
+++ b/apps/test/client/src/main.rs
@@ -31,6 +31,7 @@ enum CliCommand {
     B58Enc(Vec<u8>),
     NPrimes(u32),
     Ux(u8),
+    DeviceProp(u32),
     Panic(String),
     Exit,
 }
@@ -93,6 +94,13 @@ fn parse_command(line: &str) -> Result<CliCommand, String> {
                 let id = parse_u8(arg).map_err(|e| e.to_string())?;
                 Ok(CliCommand::Ux(id))
             }
+            "deviceprop" => {
+                let arg = tokens
+                    .next()
+                    .ok_or_else(|| format!("'{}' requires a u32 integer argument", command))?;
+                let property_id = parse_u32(arg).map_err(|e| e.to_string())?;
+                Ok(CliCommand::DeviceProp(property_id))
+            }
             "panic" => {
                 // find where the word "panic" ends and the message starts
                 let msg = line
@@ -154,6 +162,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 CliCommand::Ux(id) => {
                     test_client.ux(id).await?;
+                }
+                CliCommand::DeviceProp(property) => {
+                    let value = test_client.device_props(property).await?;
+                    println!("Value for property {}: 0x{:08x}", property, value);
                 }
                 CliCommand::Panic(msg) => {
                     test_client.panic(&msg).await?;

--- a/apps/test/client/tests/integration_test.rs
+++ b/apps/test/client/tests/integration_test.rs
@@ -86,3 +86,16 @@ async fn test_nprimes() {
         assert_eq!(setup.client.nprimes(input).await.unwrap(), expected);
     }
 }
+
+#[tokio::test]
+async fn test_deviceprop() {
+    let mut setup = common::setup().await;
+
+    let device_id = setup.client.device_props(1).await.unwrap();
+    assert_eq!(device_id >> 16, 0x2C97); // Ledger vendor_id
+    assert!(device_id & 0xFFFF > 0); // product_id, different for each device
+    let screen_size = setup.client.device_props(2).await.unwrap();
+    let width = screen_size >> 16;
+    let height = screen_size & 0xFFFF;
+    assert!(width > 0 && height > 0);
+}

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -7,6 +7,16 @@ pub const ECALL_EXIT: u32 = 4;
 
 pub const ECALL_GET_EVENT: u32 = 10;
 pub const ECALL_SHOW_PAGE: u32 = 11;
+pub const ECALL_GET_DEVICE_PROPERTY: u32 = 15;
+
+// Constants used for GET_DEVICE_PROPERTY
+
+// device id (vendor_id: u16, product_id: u16)
+pub const DEVICE_PROPERTY_ID: u32 = 0x01;
+// (screen_width: u16, screen_height: u16)
+pub const DEVICE_PROPERTY_SCREEN_SIZE: u32 = 0x02;
+// bitmask of device features (to be defined)
+pub const DEVICE_PROPERTY_FEATURES: u32 = 0x03;
 
 // Big numbers
 pub const ECALL_MODM: u32 = 110;

--- a/ecalls/src/lib.rs
+++ b/ecalls/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![allow(unused_macros)]
 
-use core::arch::asm;
 use common::ecall_constants::*;
 use common::ux::EventData;
+use core::arch::asm;
 
 macro_rules! ecall0v {
     // ECALL with no arguments and no return value
@@ -339,6 +339,7 @@ ecall2!(xrecv, ECALL_XRECV, (buffer: *mut u8), (size: usize), usize);
 
 ecall1!(get_event, ECALL_GET_EVENT, (data: *mut EventData), u32);
 ecall2!(show_page, ECALL_SHOW_PAGE, (page_desc: *const u8), (page_desc_len: usize), u32);
+ecall1!(get_device_property, ECALL_GET_DEVICE_PROPERTY, (property: u32), u32);
 
 ecall5!(bn_modm, ECALL_MODM, (r: *mut u8), (n: *const u8), (len: usize), (m: *const u8), (len_m: usize), u32);
 ecall5!(bn_addm, ECALL_ADDM, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize), u32);

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -12,7 +12,7 @@ serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json
 hex = { version = "0.4.3", default-features = false, features = ["serde", "alloc"] }
 numtoa = "0.2.4"
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-ledger_device_sdk = { version = "1.22.8", features = ["debug", "nano_nbgl"] }
+ledger_device_sdk = { version = "1.22.10", features = ["debug", "nano_nbgl"] }
 ledger_secure_sdk_sys = { version = "1.8.2", features = ["nano_nbgl"] }
 zeroize = "1.8.1"
 hex-literal = "0.4.1"


### PR DESCRIPTION
Add an ECALL to get the features and properties of the device Vanadium is running on.
Added a command in the test V-App to use the feature.

Closes: #67