### PR TITLE
Support for `print!` and `println!` in V-Apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv
 
 # Used when debugging the V-App clients
 **/debug.log
+**/print.log
 
 # Produced in integration tests with speculos
 **/test.log

--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -62,6 +62,13 @@ forward_to_ecall! {
     /// The number of bytes received.
     pub fn xrecv(buffer: *mut u8, max_size: usize) -> usize;
 
+    /// Sends a buffer to print to the host.
+    ///
+    /// # Parameters
+    /// - `buffer`: Pointer to the buffer to print, that must be a valid UTF-8 string.
+    /// - `size`: Size of the buffer.
+    pub fn print(buffer: *const u8, size: usize);
+
     /// Waits for the next event.
     ///
     /// # Parameters

--- a/app-sdk/src/ecalls_native.rs
+++ b/app-sdk/src/ecalls_native.rs
@@ -1,9 +1,9 @@
-use core::panic;
 use lazy_static::lazy_static;
 use rand::TryRngCore;
 use std::{
     io::{self, Read, Write},
     net::{TcpListener, TcpStream},
+    str::from_utf8,
     sync::Mutex,
     thread::sleep,
     time::Duration,
@@ -203,6 +203,15 @@ pub fn xrecv(buffer: *mut u8, max_size: usize) -> usize {
     let slice = unsafe { std::slice::from_raw_parts_mut(buffer, expected) };
     stream.read_exact(slice).expect("TCP read failed");
     expected
+}
+
+pub fn print(buffer: *const u8, size: usize) {
+    // SAFETY: caller guarantees [buffer, buffer+size) is valid.
+    let data = unsafe { std::slice::from_raw_parts(buffer, size) };
+
+    // TODO: too simplistic: we should allow the client to decide how the print stream should be handled
+    // For now, we just print it raw to the console
+    print!("{}", from_utf8(data).unwrap());
 }
 
 pub fn get_event(data: *mut EventData) -> u32 {

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -19,6 +19,7 @@ delegate_ecall!(exit, !, (status: i32));
 delegate_ecall!(fatal, !, (msg: *const u8), (size: usize));
 delegate_ecall!(xsend, (buffer: *const u8), (size: usize));
 delegate_ecall!(xrecv, usize, (buffer: *mut u8), (size: usize));
+delegate_ecall!(print, (buffer: *const u8), (size: usize));
 
 delegate_ecall!(get_event, u32, (data: *mut EventData));
 delegate_ecall!(show_page, u32, (page_desc: *const u8), (page_desc_len: usize));

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -8,7 +8,7 @@ mod merkle;
 
 use handlers::*;
 
-use alloc::{string::ToString, vec::Vec};
+use alloc::vec::Vec;
 
 use common::message::{Request, Response};
 use sdk::App;

--- a/apps/bitcoin/client/src/client.rs
+++ b/apps/bitcoin/client/src/client.rs
@@ -65,11 +65,11 @@ impl std::error::Error for BitcoinClientError {
 }
 
 pub struct BitcoinClient {
-    app_transport: Box<dyn VAppTransport + Send + Sync>,
+    app_transport: Box<dyn VAppTransport + Send>,
 }
 
 impl<'a> BitcoinClient {
-    pub fn new(app_transport: Box<dyn VAppTransport + Send + Sync>) -> Self {
+    pub fn new(app_transport: Box<dyn VAppTransport + Send>) -> Self {
         Self { app_transport }
     }
 

--- a/apps/bitcoin/client/src/main.rs
+++ b/apps/bitcoin/client/src/main.rs
@@ -14,6 +14,7 @@ use client::BitcoinClient;
 
 mod client;
 
+use sdk::linewriter::FileLineWriter;
 use sdk::vanadium_client::client_utils::{create_default_client, ClientType};
 
 use std::borrow::Cow;
@@ -376,8 +377,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         ClientType::Tcp
     };
-    let mut bitcoin_client =
-        BitcoinClient::new(create_default_client("vnd-bitcoin", client_type).await?);
+    let print_writer = Box::new(FileLineWriter::new("print.log", true, true)?);
+    let mut bitcoin_client = BitcoinClient::new(
+        create_default_client("vnd-bitcoin", client_type, Some(print_writer)).await?,
+    );
 
     let mut rl = Editor::<CommandCompleter, rustyline::history::DefaultHistory>::new()?;
     rl.set_helper(Some(CommandCompleter));

--- a/apps/bitcoin/client/src/main.rs
+++ b/apps/bitcoin/client/src/main.rs
@@ -377,7 +377,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         ClientType::Tcp
     };
-    let print_writer = Box::new(FileLineWriter::new("print.log", true, true)?);
+    let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
     let mut bitcoin_client = BitcoinClient::new(
         create_default_client("vnd-bitcoin", client_type, Some(print_writer)).await?,
     );

--- a/apps/sadik/client/src/client.rs
+++ b/apps/sadik/client/src/client.rs
@@ -41,11 +41,11 @@ impl std::error::Error for SadikClientError {
 }
 
 pub struct SadikClient {
-    app_transport: Box<dyn VAppTransport + Send + Sync>,
+    app_transport: Box<dyn VAppTransport + Send>,
 }
 
 impl SadikClient {
-    pub fn new(app_transport: Box<dyn VAppTransport + Send + Sync>) -> Self {
+    pub fn new(app_transport: Box<dyn VAppTransport + Send>) -> Self {
         Self { app_transport }
     }
 

--- a/apps/test/app/src/commands.rs
+++ b/apps/test/app/src/commands.rs
@@ -10,6 +10,7 @@ pub enum Command {
     CountPrimes,
     ShowUxScreen = 0x80,
     DeviceProp = 0x81,
+    Print = 0xfe,
     Panic = 0xff,
 }
 
@@ -25,6 +26,7 @@ impl TryFrom<u8> for Command {
             0x04 => Ok(Command::CountPrimes),
             0x80 => Ok(Command::ShowUxScreen),
             0x81 => Ok(Command::DeviceProp),
+            0xfe => Ok(Command::Print),
             0xff => Ok(Command::Panic),
             _ => Err(()),
         }

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+use alloc::vec;
+
 mod commands;
 mod handlers;
 
@@ -51,6 +53,11 @@ pub fn main() {
                 }
                 let property_id = u32::from_be_bytes([msg[1], msg[2], msg[3], msg[4]]);
                 sdk::get_device_property(property_id).to_be_bytes().to_vec()
+            }
+            Command::Print => {
+                let print_msg = core::str::from_utf8(&msg[1..]).unwrap();
+                sdk::println!("{}", print_msg);
+                vec![]
             }
             Command::Panic => {
                 let panic_msg = core::str::from_utf8(&msg[1..]).unwrap();

--- a/apps/test/client/src/client.rs
+++ b/apps/test/client/src/client.rs
@@ -38,11 +38,11 @@ impl std::error::Error for TestClientError {
 }
 
 pub struct TestClient {
-    app_transport: Box<dyn VAppTransport + Send + Sync>,
+    app_transport: Box<dyn VAppTransport + Send>,
 }
 
 impl TestClient {
-    pub fn new(app_transport: Box<dyn VAppTransport + Send + Sync>) -> Self {
+    pub fn new(app_transport: Box<dyn VAppTransport + Send>) -> Self {
         Self { app_transport }
     }
 

--- a/apps/test/client/src/client.rs
+++ b/apps/test/client/src/client.rs
@@ -122,6 +122,15 @@ impl TestClient {
         Ok(u32::from_be_bytes(result_raw.try_into().unwrap()))
     }
 
+    pub async fn print(&mut self, print_msg: &str) -> Result<(), TestClientError> {
+        let mut msg: Vec<u8> = Vec::new();
+        msg.extend_from_slice(&[Command::Print as u8]);
+        msg.extend_from_slice(print_msg.as_bytes());
+
+        self.app_transport.send_message(&msg).await?;
+        Ok(())
+    }
+
     pub async fn panic(&mut self, panic_msg: &str) -> Result<(), TestClientError> {
         let mut msg: Vec<u8> = Vec::new();
         msg.extend_from_slice(&[Command::Panic as u8]);

--- a/apps/test/client/src/commands.rs
+++ b/apps/test/client/src/commands.rs
@@ -10,6 +10,7 @@ pub enum Command {
     CountPrimes,
     ShowUxScreen = 0x80,
     DeviceProp = 0x81,
+    Print = 0xfe,
     Panic = 0xff,
 }
 
@@ -25,6 +26,7 @@ impl TryFrom<u8> for Command {
             0x04 => Ok(Command::CountPrimes),
             0x80 => Ok(Command::ShowUxScreen),
             0x81 => Ok(Command::DeviceProp),
+            0xfe => Ok(Command::Print),
             0xff => Ok(Command::Panic),
             _ => Err(()),
         }

--- a/apps/test/client/src/main.rs
+++ b/apps/test/client/src/main.rs
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         ClientType::Tcp
     };
-    let print_writer = Box::new(FileLineWriter::new("print.log", true, true)?);
+    let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
     let mut test_client =
         TestClient::new(create_default_client("vnd-test", client_type, Some(print_writer)).await?);
 

--- a/apps/test/client/src/main.rs
+++ b/apps/test/client/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use client::TestClient;
 
+use sdk::linewriter::FileLineWriter;
 use sdk::vanadium_client::client_utils::{create_default_client, ClientType};
 
 mod commands;
@@ -149,7 +150,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         ClientType::Tcp
     };
-    let mut test_client = TestClient::new(create_default_client("vnd-test", client_type).await?);
+    let print_writer = Box::new(FileLineWriter::new("print.log", true, true)?);
+    let mut test_client =
+        TestClient::new(create_default_client("vnd-test", client_type, Some(print_writer)).await?);
 
     loop {
         println!("Enter a command:");

--- a/apps/test/client/src/main.rs
+++ b/apps/test/client/src/main.rs
@@ -32,6 +32,7 @@ enum CliCommand {
     NPrimes(u32),
     Ux(u8),
     DeviceProp(u32),
+    Print(String),
     Panic(String),
     Exit,
 }
@@ -109,6 +110,14 @@ fn parse_command(line: &str) -> Result<CliCommand, String> {
                     .unwrap_or("");
                 Ok(CliCommand::Panic(msg.to_string()))
             }
+            "print" => {
+                // find where the word "print" ends and the message starts
+                let msg = line
+                    .find("print")
+                    .map(|i| line[i + 5..].trim())
+                    .unwrap_or("");
+                Ok(CliCommand::Print(msg.to_string()))
+            }
             _ => Err(format!("Unknown command: '{}'", command)),
         }
     } else {
@@ -174,6 +183,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 CliCommand::DeviceProp(property) => {
                     let value = test_client.device_props(property).await?;
                     println!("Value for property {}: 0x{:08x}", property, value);
+                }
+                CliCommand::Print(msg) => {
+                    test_client.print(&msg).await?;
                 }
                 CliCommand::Panic(msg) => {
                     test_client.panic(&msg).await?;

--- a/client-sdk/src/comm.rs
+++ b/client-sdk/src/comm.rs
@@ -56,7 +56,7 @@ impl core::error::Error for SendMessageError {}
 /// * An error occurs during the execution of the virtual application client.
 ///
 pub async fn send_message(
-    transport: &mut Box<dyn VAppTransport + Send + Sync>,
+    transport: &mut Box<dyn VAppTransport + Send>,
     message: &[u8],
 ) -> Result<Vec<u8>, SendMessageError> {
     // concatenate the length of the message (as a 4-byte big-endian) and the message itself

--- a/client-sdk/src/lib.rs
+++ b/client-sdk/src/lib.rs
@@ -9,6 +9,8 @@ pub mod memory;
 #[cfg(feature = "transport")]
 pub mod comm;
 #[cfg(feature = "transport")]
+pub mod linewriter;
+#[cfg(feature = "transport")]
 pub mod transport;
 #[cfg(feature = "transport")]
 pub mod vanadium_client;

--- a/client-sdk/src/linewriter.rs
+++ b/client-sdk/src/linewriter.rs
@@ -1,0 +1,264 @@
+//! Line-oriented `Write` adapters.
+//!
+//! Converts arbitrary byte streams into UTF-8 lines and emits each line to a handler.
+//! Useful for piping program output into stdout or a file without interleaving.
+//! It can be used in Vanadium V-App clients to process and display (or log) the printed output
+//! of the V-App.
+//!
+//! Types:
+//! - [`Sink`]: no-op writer; accepts bytes and discards them.
+//! - [`PrintWriter`]: writes one logical line per call to stdout; optional millisecond timestamp.
+//! - [`FileLineWriter`]: writes one logical line per call to a file; optional millisecond timestamp.
+//!
+//! Behavior:
+//! - Bytes are buffered until `\n`, then the line (without the newline) is dispatched.
+//! - Partial trailing data is flushed on [`Write::flush`] and on drop.
+//! - Lines are decoded with `String::from_utf8_lossy`.
+//! - Timestamp format: `"[seconds.millis] line"` (UNIX time).
+
+use std::{
+    fmt,
+    fs::{File, OpenOptions},
+    io::{self, BufWriter, Write},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// Converts byte streams into lines and calls the handler for every line.
+trait LineHandler {
+    fn on_line(&mut self, line: &str) -> io::Result<()>;
+}
+
+#[derive(Debug)]
+struct LineDispatcher<H: LineHandler> {
+    buffer: Vec<u8>,
+    handler: H,
+}
+
+impl<H: LineHandler> LineDispatcher<H> {
+    fn new(handler: H) -> Self {
+        Self {
+            buffer: Vec::new(),
+            handler,
+        }
+    }
+
+    #[inline]
+    fn on_line(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let line = String::from_utf8_lossy(bytes);
+        self.handler.on_line(&line)
+    }
+
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        let mut start = 0;
+        for (i, &b) in data.iter().enumerate() {
+            if b == b'\n' {
+                self.buffer.extend_from_slice(&data[start..i]);
+                let line_bytes = std::mem::take(&mut self.buffer);
+                self.on_line(&line_bytes)?;
+                start = i + 1;
+            }
+        }
+        self.buffer.extend_from_slice(&data[start..]);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.buffer.is_empty() {
+            let tmp = std::mem::take(&mut self.buffer);
+            self.on_line(&tmp)?;
+        }
+        Ok(())
+    }
+}
+
+fn format_line(with_timestamp: bool, line: &str) -> String {
+    if with_timestamp {
+        let ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+
+        let s = ms / 1000;
+        let ms_frac = (ms % 1000) as u128;
+        format!("[{s}.{ms_frac:03}] {line}")
+    } else {
+        line.to_owned()
+    }
+}
+
+impl<H: LineHandler> Drop for LineDispatcher<H> {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+/// Sink writer: implements `Write` by doing nothing
+#[derive(Debug, Default)]
+pub struct Sink;
+
+impl Write for Sink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Console writer
+pub struct PrintWriter {
+    inner: LineDispatcher<StdoutHandler>,
+}
+
+impl fmt::Debug for PrintWriter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrintWriter").finish()
+    }
+}
+
+struct StdoutHandler {
+    with_timestamp: bool,
+}
+
+impl LineHandler for StdoutHandler {
+    fn on_line(&mut self, line: &str) -> io::Result<()> {
+        let mut out = std::io::stdout().lock();
+        writeln!(out, "{}", format_line(self.with_timestamp, line))
+    }
+}
+
+impl PrintWriter {
+    pub fn new(with_timestamp: bool) -> Self {
+        Self {
+            inner: LineDispatcher::new(StdoutHandler { with_timestamp }),
+        }
+    }
+}
+
+impl Write for PrintWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// File writer
+#[derive(Debug)]
+pub struct FileLineWriter {
+    inner: LineDispatcher<FileHandler>,
+}
+
+#[derive(Debug)]
+struct FileHandler {
+    with_timestamp: bool,
+    writer: BufWriter<File>,
+}
+
+impl LineHandler for FileHandler {
+    fn on_line(&mut self, line: &str) -> io::Result<()> {
+        writeln!(self.writer, "{}", format_line(self.with_timestamp, line))?;
+        self.writer.flush()
+    }
+}
+
+impl FileLineWriter {
+    /// `overwrite = false` will append if file exists
+    pub fn new(path: &str, with_timestamp: bool, overwrite: bool) -> io::Result<Self> {
+        let file: File = if overwrite {
+            File::create(path)?
+        } else {
+            OpenOptions::new().create(true).append(true).open(path)?
+        };
+        let handler = FileHandler {
+            with_timestamp,
+            writer: BufWriter::new(file),
+        };
+
+        Ok(Self {
+            inner: LineDispatcher::new(handler),
+        })
+    }
+}
+
+impl Write for FileLineWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf};
+
+    fn tmp_path(prefix: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let pid = std::process::id();
+        p.push(format!("{}_{}_{}.log", prefix, pid, ts));
+        p
+    }
+
+    #[test]
+    fn line_dispatcher_splits_and_flushes() {
+        struct Collect<'a>(&'a mut Vec<String>);
+        impl<'a> LineHandler for Collect<'a> {
+            fn on_line(&mut self, line: &str) -> io::Result<()> {
+                self.0.push(line.to_string());
+                Ok(())
+            }
+        }
+
+        let mut out = Vec::new();
+
+        {
+            let mut ld = LineDispatcher::new(Collect(&mut out));
+            assert_eq!(ld.write(b"hello\nwor").unwrap(), 9);
+            assert_eq!(ld.write(b"ld\nlast").unwrap(), 7);
+            ld.flush().unwrap();
+        }
+
+        assert_eq!(
+            out,
+            vec!["hello".to_string(), "world".to_string(), "last".to_string()]
+        );
+    }
+
+    #[test]
+    fn sink_write_and_flush() {
+        let mut s = Sink;
+        assert_eq!(s.write(b"abc").unwrap(), 3);
+        s.flush().unwrap();
+    }
+
+    #[test]
+    fn file_line_writer_with_timestamp_format() {
+        let path = tmp_path("stream_ts");
+        {
+            let mut w = FileLineWriter::new(path.to_string_lossy().as_ref(), true, true).unwrap();
+            w.write_all(b"foo").unwrap();
+            w.flush().unwrap();
+        }
+
+        let content = fs::read_to_string(&path).unwrap();
+        let line = content.trim_end_matches('\n');
+        let (ts, rest) = line
+            .strip_prefix('[')
+            .and_then(|s| s.split_once(']'))
+            .unwrap();
+        assert_eq!(rest, " foo");
+        let (sec, ms) = ts.split_once('.').unwrap();
+        assert!(sec.chars().all(|c| c.is_ascii_digit()));
+        assert!(ms.len() == 3 && ms.chars().all(|c| c.is_ascii_digit()));
+
+        let _ = fs::remove_file(&path);
+    }
+}

--- a/client-sdk/src/linewriter.rs
+++ b/client-sdk/src/linewriter.rs
@@ -80,7 +80,7 @@ fn format_line(with_timestamp: bool, line: &str) -> String {
             .as_millis();
 
         let s = ms / 1000;
-        let ms_frac = (ms % 1000) as u128;
+        let ms_frac = ms % 1000;
         format!("[{s}.{ms_frac:03}] {line}")
     } else {
         line.to_owned()

--- a/client-sdk/src/test_utils.rs
+++ b/client-sdk/src/test_utils.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 
+use crate::linewriter::FileLineWriter;
 use crate::transport::{TransportTcp, TransportWrapper};
 use crate::vanadium_client::{VAppTransport, VanadiumAppClient};
 
@@ -153,9 +154,11 @@ where
     F: FnOnce(Box<dyn VAppTransport + Send + Sync>) -> C,
 {
     TestSetup::new(vanadium_binary, |transport| async move {
-        let (vanadium_client, _) = VanadiumAppClient::new(vapp_binary, transport, None)
-            .await
-            .expect("Failed to create client");
+        let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
+        let (vanadium_client, _) =
+            VanadiumAppClient::new(vapp_binary, transport, None, print_writer)
+                .await
+                .expect("Failed to create client");
 
         create_client(Box::new(vanadium_client))
     })

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -503,6 +503,15 @@ impl<E: std::fmt::Debug + Send + Sync + 'static> VAppEngine<E> {
                     .await
                     .map_err(|e| VAppEngineError::GenericError(Box::new(e)))?;
             }
+            BufferType::Print => {
+                // Send the print message to the VAppEngine
+                let print_message = String::from_utf8(buf)
+                    .map_err(|e| VAppEngineError::GenericError(Box::new(e)))?;
+
+                // TODO: it would be better to have a more appropriate way to specify how the stream of
+                // printed messages should be handled.
+                print!("{}", print_message);
+            }
         }
 
         // Continue processing

--- a/common/src/client_commands.rs
+++ b/common/src/client_commands.rs
@@ -604,6 +604,19 @@ pub enum BufferType {
     Print = 2,       // the VApp printed a message
 }
 
+impl TryFrom<u8> for BufferType {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(BufferType::VAppMessage),
+            1 => Ok(BufferType::Panic),
+            2 => Ok(BufferType::Print),
+            _ => Err("Invalid buffer type"),
+        }
+    }
+}
+
 /// Message sent by the VM to send a buffer (or the first chunk of it) to the host during an ECALL_XSEND.
 #[derive(Debug, Clone)]
 pub struct SendBufferMessage<'a> {

--- a/common/src/client_commands.rs
+++ b/common/src/client_commands.rs
@@ -657,12 +657,8 @@ impl<'a> Message<'a> for SendBufferMessage<'a> {
         if (!matches!(command_code, ClientCommandCode::SendBuffer)) || (data.len() < 6) {
             return Err(MessageDeserializationError::MismatchingClientCommandCode);
         }
-        let buffer_type = match data[1] {
-            0 => BufferType::VAppMessage,
-            1 => BufferType::Panic,
-            2 => BufferType::Print,
-            _ => return Err(MessageDeserializationError::InvalidBufferType),
-        };
+        let buffer_type = BufferType::try_from(data[1])
+            .map_err(|_| MessageDeserializationError::InvalidBufferType)?;
         let total_size = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
         let data = &data[6..];
 

--- a/common/src/client_commands.rs
+++ b/common/src/client_commands.rs
@@ -601,6 +601,7 @@ impl<'a> Message<'a> for CommitPageProofContinuedResponse<'a> {
 pub enum BufferType {
     VAppMessage = 0, // data buffer sent from the VApp to the host
     Panic = 1,       // the VApp panicked
+    Print = 2,       // the VApp printed a message
 }
 
 /// Message sent by the VM to send a buffer (or the first chunk of it) to the host during an ECALL_XSEND.
@@ -646,6 +647,7 @@ impl<'a> Message<'a> for SendBufferMessage<'a> {
         let buffer_type = match data[1] {
             0 => BufferType::VAppMessage,
             1 => BufferType::Panic,
+            2 => BufferType::Print,
             _ => return Err(MessageDeserializationError::InvalidBufferType),
         };
         let total_size = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -2,6 +2,7 @@ pub const ECALL_FATAL: u32 = 1;
 pub const ECALL_XSEND: u32 = 2;
 pub const ECALL_XRECV: u32 = 3;
 pub const ECALL_EXIT: u32 = 4;
+pub const ECALL_PRINT: u32 = 5;
 
 // device handling, events, and UX
 

--- a/ecalls/src/ecalls_impl.rs
+++ b/ecalls/src/ecalls_impl.rs
@@ -335,6 +335,7 @@ pub unsafe fn fatal(msg: *const u8, size: usize) -> ! {
 
 ecall2v!(xsend, ECALL_XSEND, (buffer: *const u8), (size: usize));
 ecall2!(xrecv, ECALL_XRECV, (buffer: *mut u8), (size: usize), usize);
+ecall2v!(print, ECALL_PRINT, (buffer: *const u8), (size: usize));
 
 ecall1!(get_event, ECALL_GET_EVENT, (data: *mut EventData), u32);
 ecall2!(show_page, ECALL_SHOW_PAGE, (page_desc: *const u8), (page_desc_len: usize), u32);

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -384,11 +384,6 @@ impl<'a> CommEcallHandler<'a> {
                 let copy_size = min(size, 255 - 6); // send maximum 249 bytes in the first chunk
                 segment.read_buffer(g_ptr, &mut buffer[0..copy_size])?;
 
-                crate::println!(
-                    "Sending {} bytes in the first chunk. Total: {}",
-                    copy_size,
-                    size
-                );
                 let mut comm = self.comm.borrow_mut();
                 SendBufferMessage::new(size as u32, buffer_type, &buffer[0..copy_size])
                     .serialize_to_comm(&mut comm);
@@ -398,7 +393,6 @@ impl<'a> CommEcallHandler<'a> {
             } else {
                 let copy_size = min(size, 255 - 1); // send maximum 255 bytes in each subsequent chunk
                 segment.read_buffer(g_ptr, &mut buffer[0..copy_size])?;
-                crate::println!("Sending {} bytes in the subsequent chunk.", copy_size);
                 let mut comm = self.comm.borrow_mut();
                 SendBufferContinuedMessage::new(&buffer[0..copy_size]).serialize_to_comm(&mut comm);
                 size -= copy_size;


### PR DESCRIPTION
Adds an `ECALL_PRINT` that sends a buffer as a message to the host, and various host utilities to control the stream of printed bytes on the host side, allowing to either print to console or save to a file.