### PR TITLE
Adjust cache sizes based on the target

### DIFF
--- a/vm/.cargo/config.toml
+++ b/vm/.cargo/config.toml
@@ -5,10 +5,10 @@ runner = "speculos -a=1 --model=nanosp"
 target = "nanosplus"
 
 [env]
-HEAP_SIZE = "14306"
 # The value of CUSTOM_IO_APDU_BUFFER_SIZE needs to be compatible with the MAX_APDU_DATA_SIZE
 # constant, taking into account the overhead for APDU headers
 LEDGER_SDK_EXTRA_DEFINES="CUSTOM_IO_APDU_BUFFER_SIZE=600"
+HEAP_SIZE = "nanox: 14336, nanosplus: 31744, flex: 26624, stax: 26624, apex_p: 31744"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/vm/build.rs
+++ b/vm/build.rs
@@ -1,3 +1,50 @@
+use std::{env, fs::write, path::PathBuf};
+
 fn main() {
     println!("cargo:rerun-if-changed=script.ld");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let raw_heap_size = env::var("HEAP_SIZE").unwrap();
+
+    // smallest heap size, tailored for Nano X
+    let base_heap_size = 14336usize;
+    // heap size for the current target
+    let heap_size = parse_heap_size(&raw_heap_size, &target_os);
+
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("heap_size.rs");
+    write(
+        &out,
+        format!(
+            "pub const BASE_HEAP_SIZE: usize = {base_heap_size};\n\
+             pub const HEAP_SIZE: usize = {heap_size};\n"
+        ),
+    )
+    .unwrap();
+    println!("cargo:rerun-if-env-changed=HEAP_SIZE");
+}
+
+fn parse_heap_size(raw: &str, target_os: &str) -> usize {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        panic!("HEAP_SIZE is not defined");
+    }
+
+    if let Ok(v) = trimmed.parse::<usize>() {
+        return v;
+    }
+
+    // Parse list of comma-separated target:value pairs
+    for entry in trimmed.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((k, v_str)) = entry.split_once(':') {
+            if k.trim() == target_os {
+                if let Ok(v) = v_str.trim().parse::<usize>() {
+                    return v;
+                }
+            }
+        }
+    }
+    panic!("HEAP_SIZE is not defined for the current target_os");
 }

--- a/vm/src/handlers/lib/evict.rs
+++ b/vm/src/handlers/lib/evict.rs
@@ -97,6 +97,11 @@ impl TwoQEvictionStrategy {
             a1out_max_size,
         }
     }
+
+    // estimates how much space this struct uses for each additional page slot
+    pub const fn size_per_page() -> usize {
+        core::mem::size_of::<PageState>() + core::mem::size_of::<u32>()
+    }
 }
 
 impl PageEvictionStrategy for TwoQEvictionStrategy {

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -123,6 +123,11 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
         }
     }
 
+    // Return the number of bytes used by a each additional cached page
+    pub const fn size_per_page() -> usize {
+        core::mem::size_of::<CachedPage>()
+    }
+
     fn commit_page_at(&mut self, index: usize) -> Result<(), common::vm::MemoryError> {
         #[cfg(feature = "trace_pages")]
         crate::trace!(

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -40,6 +40,8 @@ use ledger_device_sdk::{
 
 extern crate alloc;
 
+include!(concat!(env!("OUT_DIR"), "/heap_size.rs"));
+
 pub const COMM_BUFFER_SIZE: usize = 600;
 
 // define print! and println! macros using debug_printf (only for running on Speculos)


### PR DESCRIPTION
This PR tailors the size of the page cache of each device based on the total available RAM. Prior to this, a size that is small enough to fit on Nano X was chosen, which has a huge performance impact on larger binaries for all other devices.