### PR TITLE
Lightweight Psbts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Install pb-rs
         run: cargo install pb-rs
-      - name: Unit tests
+      - name: Unit tests of the common crate
+        working-directory: apps/bitcoin/common
+        run: |
+          cargo +nightly test --target x86_64-unknown-linux-gnu
+      - name: Unit tests of the app crate
         working-directory: apps/bitcoin/app
         run: |
           cargo +nightly test --target x86_64-unknown-linux-gnu

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -334,12 +334,7 @@ pub fn handle_sign_psbt(_app: &mut sdk::App, psbt: &[u8]) -> Result<Response, &'
             .get_non_witness_utxo()
             .map_err(|_| "Invalid non-witness UTXO")?
         {
-            let prevout_txid = input.previous_txid.ok_or("Missing previous txid")?;
-            let prevout_txid = Txid::from_byte_array(*prevout_txid);
             let prevout_index = input.output_index.ok_or("Missing previous output index")? as usize;
-            if non_witness_utxo.compute_txid() != prevout_txid {
-                return Err("Non-witness UTXO does not match the previous output");
-            }
             if let Some(redeem_script) = input.redeem_script {
                 let redeem_script = ScriptBuf::from_bytes(redeem_script.to_vec());
                 if non_witness_utxo.output[prevout_index].script_pubkey != redeem_script.to_p2sh() {

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -9,7 +9,10 @@ use common::{
     account::{Account, ProofOfRegistration},
     bip388::{DescriptorTemplate, SegwitVersion},
     message::{PartialSignature, Response},
-    psbt::{PsbtAccountCoordinates, PsbtAccountOutput},
+    psbt::{
+        PsbtAccount, PsbtAccountCoordinates, PsbtAccountGlobalRead, PsbtAccountInputRead,
+        PsbtAccountOutputRead,
+    },
     script::ToScript,
     taproot::{GetTapLeafHash, GetTapTreeHash},
 };
@@ -22,7 +25,6 @@ use bitcoin::{
     sighash::SighashCache,
     Address, TapLeafHash, TapNodeHash, TapSighashType, Transaction, TxOut,
 };
-use common::psbt::{PsbtAccount, PsbtAccountGlobal, PsbtAccountInput};
 use sdk::{
     curve::{Curve, EcfpPrivateKey, ToPublicKey},
     ux::TagValue,

--- a/apps/bitcoin/common/Cargo.toml
+++ b/apps/bitcoin/common/Cargo.toml
@@ -12,6 +12,9 @@ sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk" }
 serde = { version = "1.0.219", default-features = false, features = ["alloc"] }
 subtle = { version="2.6.1", default-features = false }
 
+[dev-dependencies]
+hex-literal = "0.4.1"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/apps/bitcoin/common/src/fastpsbt.rs
+++ b/apps/bitcoin/common/src/fastpsbt.rs
@@ -20,6 +20,24 @@ const PSBT_GLOBAL_TX_MODIFIABLE: u8 = 0x06;
 const PSBT_GLOBAL_VERSION: u8 = 0xFB;
 const PSBT_GLOBAL_PROPRIETARY: u8 = 0xFC;
 
+const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;
+const PSBT_IN_WITNESS_UTXO: u8 = 0x01;
+const PSBT_IN_SIGHASH_TYPE: u8 = 0x03;
+const PSBT_IN_REDEEM_SCRIPT: u8 = 0x04;
+const PSBT_IN_WITNESS_SCRIPT: u8 = 0x05;
+const PSBT_IN_FINAL_SCRIPTSIG: u8 = 0x07;
+const PSBT_IN_FINAL_SCRIPTWITNESS: u8 = 0x08;
+const PSBT_IN_PREVIOUS_TXID: u8 = 0x0E;
+const PSBT_IN_OUTPUT_INDEX: u8 = 0x0F;
+const PSBT_IN_SEQUENCE: u8 = 0x10;
+const PSBT_IN_REQUIRED_TIME_LOCKTIME: u8 = 0x11;
+const PSBT_IN_REQUIRED_HEIGHT_LOCKTIME: u8 = 0x12;
+
+const PSBT_OUT_REDEEM_SCRIPT: u8 = 0x00;
+const PSBT_OUT_WITNESS_SCRIPT: u8 = 0x01;
+const PSBT_OUT_AMOUNT: u8 = 0x03;
+const PSBT_OUT_SCRIPT: u8 = 0x04;
+
 // A key in a PSBT map, consisting of a type and key data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Key<'a> {
@@ -51,7 +69,7 @@ pub enum PsbtError {
     MapTerminatorMissing,
     DuplicateKey,   // exact duplicate key bytes in same map
     UnsortedKeys,   // only PSBTs with lexicographically sorted maps are supported
-    BadSmallField,  // wrong length for known small field
+    BadValue,       // invalid value
     MissingCounts,  // missing PSBT_GLOBAL_INPUT_COUNT or PSBT_GLOBAL_OUTPUT_COUNT
     CountsTooLarge, // counts don't fit in usize
     NotAllowed,     // not allowed in PSBT v2
@@ -72,16 +90,39 @@ pub struct Psbt<'a> {
 
     pub inputs: Vec<Input<'a>>,
     pub outputs: Vec<Output<'a>>,
+
+    pub version: u32,
+    pub tx_version: i32,
+    pub fallback_locktime: Option<u32>,
+    pub tx_modifiable: Option<u8>,
 }
 
 #[derive(Debug)]
 pub struct Input<'a> {
     map: ParsedMap<'a>,
+
+    pub non_witness_utxo: Option<&'a [u8]>,
+    pub witness_utxo: Option<&'a [u8]>,
+    pub sighash_type: Option<u32>,
+    pub redeem_script: Option<&'a [u8]>,
+    pub witness_script: Option<&'a [u8]>,
+    pub final_scriptsig: Option<&'a [u8]>,
+    pub final_scriptwitness: Option<&'a [u8]>,
+    pub previous_txid: Option<[u8; 32]>,
+    pub output_index: Option<u32>,
+    pub sequence: Option<u32>,
+    pub required_time_locktime: Option<u32>,
+    pub required_height_locktime: Option<u32>,
 }
 
 #[derive(Debug)]
 pub struct Output<'a> {
     map: ParsedMap<'a>,
+
+    pub redeem_script: Option<&'a [u8]>,
+    pub witness_script: Option<&'a [u8]>,
+    pub amount: Option<i64>,
+    pub script: Option<&'a [u8]>,
 }
 
 #[derive(Clone, Copy)]
@@ -221,16 +262,65 @@ impl<'a> Psbt<'a> {
         }
         let mut cur = Cursor::new(raw, MAGIC.len());
 
-        let mut n_inputs = None;
-        let mut n_outputs = None;
+        let mut psbt_version = None::<u32>;
+        let mut tx_version = None::<i32>;
+        let mut fallback_locktime = None::<u32>;
+        let mut n_inputs = None::<u64>;
+        let mut n_outputs = None::<u64>;
+        let mut tx_modifiable = None::<u8>;
 
         let global_map = ParsedMap::from_cursor(&mut cur, |pair: &MapPair| {
+            if !pair.key_data.is_empty() {
+                return Ok(());
+            }
             match pair.key_type {
+                PSBT_GLOBAL_UNSIGNED_TX => {
+                    return Err(PsbtError::NotAllowed);
+                }
+                PSBT_GLOBAL_TX_VERSION => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    tx_version = Some(i32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
+                PSBT_GLOBAL_FALLBACK_LOCKTIME => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    fallback_locktime = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
                 PSBT_GLOBAL_INPUT_COUNT => {
                     n_inputs = Some(u64_from_compact_size(pair.value)?);
                 }
                 PSBT_GLOBAL_OUTPUT_COUNT => {
                     n_outputs = Some(u64_from_compact_size(pair.value)?);
+                }
+                PSBT_GLOBAL_TX_MODIFIABLE => {
+                    if pair.value.len() != 1 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    tx_modifiable = Some(pair.value[0]);
+                }
+                PSBT_GLOBAL_VERSION => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    psbt_version = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
                 }
                 _ => {}
             }
@@ -240,11 +330,23 @@ impl<'a> Psbt<'a> {
         let n_inputs = n_inputs.ok_or(PsbtError::MissingCounts)?;
         let n_outputs = n_outputs.ok_or(PsbtError::MissingCounts)?;
 
-        let inputs = (0..n_inputs)
+        let psbt_version = psbt_version.ok_or(PsbtError::MissingCounts)?;
+        let tx_version = tx_version.ok_or(PsbtError::MissingCounts)?;
+
+        if psbt_version != 2 {
+            return Err(PsbtError::NotAllowed);
+        }
+
+        let inputs_count_usize =
+            usize::try_from(n_inputs).map_err(|_| PsbtError::CountsTooLarge)?;
+        let outputs_count_usize =
+            usize::try_from(n_outputs).map_err(|_| PsbtError::CountsTooLarge)?;
+
+        let inputs = (0..inputs_count_usize)
             .map(|_| Input::from_cursor(&mut cur))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let outputs = (0..n_outputs)
+        let outputs = (0..outputs_count_usize)
             .map(|_| Output::from_cursor(&mut cur))
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -257,21 +359,185 @@ impl<'a> Psbt<'a> {
             global_map,
             inputs,
             outputs,
+            version: psbt_version,
+            tx_version,
+            fallback_locktime,
+            tx_modifiable,
         })
     }
 }
 
 impl<'a> Input<'a> {
     fn from_cursor(cur: &mut Cursor<'a>) -> Result<Self, PsbtError> {
-        let map = ParsedMap::from_cursor(cur, |_pair: &MapPair| Ok(()))?;
-        Ok(Self { map })
+        let mut non_witness_utxo = None;
+        let mut witness_utxo = None;
+        let mut sighash_type = None;
+        let mut redeem_script = None;
+        let mut witness_script = None;
+        let mut final_scriptsig = None;
+        let mut final_scriptwitness = None;
+        let mut previous_txid = None;
+        let mut output_index = None;
+        let mut sequence = None;
+        let mut required_time_locktime = None;
+        let mut required_height_locktime = None;
+
+        let map = ParsedMap::from_cursor(cur, |pair: &MapPair| {
+            if !pair.key_data.is_empty() {
+                return Ok(());
+            }
+            match pair.key_type {
+                PSBT_IN_NON_WITNESS_UTXO => {
+                    non_witness_utxo = Some(pair.value);
+                }
+                PSBT_IN_WITNESS_UTXO => {
+                    witness_utxo = Some(pair.value);
+                }
+                PSBT_IN_SIGHASH_TYPE => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    sighash_type = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
+                PSBT_IN_REDEEM_SCRIPT => {
+                    redeem_script = Some(pair.value);
+                }
+                PSBT_IN_WITNESS_SCRIPT => {
+                    witness_script = Some(pair.value);
+                }
+                PSBT_IN_FINAL_SCRIPTSIG => {
+                    final_scriptsig = Some(pair.value);
+                }
+                PSBT_IN_FINAL_SCRIPTWITNESS => {
+                    final_scriptwitness = Some(pair.value);
+                }
+                PSBT_IN_PREVIOUS_TXID => {
+                    if pair.value.len() != 32 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    let mut txid = [0u8; 32];
+                    txid.copy_from_slice(pair.value);
+                    previous_txid = Some(txid);
+                }
+                PSBT_IN_OUTPUT_INDEX => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    output_index = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
+                PSBT_IN_SEQUENCE => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    sequence = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
+                PSBT_IN_REQUIRED_TIME_LOCKTIME => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    required_time_locktime = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
+                PSBT_IN_REQUIRED_HEIGHT_LOCKTIME => {
+                    if pair.value.len() != 4 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    required_height_locktime = Some(u32::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                    ]));
+                }
+                _ => {}
+            }
+            Ok(())
+        })?;
+
+        Ok(Self {
+            map,
+            non_witness_utxo,
+            witness_utxo,
+            sighash_type,
+            redeem_script,
+            witness_script,
+            final_scriptsig,
+            final_scriptwitness,
+            previous_txid,
+            output_index,
+            sequence,
+            required_time_locktime,
+            required_height_locktime,
+        })
     }
 }
 impl<'a> Output<'a> {
     fn from_cursor(cur: &mut Cursor<'a>) -> Result<Self, PsbtError> {
-        let map = ParsedMap::from_cursor(cur, |_pair: &MapPair| Ok(()))?;
+        let mut redeem_script = None;
+        let mut witness_script = None;
+        let mut amount = None;
+        let mut script = None;
 
-        Ok(Self { map })
+        let map = ParsedMap::from_cursor(cur, |pair: &MapPair| {
+            if !pair.key_data.is_empty() {
+                return Ok(());
+            }
+            match pair.key_type {
+                PSBT_OUT_REDEEM_SCRIPT => {
+                    redeem_script = Some(pair.value);
+                }
+                PSBT_OUT_WITNESS_SCRIPT => {
+                    witness_script = Some(pair.value);
+                }
+                PSBT_OUT_AMOUNT => {
+                    if pair.value.len() != 8 {
+                        return Err(PsbtError::BadValue);
+                    }
+                    amount = Some(i64::from_le_bytes([
+                        pair.value[0],
+                        pair.value[1],
+                        pair.value[2],
+                        pair.value[3],
+                        pair.value[4],
+                        pair.value[5],
+                        pair.value[6],
+                        pair.value[7],
+                    ]));
+                }
+                PSBT_OUT_SCRIPT => {
+                    script = Some(pair.value);
+                }
+                _ => {}
+            }
+            Ok(())
+        })?;
+
+        Ok(Self {
+            map,
+            redeem_script,
+            witness_script,
+            amount,
+            script,
+        })
     }
 }
 
@@ -279,6 +545,7 @@ impl<'a> Output<'a> {
 mod test {
     use super::*;
     use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use hex_literal::hex;
 
     const VALID_PSBT: &'static str = "cHNidP8BAgQBAAAAAQMEAAAAAAEEAQEBBQECAfsEAgAAAAABAP2qAgIAAAACi2Zf4OfqcC9dP65eJYTdm2lEN3xrnoEYNkv/hkQqOWYTAAAAUH9xQ+dl/v00udlaANFBQ8e8ZWi3c/8Z0+0VpGehUw6m+yXOnVtzCPM7aeSUm5QDs4ouBwzvGEwrHIOfJSApchGgqu0M+c6UDXq2s6RX1mHKAAAAABoOiW2ZTQbNg34JFFvnTHKomMgn83CJhxG7mIJ3naqVCAAAAFDB+Dkn1WRZaoy+4uHRa+OvMG/0njULECR32KQwLveX/e8envK98kFzGeZ7f3QRkTjFrNWwSMTpQdRQdhO/7Og6qIRCmBJklYV5Keo6+aRcnAAAAAAKvZcHBAAAAAAiACBUAxjw2HG6OrfLFbYssfGGedd7uQ+zRhDpUy9lVZgmv1RO9wEAAAAAIgAgROs//J4l9zteFJQLgPfThvlQ/EaW7zamDjUa3Igq+Hb+tocCAAAAACIAIJikAWfDfFJz8dDGRvcZ5wT3y1Rxzho0Od3mllEPlYHlg7sgAwAAAAAiACBKVGjcCkkC2NxgguZGk9rzzqAG8KBY5MzTFfm+vVslpmLu8gEAAAAAIgAgr00MjwnaUMATFIQXZuu42pFvDEw0gMQKjkCRRCCnwi/1HSQAAAAAACIAIGYb/o9UFORFY2ROJKcziKQglXIsJdPWagIspZ3IiT1UOzm1AAAAAAAiACDh0X20Ps51dozZHB3Fs5kY/UwQzayX3D5uW75jT0I0SiF1yAQAAAAAIgAgk2tug44aCowkvN3eHI++I/v09t1lg07puohUJaitMnN16CEDAAAAACIAIKbGDEP0Qq+vkN6BPg7+h5h35z69yxPiTLW6dDx0BGuNECcAAAAAAAAiACAF42YWI29NGW9kDAYPsBXblMbaRLXPydreRe16JcPvfAAAAAABASsQJwAAAAAAACIAIAXjZhYjb00Zb2QMBg+wFduUxtpEtc/J2t5F7Xolw+98AQX9AgFUIQMZ97fwu0jrNC0PAYtW3F2DKuKwotSdPQhAI5aJjIkX3iECgXFEyxMHM5/kW0j5cAhcvppwm0iVNC0Fe3lvaRephgghA7XkdUGcyWun5uDUQByg2S2bqORWXDxuK2KKYQ+PIGdmIQPlrYVplvzvvMn4/1grtQ6JaDh+heyYF/mFMSiAnIkpXFSuc2R2qRSj/+wHoZz/UbEtXd4ziK5a50dPZ4isa3apFP7rXJfetE6jrh2H1/pnvTTS4pioiKxsk2t2qRSBEa8aKbmTOe0oiDjtmteZdh0Hc4isbJNrdqkUZxd8DR1rcAF9hUGikKJCV3yzJ3uIrGyTU4gD//8AsmgiBgMHoiONlif9tR7i5AaLjW2skP3hhmCjInLZCdyGslZGLxz1rML9MAAAgAEAAIAAAACAAgAAgAMAAAAjHAAAIgYDGfe38LtI6zQtDwGLVtxdgyrisKLUnT0IQCOWiYyJF94c9azC/TAAAIABAACAAAAAgAIAAIABAAAAIxwAAAEOIFrwzTKgg6tMc9v7Q/I8V4WAgNcjaR/75ec1yAnDtAtKAQ8ECQAAAAEQBAAAAAAAAQMIiBMAAAAAAAABBCJRILP1RJnT7QOYUMrJAGMR3YGZOsBz2w6jZ/fU/kk6FV5CAAEB/QIBVCEDJ1HzCxSlPAsnEPz/7BEzGQp/cDWxHrGzIyfoq3QCelIhA12y7TUnW8SXC/9QR0lmIM5AOSop26+9vi4po5BfzrDnIQKF9obmSKLfpCvQbZldEYgbR8H581S9ce5gmuK52THdMiECdZrk4zzp+zP22COHZLNyMLzGa2FONuWb8gIenoo7+rNUrnNkdqkUwp8TsRTegg/yHxPtVxwoGIQ6tN6IrGt2qRTXAO9/18OwUIbq4mS4Y9JoTXEcuYisbJNrdqkUrGsPP+UzVcSq/gnU5Pxzggcj4zCIrGyTa3apFHL0P3AQrNVmKXhd6agGrlaPuZVMiKxsk1OIA///ALJoIgIC3Nt/ijs79Z4Sxy/3IXG/Rz7PixSMBIsbsi3ujO0QLSYc9azC/TAAAIABAACAAAAAgAIAAIADAAAANiAAACICAydR8wsUpTwLJxD8/+wRMxkKf3A1sR6xsyMn6Kt0AnpSHPWswv0wAACAAQAAgAAAAIACAACAAQAAADYgAAABAwiHEwAAAAAAAAEEIgAgg5JTVA1kaZh98aAl0gND0Fr+jtnDZcBgvzDG+qZirW0A";
 
@@ -287,7 +554,43 @@ mod test {
         let psbt_bin = STANDARD.decode(&VALID_PSBT).unwrap();
         let psbt = Psbt::parse(&psbt_bin).unwrap();
         assert_eq!(psbt.raw_psbt, psbt_bin);
+        assert_eq!(psbt.tx_version, 1);
+        assert_eq!(psbt.fallback_locktime, Some(0));
+        assert_eq!(psbt.tx_modifiable, None);
+
         assert_eq!(psbt.inputs.len(), 1);
+        assert_eq!(psbt.inputs[0].non_witness_utxo, Some(&hex!("02000000028b665fe0e7ea702f5d3fae5e2584dd9b6944377c6b9e8118364bff86442a396613000000507f7143e765fefd34b9d95a00d14143c7bc6568b773ff19d3ed15a467a1530ea6fb25ce9d5b7308f33b69e4949b9403b38a2e070cef184c2b1c839f2520297211a0aaed0cf9ce940d7ab6b3a457d661ca000000001a0e896d994d06cd837e09145be74c72a898c827f370898711bb9882779daa950800000050c1f83927d564596a8cbee2e1d16be3af306ff49e350b102477d8a4302ef797fdef1e9ef2bdf2417319e67b7f74119138c5acd5b048c4e941d4507613bfece83aa8844298126495857929ea3af9a45c9c000000000abd97070400000000220020540318f0d871ba3ab7cb15b62cb1f18679d77bb90fb34610e9532f65559826bf544ef7010000000022002044eb3ffc9e25f73b5e14940b80f7d386f950fc4696ef36a60e351adc882af876feb687020000000022002098a40167c37c5273f1d0c646f719e704f7cb5471ce1a3439dde696510f9581e583bb2003000000002200204a5468dc0a4902d8dc6082e64693daf3cea006f0a058e4ccd315f9bebd5b25a662eef20100000000220020af4d0c8f09da50c01314841766ebb8da916f0c4c3480c40a8e40914420a7c22ff51d240000000000220020661bfe8f5414e44563644e24a73388a42095722c25d3d66a022ca59dc8893d543b39b50000000000220020e1d17db43ece75768cd91c1dc5b39918fd4c10cdac97dc3e6e5bbe634f42344a2175c80400000000220020936b6e838e1a0a8c24bcddde1c8fbe23fbf4f6dd65834ee9ba885425a8ad327375e8210300000000220020a6c60c43f442afaf90de813e0efe879877e73ebdcb13e24cb5ba743c74046b8d102700000000000022002005e36616236f4d196f640c060fb015db94c6da44b5cfc9dade45ed7a25c3ef7c00000000")[..]));
+        assert_eq!(psbt.inputs[0].witness_utxo, Some(&hex!("102700000000000022002005e36616236f4d196f640c060fb015db94c6da44b5cfc9dade45ed7a25c3ef7c")[..]));
+        assert_eq!(psbt.inputs[0].witness_script, Some(&hex!("54210319f7b7f0bb48eb342d0f018b56dc5d832ae2b0a2d49d3d08402396898c8917de2102817144cb1307339fe45b48f970085cbe9a709b4895342d057b796f6917a986082103b5e475419cc96ba7e6e0d4401ca0d92d9ba8e4565c3c6e2b628a610f8f2067662103e5ad856996fcefbcc9f8ff582bb50e8968387e85ec9817f9853128809c89295c54ae736476a914a3ffec07a19cff51b12d5dde3388ae5ae7474f6788ac6b76a914feeb5c97deb44ea3ae1d87d7fa67bd34d2e298a888ac6c936b76a9148111af1a29b99339ed288838ed9ad799761d077388ac6c936b76a91467177c0d1d6b70017d8541a290a242577cb3277b88ac6c93538803ffff00b268")[..]));
+        assert_eq!(
+            psbt.inputs[0].previous_txid,
+            Some(hex!(
+                "5af0cd32a083ab4c73dbfb43f23c57858080d723691ffbe5e735c809c3b40b4a"
+            ))
+        );
+        assert_eq!(psbt.inputs[0].output_index, Some(9));
+        assert_eq!(psbt.inputs[0].final_scriptsig, None);
+        assert_eq!(psbt.inputs[0].final_scriptwitness, None);
+        assert_eq!(psbt.inputs[0].sequence, Some(0));
+
         assert_eq!(psbt.outputs.len(), 2);
+        assert_eq!(psbt.outputs[0].amount, Some(5000));
+        assert_eq!(
+            psbt.outputs[0].script,
+            Some(&hex!("5120b3f54499d3ed039850cac9006311dd81993ac073db0ea367f7d4fe493a155e42")[..])
+        );
+        assert_eq!(psbt.outputs[0].redeem_script, None);
+        assert_eq!(psbt.outputs[1].amount, Some(4999));
+        assert_eq!(
+            psbt.outputs[1].script,
+            Some(&hex!("0020839253540d6469987df1a025d20343d05afe8ed9c365c060bf30c6faa662ad6d")[..])
+        );
+        assert_eq!(psbt.outputs[1].redeem_script, None);
+        assert_eq!(
+            psbt.outputs[1].witness_script,
+            Some(&hex!("5421032751f30b14a53c0b2710fcffec1133190a7f7035b11eb1b32327e8ab74027a5221035db2ed35275bc4970bff5047496620ce40392a29dbafbdbe2e29a3905fceb0e7210285f686e648a2dfa42bd06d995d11881b47c1f9f354bd71ee609ae2b9d931dd322102759ae4e33ce9fb33f6d8238764b37230bcc66b614e36e59bf2021e9e8a3bfab354ae736476a914c29f13b114de820ff21f13ed571c2818843ab4de88ac6b76a914d700ef7fd7c3b05086eae264b863d2684d711cb988ac6c936b76a914ac6b0f3fe53355c4aafe09d4e4fc73820723e33088ac6c936b76a91472f43f7010acd56629785de9a806ae568fb9954c88ac6c93538803ffff00b268")[..])
+        );
+
+        // TODO: add BIP32 derivations
     }
 }

--- a/apps/bitcoin/common/src/fastpsbt.rs
+++ b/apps/bitcoin/common/src/fastpsbt.rs
@@ -6,6 +6,17 @@
 // as slices into the original PSBT data.
 //
 // It is assumed that keys in each map of the PSBT are unique and sorted in ascending order.
+//
+// This is currently only a partial implementation, only targeting what the vnd-bitcoin V-App uses.
+//
+// TODO:
+// - implement missing fields
+// - make all fields of Psbt, Input and Output private and implement accessors (preventing modifications to the
+//   internal state)
+// - Make the compulsory fields from BIP-370 not be typed as an Option<T>; fail in the constructor instead
+// - Add test vectors from BIP-370
+
+#![allow(dead_code)]
 
 use alloc::vec::Vec;
 use bitcoin::{

--- a/apps/bitcoin/common/src/fastpsbt.rs
+++ b/apps/bitcoin/common/src/fastpsbt.rs
@@ -1,0 +1,279 @@
+// This module is a fast implementation of a read-only version of PSBTv2 (Partially Signed Bitcoin Transaction)
+// as specified in BIP-370.
+// It is created by parsing a &[u8] once, and creating an indexed view of the PSBT for fast access, with minimal
+// overhead and validation.
+// Fields that are small are also stored as variables during parsing, while fields that can be large will be stored
+// as slices into the original PSBT data.
+//
+// It is assumed that keys in each map of the PSBT are unique and sorted in ascending order.
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;
+const PSBT_GLOBAL_XPUB: u8 = 0x01;
+const PSBT_GLOBAL_TX_VERSION: u8 = 0x02;
+const PSBT_GLOBAL_FALLBACK_LOCKTIME: u8 = 0x03;
+const PSBT_GLOBAL_INPUT_COUNT: u8 = 0x04;
+const PSBT_GLOBAL_OUTPUT_COUNT: u8 = 0x05;
+const PSBT_GLOBAL_TX_MODIFIABLE: u8 = 0x06;
+const PSBT_GLOBAL_VERSION: u8 = 0xFB;
+const PSBT_GLOBAL_PROPRIETARY: u8 = 0xFC;
+
+// A key in a PSBT map, consisting of a type and key data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Key<'a> {
+    pub key_type: u8,
+    pub key_data: &'a [u8],
+}
+
+impl<'a> PartialOrd for Key<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> Ord for Key<'a> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key_type
+            .cmp(&other.key_type)
+            .then_with(|| self.key_data.cmp(other.key_data))
+    }
+}
+
+// Internal struct to represent a pair of keydata and corresponding value parsed in the map. Note that the keylen and
+// keytype must have been already parsed before creating this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsbtError {
+    InvalidMagic,
+    UnexpectedEof,
+    InvalidCompactSize,
+    MapTerminatorMissing,
+    DuplicateKey,   // exact duplicate key bytes in same map
+    UnsortedKeys,   // only PSBTs with lexicographically sorted maps are supported
+    BadSmallField,  // wrong length for known small field
+    MissingCounts,  // required in v2 to split sections
+    CountsTooLarge, // counts don't fit in usize
+    NotAllowed,     // not allowed in PSBT v2
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MapPair<'a> {
+    pub key_type: u8,
+    pub key_data: &'a [u8],
+    pub value: &'a [u8],
+}
+
+#[derive(Debug)]
+pub struct Psbt<'a> {
+    pub raw_psbt: &'a [u8],
+
+    global_map: ParsedMap<'a>,
+
+    pub inputs: Vec<Input<'a>>,
+    pub outputs: Vec<Output<'a>>,
+}
+
+#[derive(Debug)]
+pub struct Input<'a> {
+    map: ParsedMap<'a>,
+}
+
+#[derive(Debug)]
+pub struct Output<'a> {
+    map: ParsedMap<'a>,
+}
+
+#[derive(Clone, Copy)]
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8], pos: usize) -> Self {
+        Self { buf, pos }
+    }
+    fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], PsbtError> {
+        if self.remaining() < n {
+            return Err(PsbtError::UnexpectedEof);
+        }
+        let start = self.pos;
+        self.pos += n;
+        Ok(&self.buf[start..start + n])
+    }
+
+    fn read_compact_size(&mut self) -> Result<u64, PsbtError> {
+        let b = *self.take(1)?.first().unwrap();
+        match b {
+            n @ 0x00..=0xfc => Ok(n as u64),
+            0xfd => {
+                let s = self.take(2)?;
+                Ok(u16::from_le_bytes([s[0], s[1]]) as u64)
+            }
+            0xfe => {
+                let s = self.take(4)?;
+                Ok(u32::from_le_bytes([s[0], s[1], s[2], s[3]]) as u64)
+            }
+            0xff => {
+                let s = self.take(8)?;
+                Ok(u64::from_le_bytes([
+                    s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7],
+                ]))
+            }
+        }
+    }
+
+    fn read_len_prefixed(&mut self) -> Result<&'a [u8], PsbtError> {
+        let len = self.read_compact_size()?;
+        usize::try_from(len)
+            .ok()
+            .and_then(|n| if self.remaining() >= n { Some(n) } else { None })
+            .ok_or(PsbtError::UnexpectedEof)
+            .and_then(|n| self.take(n))
+    }
+}
+
+#[derive(Debug)]
+struct ParsedMap<'a> {
+    pub pairs: Vec<MapPair<'a>>,
+}
+
+impl<'a> ParsedMap<'a> {
+    fn from_cursor(cur: &mut Cursor<'a>) -> Result<ParsedMap<'a>, PsbtError> {
+        let mut pairs: Vec<MapPair<'a>> = Vec::new();
+
+        loop {
+            // key
+            let key_len = cur.read_compact_size()?;
+            if key_len == 0 {
+                return Ok(ParsedMap { pairs });
+            }
+            let key_len_usize =
+                usize::try_from(key_len).map_err(|_| PsbtError::InvalidCompactSize)?;
+            let key_full = cur.take(key_len_usize)?;
+            // Extract key_type and key_data
+            let key_type = key_full[0];
+            let key_data = &key_full[1..];
+
+            if let Some(last) = pairs.last() {
+                // Check for lexicographic ordering: first key_type then key_data
+                if key_type < last.key_type
+                    || (key_type == last.key_type && key_data < last.key_data)
+                {
+                    return Err(PsbtError::UnsortedKeys);
+                }
+                if key_type == last.key_type && key_data == last.key_data {
+                    return Err(PsbtError::DuplicateKey);
+                }
+            }
+
+            let value = cur.read_len_prefixed()?;
+            pairs.push(MapPair {
+                key_type,
+                key_data,
+                value,
+            });
+        }
+    }
+
+    // Update get() to compare keys correctly
+    fn get(&self, key: &[u8]) -> Option<&'a [u8]> {
+        if key.is_empty() {
+            return None;
+        }
+        let search_key_type = key[0];
+        let search_key_data = &key[1..];
+        self.pairs
+            .binary_search_by(|p| {
+                p.key_type
+                    .cmp(&search_key_type)
+                    .then_with(|| p.key_data.cmp(search_key_data))
+            })
+            .ok()
+            .map(|idx| self.pairs[idx].value)
+    }
+}
+
+impl<'a> Psbt<'a> {
+    pub fn parse(raw: &'a [u8]) -> Result<Self, PsbtError> {
+        const MAGIC: &[u8; 5] = b"psbt\xff";
+        if raw.len() < MAGIC.len() || &raw[..5] != MAGIC {
+            return Err(PsbtError::InvalidMagic);
+        }
+        let mut cur = Cursor::new(raw, MAGIC.len());
+
+        let global_map = ParsedMap::from_cursor(&mut cur)?;
+
+        let n_inputs = global_map
+            .get(&[PSBT_GLOBAL_INPUT_COUNT])
+            .ok_or(PsbtError::MissingCounts)
+            .and_then(|v| {
+                let mut cur = Cursor::new(v, 0);
+                cur.read_compact_size()
+            })
+            .and_then(|n| usize::try_from(n).map_err(|_| PsbtError::CountsTooLarge))?;
+
+        let n_outputs = global_map
+            .get(&[PSBT_GLOBAL_OUTPUT_COUNT])
+            .ok_or(PsbtError::MissingCounts)
+            .and_then(|v| {
+                let mut cur = Cursor::new(v, 0);
+                cur.read_compact_size()
+            })
+            .and_then(|n| usize::try_from(n).map_err(|_| PsbtError::CountsTooLarge))?;
+
+        let inputs = (0..n_inputs)
+            .map(|_| Input::from_cursor(&mut cur))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let outputs = (0..n_outputs)
+            .map(|_| Output::from_cursor(&mut cur))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if cur.remaining() > 0 {
+            return Err(PsbtError::UnexpectedEof);
+        }
+
+        Ok(Self {
+            raw_psbt: raw,
+            global_map,
+            inputs,
+            outputs,
+        })
+    }
+}
+
+impl<'a> Input<'a> {
+    fn from_cursor(cur: &mut Cursor<'a>) -> Result<Self, PsbtError> {
+        let map = ParsedMap::from_cursor(cur)?;
+        Ok(Self { map })
+    }
+}
+impl<'a> Output<'a> {
+    fn from_cursor(cur: &mut Cursor<'a>) -> Result<Self, PsbtError> {
+        let map = ParsedMap::from_cursor(cur)?;
+        Ok(Self { map })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+    const VALID_PSBT: &'static str = "cHNidP8BAgQBAAAAAQMEAAAAAAEEAQEBBQECAfsEAgAAAAABAP2qAgIAAAACi2Zf4OfqcC9dP65eJYTdm2lEN3xrnoEYNkv/hkQqOWYTAAAAUH9xQ+dl/v00udlaANFBQ8e8ZWi3c/8Z0+0VpGehUw6m+yXOnVtzCPM7aeSUm5QDs4ouBwzvGEwrHIOfJSApchGgqu0M+c6UDXq2s6RX1mHKAAAAABoOiW2ZTQbNg34JFFvnTHKomMgn83CJhxG7mIJ3naqVCAAAAFDB+Dkn1WRZaoy+4uHRa+OvMG/0njULECR32KQwLveX/e8envK98kFzGeZ7f3QRkTjFrNWwSMTpQdRQdhO/7Og6qIRCmBJklYV5Keo6+aRcnAAAAAAKvZcHBAAAAAAiACBUAxjw2HG6OrfLFbYssfGGedd7uQ+zRhDpUy9lVZgmv1RO9wEAAAAAIgAgROs//J4l9zteFJQLgPfThvlQ/EaW7zamDjUa3Igq+Hb+tocCAAAAACIAIJikAWfDfFJz8dDGRvcZ5wT3y1Rxzho0Od3mllEPlYHlg7sgAwAAAAAiACBKVGjcCkkC2NxgguZGk9rzzqAG8KBY5MzTFfm+vVslpmLu8gEAAAAAIgAgr00MjwnaUMATFIQXZuu42pFvDEw0gMQKjkCRRCCnwi/1HSQAAAAAACIAIGYb/o9UFORFY2ROJKcziKQglXIsJdPWagIspZ3IiT1UOzm1AAAAAAAiACDh0X20Ps51dozZHB3Fs5kY/UwQzayX3D5uW75jT0I0SiF1yAQAAAAAIgAgk2tug44aCowkvN3eHI++I/v09t1lg07puohUJaitMnN16CEDAAAAACIAIKbGDEP0Qq+vkN6BPg7+h5h35z69yxPiTLW6dDx0BGuNECcAAAAAAAAiACAF42YWI29NGW9kDAYPsBXblMbaRLXPydreRe16JcPvfAAAAAABASsQJwAAAAAAACIAIAXjZhYjb00Zb2QMBg+wFduUxtpEtc/J2t5F7Xolw+98AQX9AgFUIQMZ97fwu0jrNC0PAYtW3F2DKuKwotSdPQhAI5aJjIkX3iECgXFEyxMHM5/kW0j5cAhcvppwm0iVNC0Fe3lvaRephgghA7XkdUGcyWun5uDUQByg2S2bqORWXDxuK2KKYQ+PIGdmIQPlrYVplvzvvMn4/1grtQ6JaDh+heyYF/mFMSiAnIkpXFSuc2R2qRSj/+wHoZz/UbEtXd4ziK5a50dPZ4isa3apFP7rXJfetE6jrh2H1/pnvTTS4pioiKxsk2t2qRSBEa8aKbmTOe0oiDjtmteZdh0Hc4isbJNrdqkUZxd8DR1rcAF9hUGikKJCV3yzJ3uIrGyTU4gD//8AsmgiBgMHoiONlif9tR7i5AaLjW2skP3hhmCjInLZCdyGslZGLxz1rML9MAAAgAEAAIAAAACAAgAAgAMAAAAjHAAAIgYDGfe38LtI6zQtDwGLVtxdgyrisKLUnT0IQCOWiYyJF94c9azC/TAAAIABAACAAAAAgAIAAIABAAAAIxwAAAEOIFrwzTKgg6tMc9v7Q/I8V4WAgNcjaR/75ec1yAnDtAtKAQ8ECQAAAAEQBAAAAAAAAQMIiBMAAAAAAAABBCJRILP1RJnT7QOYUMrJAGMR3YGZOsBz2w6jZ/fU/kk6FV5CAAEB/QIBVCEDJ1HzCxSlPAsnEPz/7BEzGQp/cDWxHrGzIyfoq3QCelIhA12y7TUnW8SXC/9QR0lmIM5AOSop26+9vi4po5BfzrDnIQKF9obmSKLfpCvQbZldEYgbR8H581S9ce5gmuK52THdMiECdZrk4zzp+zP22COHZLNyMLzGa2FONuWb8gIenoo7+rNUrnNkdqkUwp8TsRTegg/yHxPtVxwoGIQ6tN6IrGt2qRTXAO9/18OwUIbq4mS4Y9JoTXEcuYisbJNrdqkUrGsPP+UzVcSq/gnU5Pxzggcj4zCIrGyTa3apFHL0P3AQrNVmKXhd6agGrlaPuZVMiKxsk1OIA///ALJoIgIC3Nt/ijs79Z4Sxy/3IXG/Rz7PixSMBIsbsi3ujO0QLSYc9azC/TAAAIABAACAAAAAgAIAAIADAAAANiAAACICAydR8wsUpTwLJxD8/+wRMxkKf3A1sR6xsyMn6Kt0AnpSHPWswv0wAACAAQAAgAAAAIACAACAAQAAADYgAAABAwiHEwAAAAAAAAEEIgAgg5JTVA1kaZh98aAl0gND0Fr+jtnDZcBgvzDG+qZirW0A";
+
+    #[test]
+    fn test_parse_psbt() {
+        let psbt_bin = STANDARD.decode(&VALID_PSBT).unwrap();
+        let psbt = Psbt::parse(&psbt_bin).unwrap();
+        assert_eq!(psbt.raw_psbt, psbt_bin);
+        assert_eq!(psbt.inputs.len(), 1);
+        assert_eq!(psbt.outputs.len(), 2);
+    }
+}

--- a/apps/bitcoin/common/src/fastpsbt.rs
+++ b/apps/bitcoin/common/src/fastpsbt.rs
@@ -963,5 +963,5 @@ mod test {
         );
     }
 
-    // TODO: add oither missing fields
+    // TODO: add other missing fields
 }

--- a/apps/bitcoin/common/src/lib.rs
+++ b/apps/bitcoin/common/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 
 pub mod account;
 pub mod bip388;
+pub mod fastpsbt;
 pub mod message;
 pub mod psbt;
 pub mod script;

--- a/apps/bitcoin/common/src/psbt.rs
+++ b/apps/bitcoin/common/src/psbt.rs
@@ -476,6 +476,218 @@ pub fn fill_psbt_with_bip388_coordinates(
     Ok(())
 }
 
+mod convert_v0_to_v2 {
+    // This module provides a minimal conversion code from psbtv0 to psbtv2, directly in binary format.
+    // It performs very little validation, so it should only be used to convert a serialized PSBTv0 to PSBTv2
+    // before passing it to some other code that expects PSBTv2.
+    //
+    // Not thoroughly tested.
+
+    use alloc::{vec, vec::Vec};
+    use bitcoin::{
+        consensus::{encode as enc, Decodable, Encodable},
+        hashes::Hash,
+        io::{Cursor, Read},
+        Transaction,
+    };
+
+    struct KV {
+        key: Vec<u8>,
+        val: Vec<u8>,
+    }
+
+    fn read_varint<R: Read>(r: &mut R) -> Result<u64, &'static str> {
+        Ok(enc::VarInt::consensus_decode(r)
+            .map_err(|_| "Failed to read varint")?
+            .0)
+    }
+    fn write_varint(buf: &mut Vec<u8>, n: u64) -> Result<(), &'static str> {
+        enc::VarInt(n)
+            .consensus_encode(buf)
+            .map_err(|_| "Failed to write varint")?;
+        Ok(())
+    }
+    fn read_bytes<R: Read>(r: &mut R, len: usize) -> Result<Vec<u8>, &'static str> {
+        let mut v = vec![0u8; len];
+        r.read_exact(&mut v).map_err(|_| "Failed to read bytes")?;
+        Ok(v)
+    }
+    fn read_map<R: Read>(r: &mut R) -> Result<Vec<KV>, &'static str> {
+        let mut out = Vec::new();
+        loop {
+            let key_len = read_varint(r)? as usize;
+            if key_len == 0 {
+                break;
+            } // map sep
+            let key = read_bytes(r, key_len)?;
+            let val_len = read_varint(r)? as usize;
+            let val = read_bytes(r, val_len)?;
+            out.push(KV { key, val });
+        }
+        Ok(out)
+    }
+    fn key_type(raw_key: &[u8]) -> Result<u64, &'static str> {
+        let mut c = Cursor::new(raw_key);
+        Ok(enc::VarInt::consensus_decode(&mut c)
+            .map_err(|_| "Failed to read key type")?
+            .0)
+    }
+    fn mk_key(typ: u64, keydata: &[u8]) -> Result<Vec<u8>, &'static str> {
+        let mut k = Vec::with_capacity(1 + keydata.len() + 9);
+        enc::VarInt(typ)
+            .consensus_encode(&mut k)
+            .map_err(|_| "Failed to write key")?;
+        k.extend_from_slice(keydata);
+        Ok(k)
+    }
+    fn push_kv(
+        glob: &mut Vec<KV>,
+        typ: u64,
+        keydata: &[u8],
+        val: Vec<u8>,
+    ) -> Result<(), &'static str> {
+        glob.push(KV {
+            key: mk_key(typ, keydata)?,
+            val,
+        });
+        Ok(())
+    }
+
+    fn write_map_sorted(buf: &mut Vec<u8>, mut m: Vec<KV>) -> Result<(), &'static str> {
+        m.sort_unstable_by(|a, b| a.key.cmp(&b.key).then_with(|| a.val.cmp(&b.val)));
+        for KV { key, val } in m {
+            write_varint(buf, key.len() as u64)?;
+            buf.extend_from_slice(&key);
+            write_varint(buf, val.len() as u64)?;
+            buf.extend_from_slice(&val);
+        }
+        buf.push(0x00); // map separator
+        Ok(())
+    }
+
+    /// Converts a PSBTv0 to PSBTv2 in binary format, and makes sure that the keys are sorted in each map.
+    /// Returns an error if the input is not a valid PSBTv0; however, very little validation is performed on the
+    /// input PSBTv0.
+    pub fn psbt_v0_to_v2(raw_psbt: &[u8]) -> Result<Vec<u8>, &'static str> {
+        // Header
+        if raw_psbt.len() < 5 || &raw_psbt[0..5] != b"psbt\xff" {
+            return Err("Not a PSBT");
+        }
+        let mut cur = Cursor::new(&raw_psbt[5..]);
+
+        // Parse v0 global map and capture unsigned tx
+        let mut g0 = read_map(&mut cur)?;
+        let mut unsigned_tx_bytes: Option<Vec<u8>> = None;
+        let mut g_pass = Vec::<KV>::new();
+
+        for kv in g0.drain(..) {
+            let t = key_type(&kv.key)?;
+            match t {
+            0x00 /* PSBT_GLOBAL_UNSIGNED_TX */ => { unsigned_tx_bytes = Some(kv.val); }
+            0x02 | 0x03 | 0x04 | 0x05 | 0xFB => { return Err("v2 fields already present"); }
+            _ => g_pass.push(kv),
+        }
+        }
+        let utx = unsigned_tx_bytes.ok_or("missing unsigned tx")?;
+        let tx: Transaction =
+            enc::deserialize(&utx).map_err(|_| "Failed to deserialize unsigned tx")?;
+
+        // Knowing counts, parse inputs and outputs from v0
+        let n_inputs = tx.input.len();
+        let n_outputs = tx.output.len();
+
+        let mut ins_v0: Vec<Vec<KV>> = Vec::with_capacity(n_inputs);
+        for _ in 0..n_inputs {
+            ins_v0.push(read_map(&mut cur)?);
+        }
+        let mut outs_v0: Vec<Vec<KV>> = Vec::with_capacity(n_outputs);
+        for _ in 0..n_outputs {
+            outs_v0.push(read_map(&mut cur)?);
+        }
+
+        // Build v2
+        let mut out = Vec::<u8>::new();
+        out.extend_from_slice(b"psbt\xff");
+
+        // v2 global map
+        let mut g2 = g_pass;
+        // PSBT_GLOBAL_VERSION = 0xFB, value: u32 LE 2
+        push_kv(&mut g2, 0xFB, &[], 2u32.to_le_bytes().to_vec())?;
+        // PSBT_GLOBAL_TX_VERSION = 0x02, value: i32 LE
+        push_kv(&mut g2, 0x02, &[], tx.version.0.to_le_bytes().to_vec())?;
+        // PSBT_GLOBAL_FALLBACK_LOCKTIME = 0x03, value: u32 LE
+        push_kv(
+            &mut g2,
+            0x03,
+            &[],
+            tx.lock_time.to_consensus_u32().to_le_bytes().to_vec(),
+        )?;
+        // PSBT_GLOBAL_INPUT_COUNT = 0x04, value: compactsize
+        {
+            let mut v = Vec::new();
+            write_varint(&mut v, n_inputs as u64)?;
+            push_kv(&mut g2, 0x04, &[], v)?;
+        }
+        // PSBT_GLOBAL_OUTPUT_COUNT = 0x05, value: compactsize
+        {
+            let mut v = Vec::new();
+            write_varint(&mut v, n_outputs as u64)?;
+            push_kv(&mut g2, 0x05, &[], v)?;
+        }
+        write_map_sorted(&mut out, g2)?;
+
+        // v2 inputs: copy v0 fields + add {prev_txid, vout, sequence}
+        for (i, mut imap) in ins_v0.into_iter().enumerate() {
+            let txin = &tx.input[i];
+
+            // PSBT_IN_PREVIOUS_TXID = 0x0e, value: 32-byte txid
+            {
+                let mut v = Vec::with_capacity(32);
+                // Use the hash's underlying bytes
+                v.extend_from_slice(txin.previous_output.txid.as_raw_hash().as_byte_array());
+                push_kv(&mut imap, 0x0e, &[], v)?;
+            }
+            // PSBT_IN_OUTPUT_INDEX = 0x0f, value: u32 LE
+            push_kv(
+                &mut imap,
+                0x0f,
+                &[],
+                txin.previous_output.vout.to_le_bytes().to_vec(),
+            )?;
+            // PSBT_IN_SEQUENCE = 0x10, value: u32 LE (include unconditionally)
+            push_kv(&mut imap, 0x10, &[], txin.sequence.0.to_le_bytes().to_vec())?;
+
+            write_map_sorted(&mut out, imap)?;
+        }
+
+        // v2 outputs: copy v0 fields + add {amount, script}
+        for (j, mut omap) in outs_v0.into_iter().enumerate() {
+            let txout = &tx.output[j];
+
+            // PSBT_OUT_AMOUNT = 0x03, value: i64 LE
+            push_kv(
+                &mut omap,
+                0x03,
+                &[],
+                (txout.value.to_sat() as i64).to_le_bytes().to_vec(),
+            )?;
+            // PSBT_OUT_SCRIPT = 0x04, value: scriptPubKey bytes
+            push_kv(
+                &mut omap,
+                0x04,
+                &[],
+                txout.script_pubkey.as_bytes().to_vec(),
+            )?;
+
+            write_map_sorted(&mut out, omap)?;
+        }
+
+        Ok(out)
+    }
+}
+
+pub use convert_v0_to_v2::psbt_v0_to_v2;
+
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine as _};
@@ -652,5 +864,16 @@ mod tests {
             ))
         );
         assert_eq!(psbt.outputs[1].get_account_coordinates().unwrap(), None);
+    }
+
+    #[test]
+    fn test_psbt_v0_to_v2() {
+        let psbt_v0 = "cHNidP8BAIkBAAAAAVrwzTKgg6tMc9v7Q/I8V4WAgNcjaR/75ec1yAnDtAtKCQAAAAAAAAAAAogTAAAAAAAAIlEgs/VEmdPtA5hQyskAYxHdgZk6wHPbDqNn99T+SToVXkKHEwAAAAAAACIAIIOSU1QNZGmYffGgJdIDQ9Ba/o7Zw2XAYL8wxvqmYq1tAAAAAAABAP2qAgIAAAACi2Zf4OfqcC9dP65eJYTdm2lEN3xrnoEYNkv/hkQqOWYTAAAAUH9xQ+dl/v00udlaANFBQ8e8ZWi3c/8Z0+0VpGehUw6m+yXOnVtzCPM7aeSUm5QDs4ouBwzvGEwrHIOfJSApchGgqu0M+c6UDXq2s6RX1mHKAAAAABoOiW2ZTQbNg34JFFvnTHKomMgn83CJhxG7mIJ3naqVCAAAAFDB+Dkn1WRZaoy+4uHRa+OvMG/0njULECR32KQwLveX/e8envK98kFzGeZ7f3QRkTjFrNWwSMTpQdRQdhO/7Og6qIRCmBJklYV5Keo6+aRcnAAAAAAKvZcHBAAAAAAiACBUAxjw2HG6OrfLFbYssfGGedd7uQ+zRhDpUy9lVZgmv1RO9wEAAAAAIgAgROs//J4l9zteFJQLgPfThvlQ/EaW7zamDjUa3Igq+Hb+tocCAAAAACIAIJikAWfDfFJz8dDGRvcZ5wT3y1Rxzho0Od3mllEPlYHlg7sgAwAAAAAiACBKVGjcCkkC2NxgguZGk9rzzqAG8KBY5MzTFfm+vVslpmLu8gEAAAAAIgAgr00MjwnaUMATFIQXZuu42pFvDEw0gMQKjkCRRCCnwi/1HSQAAAAAACIAIGYb/o9UFORFY2ROJKcziKQglXIsJdPWagIspZ3IiT1UOzm1AAAAAAAiACDh0X20Ps51dozZHB3Fs5kY/UwQzayX3D5uW75jT0I0SiF1yAQAAAAAIgAgk2tug44aCowkvN3eHI++I/v09t1lg07puohUJaitMnN16CEDAAAAACIAIKbGDEP0Qq+vkN6BPg7+h5h35z69yxPiTLW6dDx0BGuNECcAAAAAAAAiACAF42YWI29NGW9kDAYPsBXblMbaRLXPydreRe16JcPvfAAAAAABASsQJwAAAAAAACIAIAXjZhYjb00Zb2QMBg+wFduUxtpEtc/J2t5F7Xolw+98AQX9AgFUIQMZ97fwu0jrNC0PAYtW3F2DKuKwotSdPQhAI5aJjIkX3iECgXFEyxMHM5/kW0j5cAhcvppwm0iVNC0Fe3lvaRephgghA7XkdUGcyWun5uDUQByg2S2bqORWXDxuK2KKYQ+PIGdmIQPlrYVplvzvvMn4/1grtQ6JaDh+heyYF/mFMSiAnIkpXFSuc2R2qRSj/+wHoZz/UbEtXd4ziK5a50dPZ4isa3apFP7rXJfetE6jrh2H1/pnvTTS4pioiKxsk2t2qRSBEa8aKbmTOe0oiDjtmteZdh0Hc4isbJNrdqkUZxd8DR1rcAF9hUGikKJCV3yzJ3uIrGyTU4gD//8AsmgiBgMHoiONlif9tR7i5AaLjW2skP3hhmCjInLZCdyGslZGLxz1rML9MAAAgAEAAIAAAACAAgAAgAMAAAAjHAAAIgYDGfe38LtI6zQtDwGLVtxdgyrisKLUnT0IQCOWiYyJF94c9azC/TAAAIABAACAAAAAgAIAAIABAAAAIxwAAAAAAQH9AgFUIQMnUfMLFKU8CycQ/P/sETMZCn9wNbEesbMjJ+irdAJ6UiEDXbLtNSdbxJcL/1BHSWYgzkA5Kinbr72+LimjkF/OsOchAoX2huZIot+kK9BtmV0RiBtHwfnzVL1x7mCa4rnZMd0yIQJ1muTjPOn7M/bYI4dks3IwvMZrYU425ZvyAh6eijv6s1Suc2R2qRTCnxOxFN6CD/IfE+1XHCgYhDq03oisa3apFNcA73/Xw7BQhuriZLhj0mhNcRy5iKxsk2t2qRSsaw8/5TNVxKr+CdTk/HOCByPjMIisbJNrdqkUcvQ/cBCs1WYpeF3pqAauVo+5lUyIrGyTU4gD//8AsmgiAgLc23+KOzv1nhLHL/chcb9HPs+LFIwEixuyLe6M7RAtJhz1rML9MAAAgAEAAIAAAACAAgAAgAMAAAA2IAAAIgIDJ1HzCxSlPAsnEPz/7BEzGQp/cDWxHrGzIyfoq3QCelIc9azC/TAAAIABAACAAAAAgAIAAIABAAAANiAAAAA=";
+        let psbt_v2 = "cHNidP8BAgQBAAAAAQMEAAAAAAEEAQEBBQECAfsEAgAAAAABAP2qAgIAAAACi2Zf4OfqcC9dP65eJYTdm2lEN3xrnoEYNkv/hkQqOWYTAAAAUH9xQ+dl/v00udlaANFBQ8e8ZWi3c/8Z0+0VpGehUw6m+yXOnVtzCPM7aeSUm5QDs4ouBwzvGEwrHIOfJSApchGgqu0M+c6UDXq2s6RX1mHKAAAAABoOiW2ZTQbNg34JFFvnTHKomMgn83CJhxG7mIJ3naqVCAAAAFDB+Dkn1WRZaoy+4uHRa+OvMG/0njULECR32KQwLveX/e8envK98kFzGeZ7f3QRkTjFrNWwSMTpQdRQdhO/7Og6qIRCmBJklYV5Keo6+aRcnAAAAAAKvZcHBAAAAAAiACBUAxjw2HG6OrfLFbYssfGGedd7uQ+zRhDpUy9lVZgmv1RO9wEAAAAAIgAgROs//J4l9zteFJQLgPfThvlQ/EaW7zamDjUa3Igq+Hb+tocCAAAAACIAIJikAWfDfFJz8dDGRvcZ5wT3y1Rxzho0Od3mllEPlYHlg7sgAwAAAAAiACBKVGjcCkkC2NxgguZGk9rzzqAG8KBY5MzTFfm+vVslpmLu8gEAAAAAIgAgr00MjwnaUMATFIQXZuu42pFvDEw0gMQKjkCRRCCnwi/1HSQAAAAAACIAIGYb/o9UFORFY2ROJKcziKQglXIsJdPWagIspZ3IiT1UOzm1AAAAAAAiACDh0X20Ps51dozZHB3Fs5kY/UwQzayX3D5uW75jT0I0SiF1yAQAAAAAIgAgk2tug44aCowkvN3eHI++I/v09t1lg07puohUJaitMnN16CEDAAAAACIAIKbGDEP0Qq+vkN6BPg7+h5h35z69yxPiTLW6dDx0BGuNECcAAAAAAAAiACAF42YWI29NGW9kDAYPsBXblMbaRLXPydreRe16JcPvfAAAAAABASsQJwAAAAAAACIAIAXjZhYjb00Zb2QMBg+wFduUxtpEtc/J2t5F7Xolw+98AQX9AgFUIQMZ97fwu0jrNC0PAYtW3F2DKuKwotSdPQhAI5aJjIkX3iECgXFEyxMHM5/kW0j5cAhcvppwm0iVNC0Fe3lvaRephgghA7XkdUGcyWun5uDUQByg2S2bqORWXDxuK2KKYQ+PIGdmIQPlrYVplvzvvMn4/1grtQ6JaDh+heyYF/mFMSiAnIkpXFSuc2R2qRSj/+wHoZz/UbEtXd4ziK5a50dPZ4isa3apFP7rXJfetE6jrh2H1/pnvTTS4pioiKxsk2t2qRSBEa8aKbmTOe0oiDjtmteZdh0Hc4isbJNrdqkUZxd8DR1rcAF9hUGikKJCV3yzJ3uIrGyTU4gD//8AsmgiBgMHoiONlif9tR7i5AaLjW2skP3hhmCjInLZCdyGslZGLxz1rML9MAAAgAEAAIAAAACAAgAAgAMAAAAjHAAAIgYDGfe38LtI6zQtDwGLVtxdgyrisKLUnT0IQCOWiYyJF94c9azC/TAAAIABAACAAAAAgAIAAIABAAAAIxwAAAEOIFrwzTKgg6tMc9v7Q/I8V4WAgNcjaR/75ec1yAnDtAtKAQ8ECQAAAAEQBAAAAAAAAQMIiBMAAAAAAAABBCJRILP1RJnT7QOYUMrJAGMR3YGZOsBz2w6jZ/fU/kk6FV5CAAEB/QIBVCEDJ1HzCxSlPAsnEPz/7BEzGQp/cDWxHrGzIyfoq3QCelIhA12y7TUnW8SXC/9QR0lmIM5AOSop26+9vi4po5BfzrDnIQKF9obmSKLfpCvQbZldEYgbR8H581S9ce5gmuK52THdMiECdZrk4zzp+zP22COHZLNyMLzGa2FONuWb8gIenoo7+rNUrnNkdqkUwp8TsRTegg/yHxPtVxwoGIQ6tN6IrGt2qRTXAO9/18OwUIbq4mS4Y9JoTXEcuYisbJNrdqkUrGsPP+UzVcSq/gnU5Pxzggcj4zCIrGyTa3apFHL0P3AQrNVmKXhd6agGrlaPuZVMiKxsk1OIA///ALJoIgIC3Nt/ijs79Z4Sxy/3IXG/Rz7PixSMBIsbsi3ujO0QLSYc9azC/TAAAIABAACAAAAAgAIAAIADAAAANiAAACICAydR8wsUpTwLJxD8/+wRMxkKf3A1sR6xsyMn6Kt0AnpSHPWswv0wAACAAQAAgAAAAIACAACAAQAAADYgAAABAwiHEwAAAAAAAAEEIgAgg5JTVA1kaZh98aAl0gND0Fr+jtnDZcBgvzDG+qZirW0A";
+        let psbt_v0_bytes = STANDARD.decode(psbt_v0).unwrap();
+        let psbt_v2_bytes = STANDARD.decode(psbt_v2).unwrap();
+
+        let psbt_v2_converted = psbt_v0_to_v2(&psbt_v0_bytes).unwrap();
+        assert_eq!(psbt_v2_converted, psbt_v2_bytes);
     }
 }

--- a/apps/bitcoin/common/src/psbt.rs
+++ b/apps/bitcoin/common/src/psbt.rs
@@ -128,7 +128,7 @@ impl PsbtAccountGlobalRead for Psbt {
         };
 
         if let Some(value) = self.proprietary.get(&key) {
-            if value.len() < 1 {
+            if value.is_empty() {
                 return Err("Empty account value");
             }
             match value[0] {
@@ -174,7 +174,7 @@ impl PsbtAccountGlobalRead for Psbt {
         };
 
         if let Some(value) = self.proprietary.get(&key) {
-            if value.len() < 1 {
+            if value.is_empty() {
                 return Err("Empty account value");
             }
             Ok(Some(value.to_vec()))
@@ -403,7 +403,7 @@ impl<'a> PsbtAccountGlobalRead for crate::fastpsbt::Psbt<'a> {
         // 0xFC == PSBT_GLOBAL_PROPRIETARY
         for (kd, value) in self.iter_keys(0xFC) {
             if kd == key_data.as_slice() {
-                if value.len() < 1 {
+                if value.is_empty() {
                     return Err("Empty account value");
                 }
                 return match value[0] {
@@ -452,7 +452,7 @@ impl<'a> PsbtAccountGlobalRead for crate::fastpsbt::Psbt<'a> {
 
         for (kd, value) in self.iter_keys(0xFC) {
             if kd == key_data.as_slice() {
-                if value.len() < 1 {
+                if value.is_empty() {
                     return Err("Empty account value");
                 }
                 return Ok(Some(value.to_vec()));


### PR DESCRIPTION
This crate implements a lightweight replacement of (a subset of) the `psbt` module from `rust-bitcoin`, which unfortunately is not optimized for embedded and has a huge impact in code size. Moreover, we can take advantage of the fact that PSBTs are essentially read-only for the bitcoin V-App - avoiding altogether the usage of heavy datastructures (BTrees) to store the PSBT maps.

This also migrates the V-App to require PSBTv2 with sorted keys. The CLI was modified to convert from Psbtv0 to the appropriate sorted PsbtV2 format.

The change saves over 60kb in binary size.