### PR TITLE
Add ECALL and minimal app-sdk functionality for SLIP-21 + io-revamp adaptations

### DIFF
--- a/app-sdk/Cargo.toml
+++ b/app-sdk/Cargo.toml
@@ -20,6 +20,7 @@ vanadium-ecalls = { path = "../ecalls" }
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]
 bip32 = "0.5.2"
 hex = "0.4.3"
+hmac = "0.12.1"
 k256 = { version = "0.13.4", default-features = false, features = ["alloc", "ecdsa-core", "schnorr"] }
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"

--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -207,6 +207,25 @@ forward_to_ecall! {
     /// This function panics if the curve is not supported.
     pub fn get_master_fingerprint(curve: u32) -> u32;
 
+    /// Derives the root SLIP-21 node m/<label1>/<label2>/.../<labelN>, saving it to the provided 64-byte buffer.
+    /// The last 32 bytes of the node are the SLIP-21 key, while the first 32 bytes are the chain code.
+    ///
+    /// The `labels` buffer (with length `labels_len`) must contain the concatenated labels, each prefixed by its length.
+    /// `labels_len` must be at most 256 bytes. Each of the labels must not be longer than 252 bytes.
+    ///
+    /// Ledger-specific limitations:
+    /// - The `labels` buffer must not be empty (no master key derivation).
+    /// - Each label must not contain a '/' character.
+    ///
+    /// # Parameters
+    /// - `labels`: Pointer to the label used for SLIP-21 derivation.
+    /// - `labels_len`: Length of the label.
+    /// - `out`: Pointer to the buffer where the result will be written. It must be at least 64 bytes long.
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
+    pub fn derive_slip21_node(label: *const u8, label_len: usize, out: *mut u8) -> u32;
+
     /// Adds two elliptic curve points `p` and `q`, storing the result in `r`.
     ///
     /// # Parameters

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -33,6 +33,7 @@ delegate_ecall!(bn_powm, u32, (r: *mut u8), (a: *const u8), (e: *const u8), (len
 
 delegate_ecall!(derive_hd_node, u32, (curve: u32), (path: *const u32), (path_len: usize), (privkey: *mut u8), (chain_code: *mut u8));
 delegate_ecall!(get_master_fingerprint, u32, (curve: u32));
+delegate_ecall!(derive_slip21_node, u32, (label: *const u8), (label_len: usize), (out: *mut u8));
 
 delegate_ecall!(ecfp_add_point, u32, (curve: u32), (r: *mut u8), (p: *const u8), (q: *const u8));
 delegate_ecall!(ecfp_scalar_mult, u32, (curve: u32), (r: *mut u8), (p: *const u8), (k: *const u8), (k_len: usize));

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -13,6 +13,7 @@ pub mod comm;
 pub mod curve;
 pub mod hash;
 pub mod rand;
+pub mod slip21;
 pub mod ux;
 
 pub use app::App;

--- a/app-sdk/src/slip21.rs
+++ b/app-sdk/src/slip21.rs
@@ -1,0 +1,55 @@
+use crate::ecalls;
+use alloc::vec::Vec;
+
+/// Derives a SLIP-21 key node, based on the BIP39 seed.
+/// The key corresponds to the last 32-bytes of the corresponding SLIP-21 node.
+/// The initial 32 bytes (only used for further derivations) are not returned.
+///
+/// # Returns
+/// A 32-byte array representing the derived SLIP-21 key.
+///
+/// # Panics
+/// This function will panic if either:
+/// - The total length of the encoded labels exceeds 256 bytes.
+/// - Any individual label exceeds 252 bytes.
+/// - (Ledger-specific) `labels` has length 0 (no master key derivation)
+/// - (Ledger-specific) Any label contains a '/' character.
+///
+/// # Security
+///
+/// Accessing the raw bytes of the derived key is dangerous and can lead to
+/// side-channel attacks.
+// TODO: it would be better to return an opaque type that doesn't directly allow
+// accessing the raw bytes, as incorrect usage could lead to side channel attacks.
+pub fn derive_slip21_key(labels: &[&[u8]]) -> [u8; 32] {
+    // compute the total length of the encoded labels as the sum of their lengths,
+    // each increased by 1 because of the length prefix.
+    let encoded_length = labels.iter().map(|label| label.len() + 1).sum::<usize>();
+    if encoded_length > 256 {
+        panic!("Total length of encoded labels exceeds maximum allowed size of 256 bytes");
+    }
+    let mut encoded_labels = Vec::with_capacity(encoded_length);
+
+    for label in labels {
+        if label.len() > 252 {
+            panic!("Label length exceeds maximum allowed size of 252 bytes");
+        }
+        // Write the length prefix, followed by the label
+        encoded_labels.push(label.len() as u8);
+        encoded_labels.extend_from_slice(label);
+    }
+
+    let mut node = [0u8; 64];
+    if ecalls::derive_slip21_node(
+        encoded_labels.as_ptr(),
+        encoded_labels.len(),
+        node.as_mut_ptr(),
+    ) == 0
+    {
+        panic!("Failed to derive SLIP-21 node");
+    }
+    // only return the last 32 bytes, which are the SLIP-21 key
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&node[32..64]);
+    key
+}

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -166,6 +166,10 @@ fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
                 result
             }
         },
+        Command::DeriveSlip21Key { labels } => {
+            let labels_slices: Vec<&[u8]> = labels.iter().map(|v| v.as_slice()).collect();
+            sdk::slip21::derive_slip21_key(&labels_slices).to_vec()
+        }
         Command::ECPointOperation { curve, operation } => match curve {
             Curve::Secp256k1 => match operation {
                 ECPointOperation::Add(p, q) => {

--- a/apps/sadik/client/src/client.rs
+++ b/apps/sadik/client/src/client.rs
@@ -109,6 +109,16 @@ impl SadikClient {
             .await
             .expect("Error sending message"))
     }
+    pub async fn get_slip21_key(&mut self, labels: &[&[u8]]) -> Result<Vec<u8>, SadikClientError> {
+        let cmd = Command::DeriveSlip21Key {
+            labels: labels.iter().map(|s| s.to_vec()).collect(),
+        };
+
+        let msg = postcard::to_allocvec(&cmd).expect("Serialization failed");
+        Ok(send_message(&mut self.app_client, &msg)
+            .await
+            .expect("Error sending message"))
+    }
 
     pub async fn ecpoint_add(
         &mut self,

--- a/apps/sadik/client/tests/integration_test.rs
+++ b/apps/sadik/client/tests/integration_test.rs
@@ -248,6 +248,27 @@ async fn test_secp256k1_derive_hd_node() {
 }
 
 #[tokio::test]
+async fn test_derive_slip21_key() {
+    let mut setup = test_common::setup().await;
+    let client = &mut setup.client;
+
+    let label1 = b"Vanadium".to_vec();
+
+    // m/b'Vanadium'
+    assert_eq!(
+        client.get_slip21_key(&[&label1]).await.unwrap(),
+        hex!("ba0ff8c27d6a0c9f7cb3346394b7c57306c5922a2f54a7d51352b9c511e155e0").to_vec()
+    );
+
+    // m/b'Vanadium'/b'Risc-V'
+    let label2 = b"Risc-V".to_vec();
+    assert_eq!(
+        client.get_slip21_key(&[&label1, &label2]).await.unwrap(),
+        hex!("234bbecf423f05569b6de6cbb56cd73cb9c29dec8c6599551a1a5a85bc445e5f").to_vec()
+    );
+}
+
+#[tokio::test]
 async fn test_secp256k1_point_add() {
     let mut setup = test_common::setup().await;
 

--- a/apps/sadik/client/tests/test_common/mod.rs
+++ b/apps/sadik/client/tests/test_common/mod.rs
@@ -29,7 +29,6 @@ impl TestSetup {
             "../app/target/riscv32imc-unknown-none-elf/release/vnd-sadik".to_string()
         });
 
-        let args: Vec<String> = env::args().collect();
         let has_hid = args.contains(&"--hid".to_string());
         if has_hid {
             // run the tests against the real device

--- a/apps/sadik/common/src/lib.rs
+++ b/apps/sadik/common/src/lib.rs
@@ -44,6 +44,9 @@ pub enum Command {
         curve: Curve,
         path: Vec<u32>,
     },
+    DeriveSlip21Key {
+        labels: Vec<Vec<u8>>,
+    },
     ECPointOperation {
         curve: Curve,
         operation: ECPointOperation,

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -58,6 +58,7 @@ pub enum SchnorrSignMode {
 
 pub const ECALL_DERIVE_HD_NODE: u32 = 130;
 pub const ECALL_GET_MASTER_FINGERPRINT: u32 = 131;
+pub const ECALL_DERIVE_SLIP21_KEY: u32 = 132;
 
 // Hash functions
 pub const ECALL_HASH_INIT: u32 = 150;

--- a/ecalls/src/lib.rs
+++ b/ecalls/src/lib.rs
@@ -350,6 +350,7 @@ ecall6!(bn_powm, ECALL_POWM, (r: *mut u8), (a: *const u8), (e: *const u8), (len_
 
 ecall5!(derive_hd_node, ECALL_DERIVE_HD_NODE, (curve: u32), (path: *const u32), (path_len: usize), (privkey: *mut u8), (chain_code: *mut u8), u32);
 ecall1!(get_master_fingerprint, ECALL_GET_MASTER_FINGERPRINT, (curve: u32), u32);
+ecall3!(derive_slip21_node, ECALL_DERIVE_SLIP21_KEY, (labels: *const u8), (labels_len: usize), (out: *mut u8), u32);
 
 ecall4!(ecfp_add_point, ECALL_ECFP_ADD_POINT, (curve: u32), (r: *mut u8), (p: *const u8), (q: *const u8), u32);
 ecall5!(ecfp_scalar_mult, ECALL_ECFP_SCALAR_MULT, (curve: u32), (r: *mut u8), (p: *const u8), (k: *const u8), (k_len: usize), u32);

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -46,6 +46,7 @@ run_tests = []  # Run the test suite instead of the app
 curve = ["secp256k1"]
 flags = "0x10"  # DERIVE_MASTER
 path = [""]
+# TODO: add "VANADIUM" among the allowed SLIP21 paths once cargo-ledger supports it
 name = "Vanadium"
 
 [package.metadata.ledger.nanox]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -12,8 +12,8 @@ serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json
 hex = { version = "0.4.3", default-features = false, features = ["serde", "alloc"] }
 numtoa = "0.2.4"
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-ledger_device_sdk = { version = "=1.22.10", features = ["debug", "nano_nbgl"] }
-ledger_secure_sdk_sys = { version = "=1.8.2", features = ["nano_nbgl"] }
+ledger_device_sdk = { version = "1.23.0", features = ["debug", "nano_nbgl"] }
+ledger_secure_sdk_sys = { version = "1.9.0", features = ["nano_nbgl"] }
 zeroize = "1.8.1"
 hex-literal = "0.4.1"
 subtle = { version = "2.6.0", default-features = false }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -46,7 +46,7 @@ run_tests = []  # Run the test suite instead of the app
 curve = ["secp256k1"]
 flags = "0x10"  # DERIVE_MASTER
 path = [""]
-# TODO: add "VANADIUM" among the allowed SLIP21 paths once cargo-ledger supports it
+path_slip21 = ["VANADIUM"]
 name = "Vanadium"
 
 [package.metadata.ledger.nanox]

--- a/vm/src/handlers/lib/ecall/slip21.rs
+++ b/vm/src/handlers/lib/ecall/slip21.rs
@@ -1,0 +1,82 @@
+// Because of Bolos' limited support for SLIP21, we use a separate key hierarchy that is compatible with
+// the keys that we have available in normal Ledger apps.
+//
+// These are Bolos limitations for using SLIP-21 in Vanadium:
+// - It is not possible to derive the master SLIP-21 node.
+// - It does not return the chain code (initial 32 bytes) of any node, but only the key.
+// - All the required paths must be specified in the Ledger app manifest.
+//
+// Therefore, we instead use a single, standard SLIP-21 key that is accessible to ledger apps, and use it
+// as the root secret for the
+//
+// In the notation of SLIP-21, we set:
+//   S_v = m/"VANADIUM"
+// where m is the master node computed using the BIP-39 seed S.
+//
+// Then, we compute the master node v as:
+//   m_v = HMAC-SHA512(key = b"Symmetric key seed", msg = S_v)
+//
+// Further derivations are done as in SLIP-21.
+
+use alloc::vec::Vec;
+
+use ledger_device_sdk::hmac::{sha2::Sha2_512, HMACInit};
+use ledger_secure_sdk_sys as sys;
+
+const SLIP21_MAGIC: &'static str = "Symmetric key seed";
+
+const SEED_MASTER_PATH: &'static str = "VANADIUM";
+
+fn get_seed() -> [u8; 32] {
+    // prepend a 0x00 byte to SEED_MASTER_PATH, as required by Bolos
+    let mut path = Vec::with_capacity(SEED_MASTER_PATH.len() + 1);
+    path.push(0x00);
+    path.extend_from_slice(SEED_MASTER_PATH.as_bytes());
+    let mut seed = [0u8; 32];
+    unsafe {
+        sys::os_perso_derive_node_with_seed_key(
+            sys::HDW_SLIP21,
+            sys::CX_CURVE_SECP256K1,
+            path.as_ptr() as *const u32,
+            path.len() as u32,
+            seed.as_mut_ptr(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            0,
+        );
+    }
+    seed
+}
+
+fn get_master_node() -> [u8; 64] {
+    // compute the custom seed using standard SLIP-21
+    let seed = get_seed();
+
+    // compute HMAC-SHA512(key = SLIP21_MAGIC, msg = seed)
+    let mut mac = Sha2_512::new(SLIP21_MAGIC.as_bytes());
+    mac.update(&seed).expect("Should never fail");
+    let mut output = [0u8; 64];
+    mac.finalize(&mut output).expect("Should never fail");
+    output
+}
+
+fn derive_child_node(cur_node: &[u8; 64], label: &[u8]) -> [u8; 64] {
+    // compute HMAC-SHA512(key = cur_node[:32], msg = [0] + label)
+    let mut mac = Sha2_512::new(&cur_node[..32]);
+    mac.update(&[0u8]).expect("Should never fail");
+    mac.update(label).expect("Should never fail");
+    let mut output = [0u8; 64];
+    mac.finalize(&mut output).expect("Should never fail");
+    output
+}
+
+pub fn get_custom_slip21_node(path: &[&[u8]]) -> [u8; 64] {
+    let master_node = get_master_node();
+
+    let mut current_node = master_node;
+    for label in path {
+        current_node = derive_child_node(&current_node, label);
+    }
+
+    current_node
+}

--- a/vm/src/handlers/lib/ecall/slip21.rs
+++ b/vm/src/handlers/lib/ecall/slip21.rs
@@ -7,7 +7,8 @@
 // - All the required paths must be specified in the Ledger app manifest.
 //
 // Therefore, we instead use a single, standard SLIP-21 key that is accessible to ledger apps, and use it
-// as the root secret for the
+// as the root secret for the SLIP-21 key hierarchy. This allows to make sure that we can derive these keys
+// from the seed in Vanadium today, without depending on the OS updates.
 //
 // In the notation of SLIP-21, we set:
 //   S_v = m/"VANADIUM"

--- a/vm/src/handlers/lib/ecall/ux_handler.rs
+++ b/vm/src/handlers/lib/ecall/ux_handler.rs
@@ -46,12 +46,6 @@ fn store_new_event(event_code: common::ux::EventCode, event_data: common::ux::Ev
 // nbgl_layoutTouchCallback_t
 #[cfg(any(target_os = "stax", target_os = "flex"))]
 unsafe extern "C" fn layout_touch_callback(token: core::ffi::c_int, index: u8) {
-    crate::println!(
-        "layout_touch_callback with token={} and index={}",
-        token,
-        index
-    );
-
     let action = match (token as u8, index) {
         (TOKEN_CONFIRM_REJECT, 0) => common::ux::Action::Confirm,
         (TOKEN_CONFIRM_REJECT, 1) => common::ux::Action::Reject,
@@ -89,8 +83,6 @@ unsafe extern "C" fn step_button_callback(
     _layout: *mut c_void,
     button_event: ledger_secure_sdk_sys::nbgl_buttonEvent_t,
 ) {
-    // crate::println!("step_button_callback with button={}", button_event as u8);
-
     let action = match button_event {
         // see nbgl_buttonEvent_t
         0 => common::ux::Action::PreviousPage,

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -46,80 +46,16 @@ impl Default for CachedPage {
     }
 }
 
-// Sends an APDU, and receives the reply, without processing other events in between.
-// Similar to io_exchange fron the C sdk.
-// Using the normal SDK functionalities (Comm::reply and Comm::next_command) was causing
-// messages to be throttled by 0.1s.
-// TODO: refactor after the io revamp in the SDK.
+// TODO: this is problematic because the SDK's handling of ticker events causes
+// throttling of the communication. A better solution is necessary.
 fn io_exchange<R, T>(comm: &mut io::Comm, reply: R) -> T
 where
     R: Into<io::Reply>,
     T: TryFrom<io::ApduHeader>,
     io::Reply: From<<T as TryFrom<io::ApduHeader>>::Error>,
 {
-    use ledger_secure_sdk_sys::seph as sys_seph;
-    #[cfg(any(target_os = "nanox", target_os = "stax", target_os = "flex"))]
-    use ledger_secure_sdk_sys::APDU_BLE;
-    use ledger_secure_sdk_sys::{
-        io_usb_send_apdu_data, G_io_app, APDU_IDLE, APDU_RAW, APDU_USB_HID, IO_APDU_MEDIA_NONE,
-    };
-
-    let sw = reply.into().0;
-    // Append status word
-    comm.apdu_buffer[comm.tx] = (sw >> 8) as u8;
-    comm.apdu_buffer[comm.tx + 1] = sw as u8;
-    comm.tx += 2;
-
-    // apdu_send
-    let mut spi_buffer = [0u8; 256];
-    match unsafe { G_io_app.apdu_state } {
-        APDU_USB_HID => unsafe {
-            ledger_secure_sdk_sys::io_usb_hid_send(
-                Some(io_usb_send_apdu_data),
-                comm.tx as u16,
-                comm.apdu_buffer.as_mut_ptr(),
-            );
-        },
-        APDU_RAW => {
-            let len = (comm.tx as u16).to_be_bytes();
-            sys_seph::seph_send(&[sys_seph::SephTags::RawAPDU as u8, len[0], len[1]]);
-            sys_seph::seph_send(&comm.apdu_buffer[..comm.tx]);
-        }
-        #[cfg(any(target_os = "nanox", target_os = "stax", target_os = "flex"))]
-        APDU_BLE => {
-            ledger_device_sdk::ble::send(&comm.apdu_buffer[..comm.tx]);
-        }
-        _ => (),
-    }
-    comm.tx = 0;
-    comm.rx = 0;
-
-    loop {
-        unsafe {
-            G_io_app.apdu_state = APDU_IDLE;
-            G_io_app.apdu_media = IO_APDU_MEDIA_NONE;
-            G_io_app.apdu_length = 0;
-        }
-
-        let res = loop {
-            // Signal end of command stream from SE to MCU
-            // And prepare reception
-            if !sys_seph::is_status_sent() {
-                sys_seph::send_general_status();
-            }
-
-            // Fetch the next message from the MCU
-            let _rx = sys_seph::seph_recv(&mut spi_buffer, 0);
-
-            if let Some(value) = comm.decode_event(&mut spi_buffer) {
-                break value;
-            }
-        };
-
-        if let io::Event::Command(ins) = res {
-            return ins;
-        }
-    }
+    comm.reply(reply);
+    comm.next_command()
 }
 
 pub struct OutsourcedMemory<'c> {

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -51,7 +51,7 @@ macro_rules! print {
 
 #[macro_export]
 macro_rules! println {
-    () => (print!("\n"));
+    () => ($crate::print!("\n"));
     ($($arg:tt)*) => ({
         $crate::print!("{}\n", format_args!($($arg)*));
     });


### PR DESCRIPTION
Implements support for derivations of symmetric keys from the seed, using [SLIP-21](https://github.com/satoshilabs/slips/blob/master/slip-0021.md).

Because of OS limitations, the SLIP-21 hierarchy of keys is not the same that normal apps use: in fact, the `m/"VANADIUM"` key is chosen as the master seed for the SLIP-0021 hierarchy. Should the SLIP-21 limitation be lifted in the future, we could switch to the normal key hierarchy with no syntactic change in the ECALLs and apps (however, that's a breaking change as it changes the keys obtained for the same paths).

The ECALL gets a derivation path and returns the corresponding key and chaincode.

Incidental change: generalized the Sadik V-app test suite so that it can be run on the real device.

This will depend on https://github.com/LedgerHQ/cargo-ledger/pull/41 in order to run on the real devices. It works on speculos as it does not implement the derivation path restrictions.

---

f7902aed748c6bee6be061545a4aa0efb57ba2ee makes the necessary adjustments to make the app compile after the breaking changes of the io-revamp (version 1.23 of `ledger_device_sdk` and version 1.90 of `ledger_secure_sdk_sys`). This reintroduces the performance issues fixed in #88, but it will be addressed in a future PR.