### PR TITLE
Make App stateful if apps need it

### DIFF
--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -141,7 +141,7 @@ where
     pub fn exchange(&mut self, msg: &[u8]) -> Result<Vec<u8>, MessageError> {
         crate::comm::send_message(msg);
         loop {
-            self.process_ux_events();
+            self.process_ux_events(false);
             match crate::comm::receive_message() {
                 Ok(msg) => return Ok(msg),
                 Err(crate::comm::MessageError::NoMessage) => continue,
@@ -156,11 +156,11 @@ where
         self.cleanup_ticks = 0;
     }
 
-    fn process_ux_events(&mut self) {
+    fn process_ux_events(&mut self, show_dashboard: bool) {
         use common::ux::Action::*;
         use common::ux::Event::{Action, Ticker};
 
-        if self.ux_dirty && (self.cleanup_ticks == 0) {
+        if show_dashboard && self.ux_dirty && (self.cleanup_ticks == 0) {
             if has_page_api() {
                 self.show_page_home();
             } else {
@@ -285,7 +285,7 @@ where
     /// or a fatal error occurs.
     fn run_loop(&mut self) -> ! {
         loop {
-            self.process_ux_events();
+            self.process_ux_events(true);
 
             let req_msg = match crate::comm::receive_message() {
                 Ok(msg) => msg,


### PR DESCRIPTION
While most apps are probably stateless, some might need to store some state that persists commands.

This makes the `App`, `AppBuilder` and `Handler` accept a type parameter `S` for the state, using `()` as default so that the syntax doesn't change for stateless apps.

Embedding the state in the `App` allows apps to have a natural place to store persistent state, without having to recur to global variables.

Also fixing the UX handling logic of `App::exchange`: it should not show the dashboard, since it is called to exchange a message while processing a command, rather than at the end of it.