### PR TITLE
Revert "Remove artificial 'slip21' curve, not recognized by the C SDK"

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -41,7 +41,7 @@ trace_colors = []       # if tracing features are enabled, prints them with colo
 run_tests = []  # Run the test suite instead of the app
 
 [package.metadata.ledger]
-curve = ["secp256k1"]
+curve = ["secp256k1", "slip21"]
 flags = "0x10"  # DERIVE_MASTER
 path = [""]
 path_slip21 = ["VANADIUM"]


### PR DESCRIPTION
This reverts commit f15674d7dce5259ffccb5d61faf0bc0aa308fa64.

Fixed with the new ledger-app-builder after [a fix in the C SDK](https://github.com/LedgerHQ/ledger-secure-sdk/pull/1386).