### PR TITLE
Dummy slip-21 derivation

### DIFF
--- a/apps/sadik/client/tests/integration_test.rs
+++ b/apps/sadik/client/tests/integration_test.rs
@@ -247,26 +247,27 @@ async fn test_secp256k1_derive_hd_node() {
     }
 }
 
-#[tokio::test]
-async fn test_derive_slip21_key() {
-    let mut setup = test_common::setup().await;
-    let client = &mut setup.client;
+// Disabled until SLIP-21 support is implemented properly in the Rust SDK
+// #[tokio::test]
+// async fn test_derive_slip21_key() {
+//     let mut setup = test_common::setup().await;
+//     let client = &mut setup.client;
 
-    let label1 = b"Vanadium".to_vec();
+//     let label1 = b"Vanadium".to_vec();
 
-    // m/b'Vanadium'
-    assert_eq!(
-        client.get_slip21_key(&[&label1]).await.unwrap(),
-        hex!("ba0ff8c27d6a0c9f7cb3346394b7c57306c5922a2f54a7d51352b9c511e155e0").to_vec()
-    );
+//     // m/b'Vanadium'
+//     assert_eq!(
+//         client.get_slip21_key(&[&label1]).await.unwrap(),
+//         hex!("ba0ff8c27d6a0c9f7cb3346394b7c57306c5922a2f54a7d51352b9c511e155e0").to_vec()
+//     );
 
-    // m/b'Vanadium'/b'Risc-V'
-    let label2 = b"Risc-V".to_vec();
-    assert_eq!(
-        client.get_slip21_key(&[&label1, &label2]).await.unwrap(),
-        hex!("234bbecf423f05569b6de6cbb56cd73cb9c29dec8c6599551a1a5a85bc445e5f").to_vec()
-    );
-}
+//     // m/b'Vanadium'/b'Risc-V'
+//     let label2 = b"Risc-V".to_vec();
+//     assert_eq!(
+//         client.get_slip21_key(&[&label1, &label2]).await.unwrap(),
+//         hex!("234bbecf423f05569b6de6cbb56cd73cb9c29dec8c6599551a1a5a85bc445e5f").to_vec()
+//     );
+// }
 
 #[tokio::test]
 async fn test_secp256k1_point_add() {

--- a/vm/src/handlers/lib/ecall/slip21.rs
+++ b/vm/src/handlers/lib/ecall/slip21.rs
@@ -33,19 +33,24 @@ fn get_seed() -> [u8; 32] {
     let mut path = Vec::with_capacity(SEED_MASTER_PATH.len() + 1);
     path.push(0x00);
     path.extend_from_slice(SEED_MASTER_PATH.as_bytes());
-    let mut seed = [0u8; 32];
-    unsafe {
-        sys::os_perso_derive_node_with_seed_key(
-            sys::HDW_SLIP21,
-            sys::CX_CURVE_SECP256K1,
-            path.as_ptr() as *const u32,
-            path.len() as u32,
-            seed.as_mut_ptr(),
-            core::ptr::null_mut(),
-            core::ptr::null_mut(),
-            0,
-        );
-    }
+    // let mut seed = [0u8; 32];
+    // unsafe {
+    //     sys::os_perso_derive_node_with_seed_key(
+    //         sys::HDW_SLIP21,
+    //         sys::CX_CURVE_SECP256K1,
+    //         path.as_ptr() as *const u32,
+    //         path.len() as u32,
+    //         seed.as_mut_ptr(),
+    //         core::ptr::null_mut(),
+    //         core::ptr::null_mut(),
+    //         0,
+    //     );
+    // }
+
+    // TODO: remove this once the Rust SDK has proper SLIP-21 path support
+    // We use a dummy seed for testing purposes.
+    let mut seed = [42u8; 32];
+
     seed
 }
 


### PR DESCRIPTION
To be reverted once proper SLIP-21 derivation is supported in the Ledger Rust SDK (currently, it crashes on the real device otherwise, as the Vanadium VM app lacks the correct permissions).