### PR TITLE
UX framework improvements

### DIFF
--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -206,7 +206,6 @@ impl App {
                 Err(e) => panic!("Communication error: {}", e),
             };
             let resp_msg = (self.handler)(self, &req_msg);
-            self.ux_dirty = true; // TODO: remove once handlers can set the 'dirty' state themselves
             crate::comm::send_message(&resp_msg);
         }
     }
@@ -238,5 +237,47 @@ impl App {
             self.home_info_page = Some(raw);
         }
         self.home_info_page.as_ref().unwrap() // safe, just populated
+    }
+
+    // --- UX Flows ---
+    pub fn review_pairs(
+        &mut self,
+        intro_text: &str,
+        intro_subtext: &str,
+        pairs: &[TagValue],
+        final_text: &str,
+        final_button_text: &str,
+        long_press: bool,
+    ) -> bool {
+        self.ux_dirty = true;
+        crate::ux::review_pairs(
+            intro_text,
+            intro_subtext,
+            pairs,
+            final_text,
+            final_button_text,
+            long_press,
+        )
+    }
+
+    pub fn show_spinner(&mut self, text: &str) {
+        self.ux_dirty = true;
+        crate::ux::show_spinner(text);
+    }
+
+    pub fn show_info(&mut self, icon: crate::ux::Icon, text: &str) {
+        self.ux_dirty = true;
+        crate::ux::show_info(icon, text);
+    }
+
+    pub fn show_confirm_reject(
+        &mut self,
+        title: &str,
+        text: &str,
+        confirm: &str,
+        reject: &str,
+    ) -> bool {
+        self.ux_dirty = true;
+        crate::ux::show_confirm_reject(title, text, confirm, reject)
     }
 }

--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -258,6 +258,20 @@ impl App {
     }
 
     // --- UX Flows ---
+
+    /// Displays a multi-screen review flow composed of label/value pairs followed by a
+    /// final confirmation screen. The user can navigate forward and backward through
+    /// the content before approving or aborting.
+    ///
+    /// Arguments:
+    /// * `intro_text` - Title or primary text shown on the introductory screen.
+    /// * `intro_subtext` - Secondary descriptive text shown under the intro text.
+    /// * `pairs` - Slice of tag/value entries to review; order is preserved.
+    /// * `final_text` - Text displayed on the final approval screen (e.g. summary).
+    /// * `final_button_text` - Label of the confirmation action the user presses to approve.
+    /// * `long_press` - When true, the final approval may require a long press gesture instead of a simple confirm.
+    ///
+    /// Returns `true` if the user confirms/approves on the final screen; `false` if the user aborts (e.g. quits or rejects).
     pub fn review_pairs(
         &mut self,
         intro_text: &str,
@@ -278,24 +292,30 @@ impl App {
         )
     }
 
+    /// Shows a progress indicator with the provided status text.
+    ///
+    /// Use this while performing an operation that may take noticeable time.
+    /// The call returns immediately after the spinner is displayed, and it stays on the screen
+    /// until something else is shown to replace it.
+    ///
+    /// Arguments:
+    /// * `text` - Short status message describing the ongoing work.
     pub fn show_spinner(&mut self, text: &str) {
         self.set_ux_dirty();
         crate::ux::show_spinner(text);
     }
 
-    /// Shows an informational screen with the given icon and text.
-    /// The screen is shown for about 3 seconds before returning to the dashboard,
-    /// unless a new UX flow is started, which would therefore override the timeout.
-    pub fn show_info(&mut self, icon: crate::ux::Icon, text: &str) {
-        self.set_ux_dirty();
-        if has_page_api() {
-            ux_generated::show_page_info(icon, text);
-        } else {
-            ux_generated::show_step_info_single(text);
-        }
-        self.cleanup_ticks = 30; // cleanup after about 3 seconds
-    }
-
+    /// Presents a confirmation flow consisting of an informational screen and
+    /// explicit confirm/reject actions. The user can navigate between the
+    /// confirm and reject choices before deciding.
+    ///
+    /// Arguments:
+    /// * `title` - Heading shown on the information screen.
+    /// * `text` - Descriptive text shown under the title.
+    /// * `confirm` - Label for the confirm/approve action.
+    /// * `reject` - Label for the reject/abort action.
+    ///
+    /// Returns `true` if the user selects the confirm action; `false` if the user selects reject.
     pub fn show_confirm_reject(
         &mut self,
         title: &str,
@@ -305,5 +325,25 @@ impl App {
     ) -> bool {
         self.set_ux_dirty();
         crate::ux::show_confirm_reject(title, text, confirm, reject)
+    }
+
+    /// Shows a temporary informational screen with an icon and message.
+    ///
+    /// The screen remains visible for a few seconds before automatically returning to the
+    /// dashboard, unless superseded by a new UX flow.
+    ///
+    /// Arguments:
+    /// * `icon` - Visual indicator clarifying the nature of the message.
+    /// * `text` - Informational text to display to the user.
+    ///
+    /// This function does not block for user input; it schedules automatic cleanup.
+    pub fn show_info(&mut self, icon: crate::ux::Icon, text: &str) {
+        self.set_ux_dirty();
+        if has_page_api() {
+            ux_generated::show_page_info(icon, text);
+        } else {
+            ux_generated::show_step_info_single(text);
+        }
+        self.cleanup_ticks = 30; // cleanup after about 3 seconds
     }
 }

--- a/apps/bitcoin/app/src/handlers/get_address.rs
+++ b/apps/bitcoin/app/src/handlers/get_address.rs
@@ -9,7 +9,7 @@ use common::errors::Error;
 #[cfg(not(any(test, feature = "autoapprove")))]
 fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -> bool {
     use alloc::vec;
-    use sdk::ux::TagValue;
+    use sdk::ux::{Icon, TagValue};
 
     let mut pairs = match account_name {
         Some(account_name) => {
@@ -31,14 +31,22 @@ fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -
     } else {
         ("Verify Bitcoin", "address")
     };
-    app.review_pairs(
+    let approved = app.review_pairs(
         intro_text,
         intro_subtext,
         &pairs,
         "The address is correct",
         "Confirm",
         false,
-    )
+    );
+
+    if approved {
+        app.show_info(Icon::Confirm, "Address verified");
+    } else {
+        app.show_info(Icon::Reject, "Address rejected");
+    }
+
+    approved
 }
 
 #[cfg(any(test, feature = "autoapprove"))]

--- a/apps/bitcoin/app/src/handlers/get_address.rs
+++ b/apps/bitcoin/app/src/handlers/get_address.rs
@@ -7,7 +7,7 @@ use common::{
 use common::errors::Error;
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_address(account_name: Option<&str>, addr: &str) -> bool {
+fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -> bool {
     use alloc::vec;
     use sdk::ux::TagValue;
 
@@ -31,7 +31,7 @@ fn display_address(account_name: Option<&str>, addr: &str) -> bool {
     } else {
         ("Verify Bitcoin", "address")
     };
-    sdk::ux::review_pairs(
+    app.review_pairs(
         intro_text,
         intro_subtext,
         &pairs,
@@ -42,19 +42,19 @@ fn display_address(account_name: Option<&str>, addr: &str) -> bool {
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_address(_account_name: Option<&str>, _addr: &str) -> bool {
+fn display_address(_app: &mut sdk::App, _account_name: Option<&str>, _addr: &str) -> bool {
     true
 }
 
 pub fn handle_get_address(
-    _app: &mut sdk::App,
+    app: &mut sdk::App,
     name: Option<&str>,
     account: &common::message::Account,
     por: &[u8],
     coordinates: &common::message::AccountCoordinates,
     display: bool,
 ) -> Result<Response, Error> {
-    sdk::ux::show_spinner("Processing...");
+    app.show_spinner("Processing...");
 
     let wallet_policy: bip388::WalletPolicy =
         account.try_into().map_err(|_| Error::InvalidWalletPolicy)?;
@@ -83,7 +83,7 @@ pub fn handle_get_address(
         .map_err(|_| Error::InvalidWalletPolicy)?;
 
     if display {
-        if !display_address(name, &address) {
+        if !display_address(app, name, &address) {
             return Err(Error::UserRejected);
         }
     }

--- a/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
+++ b/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
@@ -25,7 +25,7 @@ fn get_pubkey_fingerprint(pubkey: &EcfpPublicKey<Secp256k1, 32>) -> u32 {
 }
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_xpub(xpub: &str, path: &[u32]) -> bool {
+fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
     use alloc::string::ToString;
     use alloc::vec;
     use sdk::ux::TagValue;
@@ -39,7 +39,7 @@ fn display_xpub(xpub: &str, path: &[u32]) -> bool {
         ("Verify Bitcoin", "extended public key")
     };
 
-    sdk::ux::review_pairs(
+    app.review_pairs(
         intro_text,
         intro_subtext,
         &vec![
@@ -59,12 +59,12 @@ fn display_xpub(xpub: &str, path: &[u32]) -> bool {
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_xpub(_xpub: &str, _path: &[u32]) -> bool {
+fn display_xpub(_app: &mut sdk::App, _xpub: &str, _path: &[u32]) -> bool {
     true
 }
 
 pub fn handle_get_extended_pubkey(
-    _app: &mut sdk::App,
+    app: &mut sdk::App,
     bip32_path: &common::message::Bip32Path,
     display: bool,
 ) -> Result<Response, Error> {
@@ -108,7 +108,7 @@ pub fn handle_get_extended_pubkey(
 
     if display {
         let xpub_base58 = bitcoin::base58::encode_check(&xpub);
-        if !display_xpub(&xpub_base58, &bip32_path.0) {
+        if !display_xpub(app, &xpub_base58, &bip32_path.0) {
             return Err(Error::UserRejected);
         }
     }

--- a/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
+++ b/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
@@ -26,9 +26,8 @@ fn get_pubkey_fingerprint(pubkey: &EcfpPublicKey<Secp256k1, 32>) -> u32 {
 
 #[cfg(not(any(test, feature = "autoapprove")))]
 fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
-    use alloc::string::ToString;
-    use alloc::vec;
-    use sdk::ux::TagValue;
+    use alloc::{string::ToString, vec};
+    use sdk::ux::{Icon, TagValue};
 
     let path =
         bitcoin::bip32::DerivationPath::from(path.iter().map(|&x| x.into()).collect::<Vec<_>>());
@@ -39,7 +38,7 @@ fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
         ("Verify Bitcoin", "extended public key")
     };
 
-    app.review_pairs(
+    let approved = app.review_pairs(
         intro_text,
         intro_subtext,
         &vec![
@@ -52,10 +51,17 @@ fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
                 value: xpub.into(),
             },
         ],
-        "The public key is validated",
+        "Verify public key",
         "Confirm",
         false,
-    )
+    );
+    if approved {
+        app.show_info(Icon::Confirm, "Public key verified");
+    } else {
+        app.show_info(Icon::Reject, "Public key rejected");
+    }
+
+    approved
 }
 
 #[cfg(any(test, feature = "autoapprove"))]

--- a/apps/bitcoin/app/src/handlers/register_account.rs
+++ b/apps/bitcoin/app/src/handlers/register_account.rs
@@ -1,10 +1,9 @@
 use common::{
     account::{Account, ProofOfRegistration},
     bip388,
+    errors::Error,
     message::Response,
 };
-
-use common::errors::Error;
 
 #[cfg(not(any(test, feature = "autoapprove")))]
 fn display_wallet_policy(
@@ -13,7 +12,7 @@ fn display_wallet_policy(
     wallet_policy: &bip388::WalletPolicy,
 ) -> bool {
     use alloc::{format, string::ToString, vec::Vec};
-    use sdk::ux::TagValue;
+    use sdk::ux::{Icon, TagValue};
 
     let mut pairs = Vec::with_capacity(2 + wallet_policy.key_information.len());
 
@@ -38,14 +37,22 @@ fn display_wallet_policy(
     } else {
         ("Register Bitcoin", "account")
     };
-    app.review_pairs(
+    let approved = app.review_pairs(
         intro_text,
         intro_subtext,
         &pairs,
         "Confirm registration",
         "Register",
         false,
-    )
+    );
+
+    if approved {
+        app.show_info(Icon::Confirm, "Account registered");
+    } else {
+        app.show_info(Icon::Reject, "Registration cancelled");
+    }
+
+    approved
 }
 
 #[cfg(any(test, feature = "autoapprove"))]

--- a/apps/bitcoin/app/src/handlers/register_account.rs
+++ b/apps/bitcoin/app/src/handlers/register_account.rs
@@ -7,7 +7,11 @@ use common::{
 use common::errors::Error;
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_wallet_policy(name: &str, wallet_policy: &bip388::WalletPolicy) -> bool {
+fn display_wallet_policy(
+    app: &mut sdk::App,
+    name: &str,
+    wallet_policy: &bip388::WalletPolicy,
+) -> bool {
     use alloc::{format, string::ToString, vec::Vec};
     use sdk::ux::TagValue;
 
@@ -34,7 +38,7 @@ fn display_wallet_policy(name: &str, wallet_policy: &bip388::WalletPolicy) -> bo
     } else {
         ("Register Bitcoin", "account")
     };
-    sdk::ux::review_pairs(
+    app.review_pairs(
         intro_text,
         intro_subtext,
         &pairs,
@@ -45,12 +49,16 @@ fn display_wallet_policy(name: &str, wallet_policy: &bip388::WalletPolicy) -> bo
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_wallet_policy(_name: &str, _wallet_policy: &bip388::WalletPolicy) -> bool {
+fn display_wallet_policy(
+    _app: &mut sdk::App,
+    _name: &str,
+    _wallet_policy: &bip388::WalletPolicy,
+) -> bool {
     true
 }
 
 pub fn handle_register_account(
-    _app: &mut sdk::App,
+    app: &mut sdk::App,
     name: &str,
     account: &common::message::Account,
 ) -> Result<Response, Error> {
@@ -59,7 +67,7 @@ pub fn handle_register_account(
 
     // TODO: necessary sanity checks on the wallet policy
 
-    if !display_wallet_policy(name, &wallet_policy) {
+    if !display_wallet_policy(app, name, &wallet_policy) {
         return Err(Error::UserRejected);
     }
 

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -34,6 +34,9 @@ use sdk::{
 use crate::constants::COIN_TICKER;
 
 #[cfg(not(any(test, feature = "autoapprove")))]
+use sdk::ux::Icon;
+
+#[cfg(not(any(test, feature = "autoapprove")))]
 fn display_warning_high_fee(app: &mut sdk::App, fee_percent: u64) -> bool {
     app.show_confirm_reject(
         "High fees",
@@ -522,6 +525,9 @@ pub fn handle_sign_psbt(app: &mut sdk::App, psbt: &[u8]) -> Result<Response, Err
     });
 
     if !display_transaction(app, &pairs) {
+        #[cfg(not(any(test, feature = "autoapprove")))]
+        app.show_info(Icon::Reject, "Transaction rejected");
+
         return Err(Error::UserRejected);
     }
 
@@ -632,6 +638,9 @@ pub fn handle_sign_psbt(app: &mut sdk::App, psbt: &[u8]) -> Result<Response, Err
             }
         }
     }
+
+    #[cfg(not(any(test, feature = "autoapprove")))]
+    app.show_info(Icon::Confirm, "Transaction signed");
 
     Ok(Response::PsbtSigned(partial_signatures))
 }


### PR DESCRIPTION
Implements support for UX interactions via the App struct, allowing a stateful approach to UX flows.
This allows simplifying the state machine, always being aware if the UX is dirty (that is, the dashboard needs to be shown), or handling timeouts for notice screens.

Immediate improvements as a result:
- the dashboard is only refreshed if some UX flow was shown (not for background command)
- The app can handle timeouts after `app.show_info()` calls, automatically showing the dashboard after expiration (but only if it's needed, as any new UX interaction deletes the timer).

Also, improved the UX flows of the Bitcoin V-App with the appropriate calls to `show_info` at the end of UX flows.

Closes: #96 