### PR TITLE
Split AppBuilder off of App

### DIFF
--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -54,13 +54,13 @@ impl AppBuilder {
         }
     }
 
-    /// Sets the V-App description shown on the dashboard
+    /// Sets the V-App description shown on the dashboard.
     pub fn description(mut self, description: &str) -> Self {
         self.description = Some(description.to_string());
         self
     }
 
-    /// Sets the developer name
+    /// Sets the developer name.
     pub fn developer(mut self, developer: &str) -> Self {
         self.developer = Some(developer.to_string());
         self
@@ -113,7 +113,20 @@ pub struct App {
 }
 
 impl App {
-    /// Sends a message to the host and waits for the response.
+    /// Sends a message to the host and waits for a response, processing UX events in the meantime to keep the app responsive.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - The message to send to the host.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the response message from the host on success, or a `MessageError` on failure.
+    ///
+    /// # Behavior
+    ///
+    /// This method enters a loop where it continuously processes user interface events and checks for incoming messages.
+    /// It will not return until a message is received or an error occurs.
     pub fn exchange(&mut self, msg: &[u8]) -> Result<Vec<u8>, MessageError> {
         crate::comm::send_message(msg);
         loop {

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -16,7 +16,7 @@ pub mod rand;
 pub mod slip21;
 pub mod ux;
 
-pub use app::App;
+pub use app::{App, AppBuilder};
 
 mod ecalls;
 

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -10,7 +10,7 @@ use handlers::*;
 use alloc::vec::Vec;
 
 use common::message::{Request, Response};
-use sdk::App;
+use sdk::{App, AppBuilder};
 
 sdk::bootstrap!();
 
@@ -44,7 +44,7 @@ fn process_message(app: &mut App, request: &[u8]) -> Vec<u8> {
 }
 
 pub fn main() {
-    App::new("Bitcoin", env!("CARGO_PKG_VERSION"), process_message)
+    AppBuilder::new("Bitcoin", env!("CARGO_PKG_VERSION"), process_message)
         .description("Bitcoin is ready")
         .developer("Salvatore Ingala")
         .run();

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -4,7 +4,7 @@ use sdk::{
     bignum::{BigNum, BigNumMod, ModulusProvider},
     curve::{Curve as _, EcfpPrivateKey, EcfpPublicKey, Secp256k1Point},
     hash::Hasher,
-    App,
+    App, AppBuilder,
 };
 
 extern crate alloc;
@@ -268,5 +268,5 @@ fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
 }
 
 pub fn main() {
-    App::new("Sadik", env!("CARGO_PKG_VERSION"), process_message).run();
+    AppBuilder::new("Sadik", env!("CARGO_PKG_VERSION"), process_message).run();
 }


### PR DESCRIPTION
This allows a clean separation between the building phase and the execution phase, distinguishing which methods can be called in the two phases.

Also adds an `exchange` method to `App` for interactive commands.