### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/vm/rust-toolchain.toml
+++ b/vm/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-12-01"


### PR DESCRIPTION
It will soon be required for the deployment pipeline of Rust apps.