### PR TITLE
Remove unnecessary feature from the common crate

### DIFF
--- a/common/src/client_commands.rs
+++ b/common/src/client_commands.rs
@@ -4,9 +4,6 @@ use crate::constants::PAGE_SIZE;
 use alloc::vec::Vec;
 use core::fmt;
 
-#[cfg(feature = "device_sdk")]
-use ledger_device_sdk::io::Comm;
-
 #[derive(Debug)]
 pub enum MessageDeserializationError {
     InvalidClientCommandCode,
@@ -38,12 +35,6 @@ impl core::error::Error for MessageDeserializationError {}
 
 pub trait Message<'a>: Sized {
     fn serialize_with<F: FnMut(&[u8])>(&self, f: F);
-
-    #[cfg(feature = "device_sdk")]
-    #[inline]
-    fn serialize_to_comm(&self, comm: &mut Comm) {
-        self.serialize_with(|data| comm.append(data));
-    }
 
     fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Salvatore Ingala"]
 edition = "2021"
 
 [dependencies]
-common = { path = "../common", features=["device_sdk"] }
+common = { path = "../common" }
 include_gif = "1.2.0"
 serde = {version="1.0.192", default-features = false, features = ["derive"]}
 serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core"}

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -23,7 +23,7 @@ use ledger_secure_sdk_sys::{
 
 use crate::{AppSW, Instruction};
 
-use super::outsourced_mem::OutsourcedMemory;
+use super::{outsourced_mem::OutsourcedMemory, SerializeToComm};
 
 use zeroize::Zeroizing;
 

--- a/vm/src/handlers/lib/mod.rs
+++ b/vm/src/handlers/lib/mod.rs
@@ -1,3 +1,15 @@
+use common::client_commands::Message;
+
 pub mod ecall;
 pub mod outsourced_mem;
 pub mod vapp;
+
+trait SerializeToComm {
+    fn serialize_to_comm(&self, comm: &mut ledger_device_sdk::io::Comm);
+}
+
+impl<'a, T: Message<'a>> SerializeToComm for T {
+    fn serialize_to_comm(&self, comm: &mut ledger_device_sdk::io::Comm) {
+        self.serialize_with(|data| comm.append(data));
+    }
+}

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -20,6 +20,8 @@ use crate::aes::AesCtr;
 use crate::hash::Sha256Hasher;
 use crate::{AppSW, Instruction};
 
+use super::SerializeToComm;
+
 #[derive(Clone, Debug)]
 struct CachedPage {
     idx: u32,                  // Page index


### PR DESCRIPTION
It complicates the dependency graph, and it's easy to replace.