### PR TITLE
Avoid referring to the explicit target for native compilation

### DIFF
--- a/app-sdk/.cargo/config.toml
+++ b/app-sdk/.cargo/config.toml
@@ -1,7 +1,3 @@
-[build]
-target = "x86_64-unknown-linux-gnu"
-
-
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put

--- a/app-sdk/justfile
+++ b/app-sdk/justfile
@@ -1,12 +1,12 @@
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/apps/bitcoin/README.md
+++ b/apps/bitcoin/README.md
@@ -21,7 +21,7 @@ In order to build the app for the Risc-V target, enter the `app` folder and run:
 In order to build the app for the native target, enter the `app` folder and run:
 
    ```sh
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
    ```
 
 ## Run the V-App

--- a/apps/bitcoin/app/.cargo/config.toml
+++ b/apps/bitcoin/app/.cargo/config.toml
@@ -1,7 +1,3 @@
-[build]
-target = "x86_64-unknown-linux-gnu"
-
-
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put

--- a/apps/bitcoin/app/justfile
+++ b/apps/bitcoin/app/justfile
@@ -3,12 +3,12 @@ run:
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/apps/rps/README.md
+++ b/apps/rps/README.md
@@ -24,7 +24,7 @@ In order to build the app for the Risc-V target, enter the `app` folder and run:
 In order to build the app for the native target, enter the `app` folder and run:
 
    ```sh
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
    ```
 
 ## Run the V-App

--- a/apps/rps/app/.cargo/config.toml
+++ b/apps/rps/app/.cargo/config.toml
@@ -1,7 +1,3 @@
-[build]
-target = "x86_64-unknown-linux-gnu"
-
-
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put

--- a/apps/rps/app/justfile
+++ b/apps/rps/app/justfile
@@ -3,12 +3,12 @@ run:
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/apps/sadik/README.md
+++ b/apps/sadik/README.md
@@ -21,7 +21,7 @@ In order to build the app for the Risc-V target, enter the `app` folder and run:
 In order to build the app for the native target, enter the `app` folder and run:
 
    ```sh
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
    ```
 
 ## Tests with speculos

--- a/apps/sadik/app/.cargo/config.toml
+++ b/apps/sadik/app/.cargo/config.toml
@@ -1,7 +1,3 @@
-[build]
-target = "x86_64-unknown-linux-gnu"
-
-
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put

--- a/apps/sadik/app/justfile
+++ b/apps/sadik/app/justfile
@@ -3,12 +3,12 @@ run:
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -23,7 +23,7 @@ In order to build the app for the Risc-V target, enter the `app` folder and run:
 In order to build the app for the native target, enter the `app` folder and run:
 
    ```sh
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
    ```
 
 ## Run the V-App

--- a/apps/template/app/justfile
+++ b/apps/template/app/justfile
@@ -3,12 +3,12 @@ run:
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/apps/template/generate/README.md
+++ b/apps/template/generate/README.md
@@ -23,7 +23,7 @@ In order to build the app for the Risc-V target, enter the `app` folder and run:
 In order to build the app for the native target, enter the `app` folder and run:
 
    ```sh
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
    ```
 
 ## Run the V-App

--- a/apps/template/generate/app/justfile
+++ b/apps/template/generate/app/justfile
@@ -3,12 +3,12 @@ run:
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/apps/test/README.md
+++ b/apps/test/README.md
@@ -20,7 +20,7 @@ In order to build the app for the Risc-V target, enter the `app` folder and run:
 In order to build the app for the native target, enter the `app` folder and run:
 
    ```sh
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
    ```
 
 ## Run the V-App

--- a/apps/test/app/.cargo/config.toml
+++ b/apps/test/app/.cargo/config.toml
@@ -1,7 +1,3 @@
-[build]
-target = "x86_64-unknown-linux-gnu"
-
-
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put

--- a/apps/test/app/justfile
+++ b/apps/test/app/justfile
@@ -3,12 +3,12 @@ run:
 
 # build for both native and riscv targets
 build:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
   cargo build --release --target=riscv32imc-unknown-none-elf
 
 # build for native target
 build-native:
-  cargo build --release --target=x86_64-unknown-linux-gnu
+  cargo build --release
 
 # build for riscv target
 build-riscv:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 With the exception of the Vanadium app itself, which is an embedded Ledger app on the `ARM` target, all the other crates target either the `native` or the `riscv` targets.
 
-- The `native` target is currently `x86_64-unknown-linux-gnu`, but more native targets might be added in the future. It has `riscv` and `native` targets, in `no_std` mode.
+- The `native` target is what is running in your machine.
 - The `riscv` target is currently `riscv32imc-unknown-none`.
 
 > **⚠️ WARNING: The native target is insecure.**<br> While it is possible to compile and run the V-Apps on native targets, this is only intended for development and testing purposes. The cryptographic primitives are not hardened against side channels, or other kinds of attacks.


### PR DESCRIPTION
This should help developers not using Linux.