### PR TITLE
Hashes and proof verification performance

### DIFF
--- a/app-sdk/src/hash.rs
+++ b/app-sdk/src/hash.rs
@@ -1,4 +1,4 @@
-pub use common::accumulator::{Hasher, ResettableHasher};
+pub use common::accumulator::Hasher;
 
 #[cfg(not(target_arch = "riscv32"))]
 mod hashers {
@@ -27,16 +27,6 @@ mod hashers {
 
                 fn digest(self, digest: &mut [u8; $digest_size]) {
                     digest.copy_from_slice(&self.hasher.finalize());
-                }
-            }
-
-            impl ResettableHasher<$digest_size> for $name {
-                fn reset(&mut self) {
-                    self.hasher = <$real>::new();
-                }
-
-                fn digest_inplace<'a, 'b>(&'a mut self, out: &'b mut [u8; $digest_size]) {
-                    out.copy_from_slice(&self.hasher.clone().finalize());
                 }
             }
         };
@@ -122,25 +112,6 @@ mod hashers {
                         HashId::$name as u32,
                         &mut self_clone.0 as *mut _ as *mut u8,
                         digest.as_mut_ptr(),
-                    ) {
-                        panic!("Failed to finalize hash");
-                    }
-                }
-            }
-
-            impl ResettableHasher<$digest_size> for $name {
-                fn reset(&mut self) {
-                    ecalls::hash_init(HashId::$name as u32, &mut self.0 as *mut _ as *mut u8);
-                }
-
-                fn digest_inplace<'a, 'b>(&'a mut self, out: &'b mut [u8; $digest_size]) {
-                    if out.len() != $digest_size {
-                        panic!("Invalid digest size");
-                    }
-                    if 0 == ecalls::hash_final(
-                        HashId::$name as u32,
-                        &mut self.0 as *mut _ as *mut u8,
-                        out.as_mut_ptr(),
                     ) {
                         panic!("Failed to finalize hash");
                     }

--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -204,7 +204,7 @@ pub trait VectorAccumulator<
 pub trait VectorAccumulatorVerifier<
     T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
     const OUTPUT_SIZE: usize,
-    H: ResettableHasher<OUTPUT_SIZE>,
+    H: Hasher<OUTPUT_SIZE>,
 >
 {
     /// The type representing a reference to an inclusion proof.
@@ -434,7 +434,7 @@ impl<H: ResettableHasher<OUTPUT_SIZE>, const OUTPUT_SIZE: usize> UpdateProofVeri
 
 /// A Merkle tree-based implementation of the `VectorAccumulator` trait.
 pub struct MerkleAccumulator<
-    H: ResettableHasher<OUTPUT_SIZE>,
+    H: Hasher<OUTPUT_SIZE>,
     T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
     const OUTPUT_SIZE: usize,
 > {
@@ -488,7 +488,7 @@ impl<
 }
 
 impl<
-        H: ResettableHasher<OUTPUT_SIZE>,
+        H: Hasher<OUTPUT_SIZE>,
         T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
         const OUTPUT_SIZE: usize,
     > VectorAccumulator<T, OUTPUT_SIZE> for MerkleAccumulator<H, T, OUTPUT_SIZE>
@@ -599,7 +599,7 @@ impl<
 }
 
 impl<
-        H: ResettableHasher<OUTPUT_SIZE>,
+        H: Hasher<OUTPUT_SIZE>,
         T: AsRef<[u8]> + Clone + Serialize + DeserializeOwned,
         const OUTPUT_SIZE: usize,
     > MerkleAccumulator<H, T, OUTPUT_SIZE>

--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -61,9 +61,7 @@ pub trait Hasher<const OUTPUT_SIZE: usize>: Sized {
     fn hash(data: &[u8]) -> [u8; OUTPUT_SIZE] {
         let mut hasher = Self::new();
         hasher.update(data);
-        let mut out = [0u8; OUTPUT_SIZE];
-        hasher.digest(&mut out);
-        out
+        hasher.finalize()
     }
 }
 
@@ -619,9 +617,7 @@ impl<
         let mut hasher = H::new();
         hasher.update(&[0x00]);
         hasher.update(data.as_ref());
-        let mut digest = [0u8; OUTPUT_SIZE];
-        hasher.digest(&mut digest);
-        HashOutput(digest)
+        HashOutput(hasher.finalize())
     }
 
     /// Computes the hash for an internal node. A 0x01 byte is prepended to the data before hashing the child nodes.
@@ -634,9 +630,7 @@ impl<
         hasher.update(&[0x01]);
         hasher.update(&left.0);
         hasher.update(&right.0);
-        let mut digest = [0u8; OUTPUT_SIZE];
-        hasher.digest(&mut digest);
-        HashOutput(digest)
+        HashOutput(hasher.finalize())
     }
 }
 

--- a/vm/src/handlers/start_vapp.rs
+++ b/vm/src/handlers/start_vapp.rs
@@ -1,11 +1,11 @@
 use core::cell::RefCell;
 
+use alloc::vec::Vec;
 use alloc::{boxed::Box, rc::Rc};
-use common::client_commands::SectionKind;
 use ledger_device_sdk::io;
 use subtle::ConstantTimeEq;
 
-use alloc::vec::Vec;
+use common::client_commands::SectionKind;
 use common::manifest::Manifest;
 use common::vm::{Cpu, MemorySegment};
 

--- a/vm/src/hash.rs
+++ b/vm/src/hash.rs
@@ -1,4 +1,4 @@
-use common::accumulator::Hasher;
+use common::accumulator::{Hasher, ResettableHasher};
 use ledger_device_sdk::hash::HashInit;
 
 pub struct Sha256Hasher(ledger_device_sdk::hash::sha2::Sha2_256);
@@ -17,6 +17,17 @@ impl Hasher<32> for Sha256Hasher {
 
     #[inline]
     fn digest(mut self, out: &mut [u8; 32]) {
+        self.0.finalize(out).unwrap();
+    }
+}
+
+impl ResettableHasher<32> for Sha256Hasher {
+    #[inline]
+    fn reset(&mut self) {
+        self.0.reset();
+    }
+
+    fn digest_inplace<'a, 'b>(&'a mut self, out: &'b mut [u8; 32]) {
         self.0.finalize(out).unwrap();
     }
 }


### PR DESCRIPTION
Adds a ResettableHasher trait that allows the Vanadium VM app to re-use the same hasher over and over, avoiding allocations in a rather performance-critical code path.