### PR TITLE
Avoid using the 'base64' feature in the bitcoin V-App

### DIFF
--- a/apps/bitcoin/app/Cargo.toml
+++ b/apps/bitcoin/app/Cargo.toml
@@ -16,6 +16,9 @@ nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
 sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
 
+[dev-dependencies]
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -515,11 +515,8 @@ pub fn handle_sign_psbt(_app: &mut sdk::App, psbt: &[u8]) -> Result<Response, &'
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::{
-        base64::{engine::general_purpose::STANDARD, Engine as _},
-        secp256k1::schnorr::Signature,
-        XOnlyPublicKey,
-    };
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use bitcoin::{secp256k1::schnorr::Signature, XOnlyPublicKey};
     use common::{
         bip388::{KeyPlaceholder, WalletPolicy},
         psbt::fill_psbt_with_bip388_coordinates,

--- a/apps/bitcoin/common/Cargo.toml
+++ b/apps/bitcoin/common/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitcoin = { version = "0.32.0", features = ["serde", "base64"], default-features = false }
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
+bitcoin = { version = "0.32.0", features = ["serde"], default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.219", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
The `base64` feature of rust-bitcoin doesn't work in `no_std` for the currently released versions.
While that will be fixed in the next major release, it is simpler to work on other tasks (like #138) if we don't depend on it for now.
