### PR TITLE
Verify Merkle proofs while streaming them

### DIFF
--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -7,7 +7,7 @@
 //! produced by the prover.
 
 use alloc::{vec, vec::Vec};
-use core::{error::Error, fmt, marker::PhantomData, mem::MaybeUninit};
+use core::{error::Error, fmt, marker::PhantomData, mem::MaybeUninit, ops::Deref};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug)]
@@ -71,15 +71,20 @@ pub trait Hasher<const OUTPUT_SIZE: usize>: Sized {
 ///
 /// This wrapper allows implementing serialization and deserialization traits
 /// for byte arrays of arbitrary lengths, which is not natively supported by Serde.
+#[repr(transparent)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct HashOutput<const N: usize>(pub [u8; N]);
 
-impl<const N: usize> Serialize for HashOutput<N> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bytes(&self.0)
+impl<const N: usize> Deref for HashOutput<N> {
+    type Target = [u8; N];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize> HashOutput<N> {
+    pub fn as_hash_output(array: &[u8; N]) -> &Self {
+        unsafe { core::mem::transmute(array) }
     }
 }
 
@@ -92,6 +97,15 @@ impl<const N: usize> From<[u8; N]> for HashOutput<N> {
 impl<const N: usize> From<HashOutput<N>> for [u8; N] {
     fn from(hash: HashOutput<N>) -> Self {
         hash.0
+    }
+}
+
+impl<const N: usize> Serialize for HashOutput<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.0)
     }
 }
 
@@ -112,7 +126,7 @@ impl<'de, const N: usize> Deserialize<'de> for HashOutput<N> {
 /// proofs of inclusion and updates.
 pub trait VectorAccumulator<
     T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
-    H: Clone + Serialize + DeserializeOwned,
+    H: PartialEq + Clone + Serialize + DeserializeOwned,
 >
 {
     /// The type representing an inclusion proof.
@@ -146,6 +160,38 @@ pub trait VectorAccumulator<
     /// Computes the hash of an element.
     fn hash_element<T_: AsRef<[u8]>>(element: &T_) -> H;
 
+    /// Updates the accumulator by replacing the element at the given index.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The index of the element to be updated.
+    /// * `value` - The new value to replace the existing element.
+    ///
+    /// # Returns
+    ///
+    /// A pair of the update proof and the new root hash, or an error string if the index is out of bounds.
+    fn update(
+        &mut self,
+        index: usize,
+        value: T,
+    ) -> Result<(Self::UpdateProof, H), AccumulatorError>;
+}
+
+pub trait VectorAccumulatorVerifier<
+    T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+    H: PartialEq + Clone + Serialize + DeserializeOwned,
+>
+{
+    /// The type representing a reference to an inclusion proof.
+    type InclusionProofRef<'a>
+    where
+        H: 'a;
+
+    /// The type representing a reference to an update proof.
+    type UpdateProofRef<'a>
+    where
+        H: 'a;
+
     /// Verifies an inclusion proof. This associated function is called by the verifier,
     /// rather than the owner of the instance.
     ///
@@ -166,23 +212,9 @@ pub trait VectorAccumulator<
         value_hash: &H,
         index: usize,
         size: usize,
-    ) -> bool;
-
-    /// Updates the accumulator by replacing the element at the given index.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` - The index of the element to be updated.
-    /// * `value` - The new value to replace the existing element.
-    ///
-    /// # Returns
-    ///
-    /// A pair of the update proof and the new root hash, or an error string if the index is out of bounds.
-    fn update(
-        &mut self,
-        index: usize,
-        value: T,
-    ) -> Result<(Self::UpdateProof, H), AccumulatorError>;
+    ) -> bool
+    where
+        H: 'a;
 
     /// Verifies an update proof. This associated function is called by the verifier,
     /// rather than the owner of the instance.
@@ -208,7 +240,188 @@ pub trait VectorAccumulator<
         new_value_hash: &H,
         index: usize,
         size: usize,
-    ) -> bool;
+    ) -> bool
+    where
+        H: 'a;
+}
+
+/// Trait for incrementally verifying an inclusion proof.
+pub trait InclusionProofVerifier<H> {
+    /// Feeds a single proof element into the verifier.
+    fn feed(&mut self, element: &H);
+
+    /// Returns `true` if the proof has been verified, `false` otherwise.
+    fn verified(&self) -> bool;
+}
+
+/// Trait for incrementally verifying an update proof.
+pub trait UpdateProofVerifier<H> {
+    /// Feeds a single proof element into the verifier.
+    fn feed(&mut self, element: &H);
+
+    /// Returns `true` if the proof has been verified, `false` otherwise.
+    fn verified(&self) -> bool;
+}
+
+/// Trait for vector accumulators that support streaming proof verification.
+/// Assumes that the proofs are just lists of hashes.
+pub trait StreamingVectorAccumulator<
+    T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+    H: PartialEq + Clone + Serialize + DeserializeOwned,
+>: VectorAccumulator<T, H>
+{
+    type InclusionProofVerifier: InclusionProofVerifier<H>;
+    type UpdateProofVerifier: UpdateProofVerifier<H>;
+
+    /// Initiates an inclusion proof verifier with the given parameters.
+    fn begin_inclusion_proof(
+        root: &H,
+        value_hash: &H,
+        index: usize,
+        size: usize,
+    ) -> Self::InclusionProofVerifier;
+
+    /// Initiates an update proof verifier with the given parameters.
+    fn begin_update_proof(
+        old_root: &H,
+        new_root: &H,
+        old_value_hash: &H,
+        new_value_hash: &H,
+        index: usize,
+        size: usize,
+    ) -> Self::UpdateProofVerifier;
+}
+
+// blanket implementation of verify_inclusion_proof and verify_update_proof for a StreamingVectorAccumulator
+impl<
+        T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+        H: PartialEq + Clone + Serialize + DeserializeOwned,
+        S: StreamingVectorAccumulator<T, H>,
+    > VectorAccumulatorVerifier<T, H> for S
+{
+    type InclusionProofRef<'a>
+        = &'a [H]
+    where
+        H: 'a;
+    type UpdateProofRef<'a>
+        = &'a [H]
+    where
+        H: 'a;
+
+    fn verify_inclusion_proof<'a>(
+        root: &H,
+        proof: Self::InclusionProofRef<'a>,
+        value_hash: &H,
+        index: usize,
+        size: usize,
+    ) -> bool
+    where
+        H: 'a,
+    {
+        let mut verifier = Self::begin_inclusion_proof(root, value_hash, index, size);
+
+        for el in proof.iter() {
+            verifier.feed(el);
+        }
+        verifier.verified()
+    }
+
+    fn verify_update_proof<'a>(
+        old_root: &H,
+        new_root: &H,
+        update_proof: Self::UpdateProofRef<'a>,
+        old_value_hash: &H,
+        new_value_hash: &H,
+        index: usize,
+        size: usize,
+    ) -> bool
+    where
+        H: 'a,
+    {
+        let mut verifier = Self::begin_update_proof(
+            old_root,
+            new_root,
+            old_value_hash,
+            new_value_hash,
+            index,
+            size,
+        );
+
+        for el in update_proof.iter() {
+            verifier.feed(el);
+        }
+        verifier.verified()
+    }
+}
+
+/// Verifier for streaming inclusion proof verification in a Merkle tree.
+pub struct MerkleInclusionProofVerifier<H: Hasher<OUTPUT_SIZE>, const OUTPUT_SIZE: usize> {
+    current_hash: HashOutput<OUTPUT_SIZE>, // Current computed hash
+    pos: usize,                            // Current position in the tree
+    root: HashOutput<OUTPUT_SIZE>,         // Expected root hash
+    verified: bool,                        // Whether the proof has been verified
+    _marker: PhantomData<H>,               // For hasher type
+}
+
+impl<H: Hasher<OUTPUT_SIZE>, const OUTPUT_SIZE: usize>
+    InclusionProofVerifier<HashOutput<OUTPUT_SIZE>>
+    for MerkleInclusionProofVerifier<H, OUTPUT_SIZE>
+{
+    fn feed(&mut self, sibling_hash: &HashOutput<OUTPUT_SIZE>) {
+        if self.pos == 0 {
+            // Verification already completed; extra elements make the proof invalid
+
+            self.verified = false;
+            return;
+        }
+
+        // Determine if the current node is a left or right child
+        let (left, right) = if self.pos % 2 == 0 {
+            (sibling_hash, &self.current_hash) // Even pos: right child
+        } else {
+            (&self.current_hash, sibling_hash) // Odd pos: left child
+        };
+
+        // Compute the parent hash
+        let mut hasher = H::new();
+        hasher.update(&[0x01]); // Internal node prefix
+        hasher.update(&left.0);
+        hasher.update(&right.0);
+        self.current_hash = hasher.finalize().into();
+
+        // Move up the tree
+        self.pos = (self.pos - 1) / 2;
+
+        // If at the root, check if the computed hash matches
+        if self.pos == 0 {
+            self.verified = &self.current_hash == &self.root;
+        }
+    }
+
+    fn verified(&self) -> bool {
+        self.verified
+    }
+}
+
+/// Verifier for streaming update proof verification in a Merkle tree.
+/// An update proof is just a pair of inclusion proofs, one for the old element value and root, the other for
+/// the new ones.
+pub struct MerkleUpdateProofVerifier<H: Hasher<OUTPUT_SIZE>, const OUTPUT_SIZE: usize> {
+    old_verifier: MerkleInclusionProofVerifier<H, OUTPUT_SIZE>,
+    new_verifier: MerkleInclusionProofVerifier<H, OUTPUT_SIZE>,
+}
+
+impl<H: Hasher<OUTPUT_SIZE>, const OUTPUT_SIZE: usize> UpdateProofVerifier<HashOutput<OUTPUT_SIZE>>
+    for MerkleUpdateProofVerifier<H, OUTPUT_SIZE>
+{
+    fn feed(&mut self, sibling_hash: &HashOutput<OUTPUT_SIZE>) {
+        self.old_verifier.feed(sibling_hash);
+        self.new_verifier.feed(sibling_hash);
+    }
+
+    fn verified(&self) -> bool {
+        self.new_verifier.verified() && self.old_verifier.verified()
+    }
 }
 
 /// A Merkle tree-based implementation of the `VectorAccumulator` trait.
@@ -220,6 +433,51 @@ pub struct MerkleAccumulator<
     data: Vec<T>,
     tree: Vec<HashOutput<OUTPUT_SIZE>>,
     _marker: PhantomData<H>,
+}
+
+impl<
+        H: Hasher<OUTPUT_SIZE>,
+        T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
+        const OUTPUT_SIZE: usize,
+    > StreamingVectorAccumulator<T, HashOutput<OUTPUT_SIZE>>
+    for MerkleAccumulator<H, T, OUTPUT_SIZE>
+{
+    type InclusionProofVerifier = MerkleInclusionProofVerifier<H, OUTPUT_SIZE>;
+    type UpdateProofVerifier = MerkleUpdateProofVerifier<H, OUTPUT_SIZE>;
+
+    fn begin_inclusion_proof(
+        root: &HashOutput<OUTPUT_SIZE>,
+        value_hash: &HashOutput<OUTPUT_SIZE>,
+        index: usize,
+        size: usize,
+    ) -> Self::InclusionProofVerifier {
+        let pos = size - 1 + index;
+        MerkleInclusionProofVerifier {
+            current_hash: value_hash.clone(),
+            pos,
+            root: root.clone(),
+            // a zero-length proof (for a single-element tree) is only valid if the value hash is equal to the root
+            verified: size == 1 && value_hash == root,
+            _marker: PhantomData,
+        }
+    }
+
+    fn begin_update_proof(
+        old_root: &HashOutput<OUTPUT_SIZE>,
+        new_root: &HashOutput<OUTPUT_SIZE>,
+        old_value_hash: &HashOutput<OUTPUT_SIZE>,
+        new_value_hash: &HashOutput<OUTPUT_SIZE>,
+        index: usize,
+        size: usize,
+    ) -> Self::UpdateProofVerifier {
+        let old_verifier = Self::begin_inclusion_proof(old_root, old_value_hash, index, size);
+        let new_verifier = Self::begin_inclusion_proof(new_root, new_value_hash, index, size);
+
+        MerkleUpdateProofVerifier {
+            old_verifier,
+            new_verifier,
+        }
+    }
 }
 
 impl<
@@ -292,28 +550,6 @@ impl<
         Ok(proof)
     }
 
-    /// Verifies an inclusion proof for a given element hash and index
-    fn verify_inclusion_proof<'a>(
-        root: &HashOutput<OUTPUT_SIZE>,
-        proof: Self::InclusionProofRef<'a>,
-        value_hash: &HashOutput<OUTPUT_SIZE>,
-        index: usize,
-        size: usize,
-    ) -> bool {
-        let mut hash = value_hash.clone();
-        let mut pos = size - 1 + index;
-        for sibling_hash in proof.iter() {
-            let (left, right) = if pos % 2 == 0 {
-                (sibling_hash, &hash)
-            } else {
-                (&hash, sibling_hash)
-            };
-            hash = Self::hash_internal_node(left, right);
-            pos = (pos - 1) / 2;
-        }
-        &hash == root
-    }
-
     /// Updates the Merkle tree by replacing the element at the given index.
     ///
     /// # Arguments
@@ -348,22 +584,6 @@ impl<
         let new_root = self.root();
         Ok((merkle_proof, new_root.clone()))
     }
-
-    /// Verifies an update proof.
-    fn verify_update_proof<'a>(
-        old_root: &HashOutput<OUTPUT_SIZE>,
-        new_root: &HashOutput<OUTPUT_SIZE>,
-        update_proof: Self::UpdateProofRef<'a>,
-        old_value_hash: &HashOutput<OUTPUT_SIZE>,
-        new_value_hash: &HashOutput<OUTPUT_SIZE>,
-        index: usize,
-        size: usize,
-    ) -> bool {
-        // verify that the old value was correct with old root, and the new value is correct with new root
-        Self::verify_inclusion_proof(old_root, update_proof, old_value_hash, index, size)
-            && Self::verify_inclusion_proof(new_root, update_proof, new_value_hash, index, size)
-    }
-
     /// Computes the hash of an element.
     #[inline]
     fn hash_element<T_: AsRef<[u8]>>(element: &T_) -> HashOutput<OUTPUT_SIZE> {
@@ -617,5 +837,58 @@ mod tests {
         let deserialized_update_proof: Vec<HashOutput<32>> =
             postcard::from_bytes(&serialized_update_proof).unwrap();
         assert_eq!(update_proof, deserialized_update_proof);
+    }
+
+    #[test]
+    fn test_size1_accumulator() {
+        // If an accumulator has only one element, valid proofs are empty
+        let data = vec![b"single_element".to_vec()];
+        let ma = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::new(data.clone());
+
+        let root = ma.root().clone();
+        let element_hash = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::hash_leaf(&data[0]);
+
+        // For a single element, the root should equal the element hash
+        assert_eq!(root, element_hash);
+
+        // Generate proof for the single element
+        let proof = ma.prove(0).unwrap();
+
+        // Proof should be empty for a single element accumulator
+        assert!(proof.is_empty());
+
+        // Verify the empty proof is valid
+        assert!(
+            MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_inclusion_proof(
+                &root,
+                &proof,
+                &element_hash,
+                0,
+                1
+            )
+        );
+
+        // Test update on single element accumulator
+        let new_data = b"updated_element".to_vec();
+        let mut ma_mut = ma;
+        let (update_proof, new_root) = ma_mut.update(0, new_data.clone()).unwrap();
+
+        // Update proof should also be empty for single element
+        assert!(update_proof.is_empty());
+
+        let new_element_hash = MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::hash_leaf(&new_data);
+
+        // Verify update proof
+        assert!(
+            MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
+                &root,
+                &new_root,
+                &update_proof,
+                &element_hash,
+                &new_element_hash,
+                0,
+                1
+            )
+        );
     }
 }

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -283,13 +283,10 @@ impl<'c> OutsourcedMemory<'c> {
         let proof_elements: Vec<HashOutput<32>> =
             proof_elements.into_iter().map(Into::into).collect();
 
-        // Create update proof (InclusionProof, new_root)
-        let update_proof = (proof_elements, new_root.clone());
-
         // Verify the update proof
         if !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
             &self.merkle_root,
-            &update_proof,
+            (&proof_elements, &new_root),
             page_hash_old,
             &new_page_hash,
             cached_page.idx as usize,

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -1,7 +1,7 @@
 use core::cell::RefCell;
 
 use alloc::{rc::Rc, vec, vec::Vec};
-use common::accumulator::{HashOutput, Hasher, MerkleAccumulator, VectorAccumulator};
+use common::accumulator::{HashOutput, Hasher, MerkleAccumulator, VectorAccumulatorVerifier};
 use common::vm::{Page, PagedMemory};
 use ledger_device_sdk::io;
 

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -286,7 +286,8 @@ impl<'c> OutsourcedMemory<'c> {
         // Verify the update proof
         if !MerkleAccumulator::<Sha256Hasher, Vec<u8>, 32>::verify_update_proof(
             &self.merkle_root,
-            (&proof_elements, &new_root),
+            &new_root,
+            &proof_elements,
             page_hash_old,
             &new_page_hash,
             cached_page.idx as usize,


### PR DESCRIPTION
Generalizes the code of the accumulator in order to enable verifying proofs in streaming mode. Since Merkle proofs might not fit in a single message, this avoids having to store the entire proof in memory, saving both memory and allocations/copying.