### PR TITLE
Client logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 # so we ignore these folders if present.
 venv
 .venv
+
+# Used when debugging the V-App clients
+**/debug.log

--- a/apps/bitcoin/client/Cargo.toml
+++ b/apps/bitcoin/client/Cargo.toml
@@ -3,6 +3,10 @@ name = "vnd-bitcoin-client"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+debug = ["dep:env_logger", "sdk/debug"]
+
 [dependencies]
 bitcoin = { version = "0.32.0" }
 common = { package = "vnd-bitcoin-common", path = "../common"}
@@ -21,7 +25,7 @@ rustyline = "15.0.0"
 shellwords = "1.1.0"
 postcard = { version = "1.1.1", features = ["alloc"] }
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
-
+env_logger = { version = "0.11.8", optional = true }
 
 [lib]
 name = "vnd_bitcoin_client"

--- a/apps/bitcoin/client/src/main.rs
+++ b/apps/bitcoin/client/src/main.rs
@@ -341,6 +341,14 @@ async fn handle_cli_command(
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "debug")]
+    {
+        let log_file = std::fs::File::create("debug.log")?;
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
+            .target(env_logger::Target::Pipe(Box::new(log_file)))
+            .init();
+    }
+
     let args = Args::parse();
 
     if args.hid && args.native {

--- a/apps/test/client/Cargo.toml
+++ b/apps/test/client/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = []
 speculos-tests = []
+debug = ["dep:env_logger", "sdk/debug"]
 
 [dependencies]
 clap = { version = "4.5.17", features = ["derive"] }
@@ -13,6 +15,7 @@ hidapi = "2.6.3"
 ledger-transport-hid = "0.11.0"
 sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk"}
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
+env_logger = { version = "0.11.8", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/apps/test/client/src/main.rs
+++ b/apps/test/client/src/main.rs
@@ -118,6 +118,14 @@ fn parse_command(line: &str) -> Result<CliCommand, String> {
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "debug")]
+    {
+        let log_file = std::fs::File::create("debug.log")?;
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
+            .target(env_logger::Target::Pipe(Box::new(log_file)))
+            .init();
+    }
+
     let args = Args::parse();
 
     if args.hid && args.native {

--- a/client-sdk/Cargo.toml
+++ b/client-sdk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = ["cargo_toml", "transport"]
 transport = ["hidapi", "ledger-apdu", "ledger-transport-hid"]
+debug = ["dep:log"]
 
 [dependencies]
 
@@ -25,3 +26,4 @@ ledger-transport-hid = { version = "0.11.0", optional = true }
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
 sha2 = "0.10.8"
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "process", "rt", "sync"] }
+log = { version = "0.4.27", optional = true }

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "debug")]
+use log::debug;
+
 use async_trait::async_trait;
 use std::{
     cmp::min,
@@ -178,6 +181,12 @@ impl<E: std::fmt::Debug + Send + Sync + 'static> VAppEngine<E> {
             page_index,
         } = GetPageMessage::deserialize(command)?;
 
+        #[cfg(feature = "debug")]
+        debug!(
+            "Processing get_page: section = {:?}, page_index = {}",
+            section_kind, page_index
+        );
+
         let segment = match section_kind {
             SectionKind::Code => &self.code_seg,
             SectionKind::Data => &self.data_seg,
@@ -295,6 +304,12 @@ impl<E: std::fmt::Debug + Send + Sync + 'static> VAppEngine<E> {
         command: &[u8],
     ) -> Result<(StatusWord, Vec<u8>), VAppEngineError<E>> {
         let msg = CommitPageMessage::deserialize(command)?;
+
+        #[cfg(feature = "debug")]
+        debug!(
+            "Processing commit_page: section = {:?}, page_index = {}",
+            msg.section_kind, msg.page_index,
+        );
 
         let segment = match msg.section_kind {
             SectionKind::Code => {


### PR DESCRIPTION
Adds a 'debug' feature to the `client-sdk`, and uses it to enable debug log files when running the CLIs of the `vnd-test` and `vnd-bitcoin` V-Apps.

Logging in this PR is limited to page loads and commit; more will be added, but this prepares the necessary scaffolding.