### PR TITLE
Btc V-App improvements

### DIFF
--- a/app-sdk/Cargo.toml
+++ b/app-sdk/Cargo.toml
@@ -10,6 +10,10 @@ subtle = { version="2.6.1", default-features = false }
 hex-literal = "0.4.1"
 zeroize = "1.8.1"
 
+[features]
+# Enable this in V-App's dev-dependencies
+test-mode = [] 
+
 [build-dependencies]
 common = { path = "../common", features = ["wrapped_serializable"] }
 

--- a/apps/bitcoin/app/Cargo.toml
+++ b/apps/bitcoin/app/Cargo.toml
@@ -21,6 +21,7 @@ sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
 
 [dev-dependencies]
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", features = ["test-mode"]}
 
 [profile.release]
 opt-level = "s"

--- a/apps/bitcoin/common/src/script.rs
+++ b/apps/bitcoin/common/src/script.rs
@@ -9,6 +9,32 @@ use bitcoin::{PubkeyHash, ScriptBuf, ScriptHash, TapNodeHash, WPubkeyHash, WScri
 
 use crate::taproot::GetTapTreeHash;
 
+// Simple generic bubble sort implementation for Vec<[u8; N]>.
+trait BubbleSort {
+    fn bubble_sort(&mut self);
+}
+
+impl<const N: usize> BubbleSort for Vec<[u8; N]> {
+    fn bubble_sort(&mut self) {
+        let len = self.len();
+        if len < 2 {
+            return;
+        }
+        for i in 0..len {
+            let mut swapped = false;
+            for j in 0..(len - 1 - i) {
+                if self[j] > self[j + 1] {
+                    self.swap(j, j + 1);
+                    swapped = true;
+                }
+            }
+            if !swapped {
+                break;
+            }
+        }
+    }
+}
+
 use crate::account::{DescriptorTemplate, KeyInformation, KeyPlaceholder, WalletPolicy};
 
 const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
@@ -186,7 +212,8 @@ impl ToScriptWithKeyInfoInner for DescriptorTemplate {
                     .collect::<Result<Vec<[u8; 33]>, &'static str>>()?;
 
                 if matches!(self, DescriptorTemplate::Sortedmulti(_, _)) {
-                    keys.sort();
+                    // O(n^2) sorting, better for small arrays
+                    keys.bubble_sort();
                 }
 
                 for key in keys {
@@ -224,7 +251,8 @@ impl ToScriptWithKeyInfoInner for DescriptorTemplate {
                     .collect::<Result<Vec<[u8; 32]>, &'static str>>()?;
 
                 if matches!(self, DescriptorTemplate::Sortedmulti_a(_, _)) {
-                    keys.sort();
+                    // O(n^2) sorting, better for small arrays
+                    keys.bubble_sort();
                 }
 
                 for (idx, key) in keys.iter().enumerate() {


### PR DESCRIPTION
Small improvement in code size.

Incidentally, added a 'test-mode' feature `vanadum-app-sdk` to avoid attempting the creation of the TCP listener in native compilation during tests if `print!` is used.