### PR TITLE
Fix rust sdk version

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,6 @@ serde = { version = "1.0.204", default-features = false, features = [
 vanadium_macros = { path = "../macros" }
 
 # Optional dependencies
-ledger_device_sdk = { version = "1.22.8", optional = true }
 serde_json = { version = "1.0.140", default-features = false, features = ["alloc"], optional = true }
 
 
@@ -21,7 +20,6 @@ postcard = { version = "1.0.8", default-features = false, features = ["alloc"] }
 
 [features]
 default = []
-device_sdk = ["ledger_device_sdk"]
 
 # This feature should only be used in the build.rs script app-sdk crate
 wrapped_serializable = []

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -12,8 +12,8 @@ serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json
 hex = { version = "0.4.3", default-features = false, features = ["serde", "alloc"] }
 numtoa = "0.2.4"
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-ledger_device_sdk = { version = "1.22.10", features = ["debug", "nano_nbgl"] }
-ledger_secure_sdk_sys = { version = "1.8.2", features = ["nano_nbgl"] }
+ledger_device_sdk = { version = "=1.22.10", features = ["debug", "nano_nbgl"] }
+ledger_secure_sdk_sys = { version = "=1.8.2", features = ["nano_nbgl"] }
 zeroize = "1.8.1"
 hex-literal = "0.4.1"
 subtle = { version = "2.6.0", default-features = false }


### PR DESCRIPTION
This avoids the reusable build from the CI using a more recent version of the SDK crates than specified in Cargo.toml.

Also removes an unused optional feature from the `common` crate, forgotten in #153.