### PR TITLE
IO refactoring and performance

### DIFF
--- a/vm/src/io.rs
+++ b/vm/src/io.rs
@@ -1,0 +1,36 @@
+use ledger_device_sdk::io;
+
+// This trait encapsulates some customized functions that the Ledger Vanadium app
+// implements on top of the io::Comm
+pub trait CommExt {
+    fn io_exchange<R, T>(&mut self, reply: R) -> T
+    where
+        R: Into<io::Reply>,
+        T: TryFrom<io::ApduHeader>,
+        io::Reply: From<<T as TryFrom<io::ApduHeader>>::Error>;
+}
+
+impl CommExt for io::Comm {
+    fn io_exchange<R, T>(&mut self, reply: R) -> T
+    where
+        R: Into<io::Reply>,
+        T: TryFrom<io::ApduHeader>,
+        io::Reply: From<<T as TryFrom<io::ApduHeader>>::Error>,
+    {
+        let sw = reply.into().0;
+        self.io_buffer[self.tx_length] = (sw >> 8) as u8;
+        self.io_buffer[self.tx_length + 1] = sw as u8;
+        self.tx_length += 2;
+
+        if self.tx != 0 {
+            ledger_secure_sdk_sys::seph::io_tx(self.apdu_type, &self.apdu_buffer, self.tx);
+            self.tx = 0;
+        } else {
+            ledger_secure_sdk_sys::seph::io_tx(self.apdu_type, &self.io_buffer, self.tx_length);
+        }
+        self.tx_length = 0;
+        self.rx_length = 0;
+
+        self.next_command()
+    }
+}

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -22,6 +22,7 @@ mod aes;
 mod app_ui;
 mod handlers;
 mod hash;
+mod io;
 
 #[cfg(feature = "run_tests")]
 mod app_tests;


### PR DESCRIPTION
Cleans up the `io_exchange` function that we use for interrupted executions into a trait implemented for `Comm`. Using it in the `ecalls` module, avoiding unnecessary ticker delays when communicating with the V-app.