### PR TITLE
Changes to support latest nightly

### DIFF
--- a/vanadium.code-workspace
+++ b/vanadium.code-workspace
@@ -19,7 +19,7 @@
       "path": "macros"
     },
     {
-      "path": "docs",
+      "path": "docs"
     },
     {
       "path": "libs/bitcoin_hashes",
@@ -61,6 +61,7 @@
       "path": "apps/template/client",
       "name": "vnd-template-client"
     },
+    {
       "path": "apps/test/app",
       "name": "vnd-test"
     },

--- a/vm/rust-toolchain.toml
+++ b/vm/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-12-01"
+channel = "nightly-2025-12-05"

--- a/vm/src/handlers/lib/ecall/ux_handler.rs
+++ b/vm/src/handlers/lib/ecall/ux_handler.rs
@@ -188,7 +188,7 @@ impl UxHandler {
     pub unsafe fn alloc_cstring(
         &mut self,
         string: Option<&String>,
-    ) -> Result<*const i8, CommEcallError> {
+    ) -> Result<*const core::ffi::c_char, CommEcallError> {
         if let Some(string) = string {
             self.cstrings.push(CString::new(string.clone())?);
             return Ok(self.cstrings[self.cstrings.len() - 1].as_ptr());


### PR DESCRIPTION
The way `LAST_EVENT` was stored used to be 0-initialized (therefore in the .bss section), but now it is no longer working - causing the creation of a .data section which we do not support.
Wrapping it inside `MaybeUninit` guarantees that it can remain in the .bss section.

Also, some minor type changes.