### PR TITLE
Use target features to distinguish between Vanadium targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         working-directory: bench
         run: |
           for case_dir in ./cases/*; do
-            (cd "$case_dir" && cargo +stable build --release --target=riscv32imc-unknown-none-elf) || exit 1
+            (cd "$case_dir" && cargo +stable build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger) || exit 1
           done
 
   # VM app tests in speculos
@@ -327,7 +327,7 @@ jobs:
         run: cargo vnd new --name testapp --template-path "$(pwd)/apps/template/generate"
       - name: Build the app for RISC-V target
         working-directory: testapp/app
-        run: cargo build --release --target=riscv32imc-unknown-none-elf
+        run: cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
       - name: Build the client
         working-directory: testapp/client
         run: cargo build --release

--- a/.github/workflows/reusable_vapp_build.yaml
+++ b/.github/workflows/reusable_vapp_build.yaml
@@ -73,7 +73,7 @@ jobs:
         working-directory: ${{ inputs.app_dir }}
         run: |
           set -e
-          cargo +${{ inputs.rust_toolchain }} build --release --target ${{ inputs.riscv_target }} ${{ inputs.extra_build_args }}
+          cargo +${{ inputs.rust_toolchain }} build --release --target ${{ inputs.riscv_target }} --no-default-features --features target_vanadium_ledger ${{ inputs.extra_build_args }}
           cargo vnd package
 
       - name: Upload V-App artifact

--- a/app-sdk/Cargo.toml
+++ b/app-sdk/Cargo.toml
@@ -4,31 +4,51 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-common = { path = "../common" }
+common = { path = "../common", default-features = false }
 critical-section = "1.1.2"
 subtle = { version="2.6.1", default-features = false }
 hex-literal = "0.4.1"
 zeroize = "1.8.1"
 
+# target_vanadium_ledger dependencies (optional)
+embedded-alloc = { version = "0.5.1", optional = true }
+vanadium-ecalls = { path = "../ecalls", default-features = false, optional = true }
+
+# target_native dependencies (optional)
+bip32 = { version = "0.5.2", optional = true }
+hex = { version = "0.4.3", optional = true }
+hmac = { version = "0.12.1", optional = true }
+k256 = { version = "0.13.4", default-features = false, features = ["alloc", "ecdsa-core", "schnorr"], optional = true }
+lazy_static = { version = "1.5.0", optional = true }
+num-bigint = { version = "0.4.6", optional = true }
+num-traits = { version = "0.2.19", optional = true }
+rand = { version = "0.9.1", optional = true }
+ripemd = { version = "0.1.3", optional = true }
+sha2 = { version = "0.10.8", optional = true }
+
 [features]
+default = ["target_native"]
+target_native = [
+    "common/target_native",
+    "dep:bip32",
+    "dep:hex",
+    "dep:hmac",
+    "dep:k256",
+    "dep:lazy_static",
+    "dep:num-bigint",
+    "dep:num-traits",
+    "dep:rand",
+    "dep:ripemd",
+    "dep:sha2",
+]
+target_vanadium_ledger = [
+    "common/target_vanadium_ledger",
+    "dep:embedded-alloc",
+    "vanadium-ecalls/target_vanadium_ledger",
+]
+
 # Enable this in V-App's dev-dependencies
 test-mode = [] 
 
 [build-dependencies]
 common = { path = "../common", features = ["wrapped_serializable"] }
-
-[target.'cfg(target_arch = "riscv32")'.dependencies]
-embedded-alloc = "0.5.1"
-vanadium-ecalls = { path = "../ecalls" }
-
-[target.'cfg(not(target_arch = "riscv32"))'.dependencies]
-bip32 = "0.5.2"
-hex = "0.4.3"
-hmac = "0.12.1"
-k256 = { version = "0.13.4", default-features = false, features = ["alloc", "ecdsa-core", "schnorr"] }
-lazy_static = "1.5.0"
-num-bigint = "0.4.6"
-num-traits = "0.2.19"
-rand = "0.9.1"
-ripemd = "0.1.3"
-sha2 = "0.10.8"

--- a/app-sdk/justfile
+++ b/app-sdk/justfile
@@ -2,13 +2,13 @@
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -1,7 +1,7 @@
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "target_vanadium_ledger")]
 use crate::ecalls_riscv as ecalls_module;
 
-#[cfg(not(target_arch = "riscv32"))]
+#[cfg(feature = "target_native")]
 use crate::ecalls_native as ecalls_module;
 
 use common::ux::EventData;
@@ -372,7 +372,7 @@ forward_to_ecall! {
     ) -> u32;
 }
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "target_vanadium_ledger")]
 forward_to_ecall! {
     pub fn hash_init(hash_id: u32, ctx: *mut u8);
     pub fn hash_update(hash_id: u32, ctx: *mut u8, data: *const u8, len: usize) -> u32;

--- a/app-sdk/src/hash.rs
+++ b/app-sdk/src/hash.rs
@@ -1,6 +1,6 @@
 pub use common::accumulator::Hasher;
 
-#[cfg(not(target_arch = "riscv32"))]
+#[cfg(feature = "target_native")]
 mod hashers {
     use super::*;
     use ripemd::Ripemd160 as Ripemd160Real;
@@ -37,7 +37,7 @@ mod hashers {
     impl_hash!(Ripemd160, Ripemd160Real, 20);
 }
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "target_vanadium_ledger")]
 mod hashers {
     use super::*;
     use crate::ecalls;

--- a/apps/bitcoin/app/Cargo.toml
+++ b/apps/bitcoin/app/Cargo.toml
@@ -8,20 +8,23 @@ name = "Bitcoin"
 stack_size = 65536
 
 [features]
+default = ["target_native"]
+target_native = ["sdk/target_native", "bitcoin/target_native", "common/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger", "bitcoin/target_vanadium_ledger", "common/target_vanadium_ledger"]
 autoapprove = []  # used for integration tests
 
 [dependencies]
 bitcoin = { version = "0.32.0", features = ["serde"], default-features = false }
-common = { package = "vnd-bitcoin-common", path = "../common"}
+common = { package = "vnd-bitcoin-common", path = "../common", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = "0.4.1"
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 
 [dev-dependencies]
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", features = ["test-mode"]}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false, features = ["test-mode", "target_native"] }
 
 [profile.release]
 opt-level = "s"
@@ -37,5 +40,7 @@ path = "../../../libs/bitcoin"
 path = "../../../libs/bitcoin_hashes"
 [patch.crates-io.secp256k1]
 path = "../../../libs/secp256k1"
+[patch.crates-io.base58ck]
+path = "../../../libs/base58"
 [patch.crates-io.getrandom]
 path = "../../../libs/getrandom"

--- a/apps/bitcoin/app/justfile
+++ b/apps/bitcoin/app/justfile
@@ -4,15 +4,15 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # disassembles the riscv binary
 disassemble:

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/apps/bitcoin/client/Cargo.toml
+++ b/apps/bitcoin/client/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = []
+default = ["target_all"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+target_all = ["sdk/target_all"]
 debug = ["dep:env_logger", "sdk/debug"]
 speculos-tests = []
 
@@ -13,7 +16,7 @@ bitcoin = { version = "0.32.0" }
 common = { package = "vnd-bitcoin-common", path = "../common"}
 hex = "0.4.3"
 hidapi = "2.6.3"
-sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk"}
+sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk" }
 serde = "1.0.219"
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
 
@@ -28,7 +31,7 @@ base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 env_logger = { version = "0.11.8", optional = true }
 
 [dev-dependencies]
-sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk", features = ["test-utils"]}
+sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk", features = ["test-utils"] }
 
 
 [lib]
@@ -48,5 +51,7 @@ path = "../../../libs/bitcoin"
 path = "../../../libs/bitcoin_hashes"
 [patch.crates-io.secp256k1]
 path = "../../../libs/secp256k1"
+[patch.crates-io.base58ck]
+path = "../../../libs/base58"
 [patch.crates-io.getrandom]
 path = "../../../libs/getrandom"

--- a/apps/bitcoin/common/Cargo.toml
+++ b/apps/bitcoin/common/Cargo.toml
@@ -3,17 +3,23 @@ name = "vnd-bitcoin-common"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native", "bitcoin/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger", "bitcoin/target_vanadium_ledger"]
+
 [dependencies]
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bitcoin = { version = "0.32.0", features = ["serde"], default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk" }
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["alloc"] }
 subtle = { version="2.6.1", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false, features = ["target_native"] }
 
 [profile.release]
 opt-level = 3
@@ -27,5 +33,7 @@ path = "../../../libs/bitcoin"
 path = "../../../libs/bitcoin_hashes"
 [patch.crates-io.secp256k1]
 path = "../../../libs/secp256k1"
+[patch.crates-io.base58ck]
+path = "../../../libs/base58"
 [patch.crates-io.getrandom]
 path = "../../../libs/getrandom"

--- a/apps/rps/app/Cargo.toml
+++ b/apps/rps/app/Cargo.toml
@@ -7,13 +7,18 @@ edition = "2021"
 name = "Rock Paper Scissors"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 serde = { version = "1.0.215", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", features = ["test-mode"]}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false, features = ["test-mode", "target_native"] }
 
 [workspace]

--- a/apps/rps/app/justfile
+++ b/apps/rps/app/justfile
@@ -4,13 +4,13 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/rps/app/src/main.rs
+++ b/apps/rps/app/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/apps/rps/client/Cargo.toml
+++ b/apps/rps/client/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["target_all"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+target_all = ["sdk/target_all"]
 speculos-tests = []
 
 [dependencies]
@@ -11,7 +15,7 @@ clap = { version = "4.5.17", features = ["derive"] }
 hex = "0.4.3"
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
 rand = "0.9.1"
-sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk"}
+sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk" }
 serde = { version = "1.0.215", default-features = false, features = ["alloc", "derive"] }
 sha2 = "0.10.9"
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }

--- a/apps/sadik/app/Cargo.toml
+++ b/apps/sadik/app/Cargo.toml
@@ -7,11 +7,15 @@ edition = "2021"
 name = "Sadik"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
 
 [dependencies]
 common = { package = "vnd-sadik-common", path = "../common"}
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 serde = { version = "1.0.215", default-features = false, features = ["alloc"] }
 
 [workspace]

--- a/apps/sadik/app/justfile
+++ b/apps/sadik/app/justfile
@@ -4,15 +4,15 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # disassembles the riscv binary
 disassemble:

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 use sdk::{
     bignum::{BigNum, BigNumMod, ModulusProvider},

--- a/apps/sadik/client/Cargo.toml
+++ b/apps/sadik/client/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["target_all"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+target_all = ["sdk/target_all"]
 speculos-tests = []
 debug = ["dep:env_logger", "sdk/debug"]
 
@@ -14,7 +18,7 @@ env_logger = { version = "0.11.8", optional = true }
 hex = "0.4.3"
 hidapi = "2.6.3"
 postcard = { version = "1.1.1", features = ["alloc"] }
-sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk"}
+sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk" }
 serde = "1.0.215"
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
 

--- a/apps/template/app/Cargo.toml
+++ b/apps/template/app/Cargo.toml
@@ -7,14 +7,19 @@ edition = "2021"
 name = "Template"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk"}
+sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk", default-features = false }
 serde = { version = "1.0.215", default-features = false, features = ["alloc", "derive"] }
 client = { package = "vnd-template-client", path = "../client", default-features = false}
 
 [dev-dependencies]
-sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk", features = ["test-mode"]}
+sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk", default-features = false, features = ["test-mode", "target_native"] }
 
 [workspace]

--- a/apps/template/app/justfile
+++ b/apps/template/app/justfile
@@ -4,13 +4,13 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/template/app/src/main.rs
+++ b/apps/template/app/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/apps/template/client/Cargo.toml
+++ b/apps/template/client/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["client"]
-client = ["dep:tokio", "dep:sdk", "dep:clap"]
+default = ["client", "target_all"]
+client = ["dep:tokio", "dep:clap"]
+target_native = ["dep:sdk", "sdk/target_native"]
+target_vanadium_ledger = ["dep:sdk", "sdk/target_vanadium_ledger"]
+target_all = ["dep:sdk", "sdk/target_all"]
 speculos-tests = []
 
 [dependencies]
@@ -17,7 +20,7 @@ serde = { version = "1.0.215", default-features = false, features = ["alloc", "d
 # All the following dependencies are only present if the 'client' feature is enabled.
 # They do not require no_std
 clap = { version = "4.5.17", features = ["derive"], optional = true }
-sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-client-sdk", optional = true}
+sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-client-sdk", optional = true }
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"], optional = true }
 
 [lib]

--- a/apps/template/generate/app/Cargo.toml.liquid
+++ b/apps/template/generate/app/Cargo.toml.liquid
@@ -7,14 +7,19 @@ edition = "2021"
 name = "Template"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
-sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk"}
+sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk", default-features = false }
 serde = { version = "1.0.215", default-features = false, features = ["alloc", "derive"] }
 client = { package = "{{project-client-crate}}", path = "../client", default-features = false}
 
 [dev-dependencies]
-sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk", features = ["test-mode"]}
+sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-app-sdk", default-features = false, features = ["test-mode", "target_native"] }
 
 [workspace]

--- a/apps/template/generate/app/justfile
+++ b/apps/template/generate/app/justfile
@@ -4,13 +4,13 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/template/generate/app/src/main.rs
+++ b/apps/template/generate/app/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/apps/template/generate/client/Cargo.toml.liquid
+++ b/apps/template/generate/client/Cargo.toml.liquid
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["client"]
-client = ["dep:tokio", "dep:sdk", "dep:clap"]
+default = ["client", "target_all"]
+client = ["dep:tokio", "dep:clap"]
+target_native = ["dep:sdk", "sdk/target_native"]
+target_vanadium_ledger = ["dep:sdk", "sdk/target_vanadium_ledger"]
+target_all = ["dep:sdk", "sdk/target_all"]
 speculos-tests = []
 
 [dependencies]
@@ -17,7 +20,7 @@ serde = { version = "1.0.215", default-features = false, features = ["alloc", "d
 # All the following dependencies are only present if the 'client' feature is enabled.
 # They do not require no_std
 clap = { version = "4.5.17", features = ["derive"], optional = true }
-sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-client-sdk", optional = true}
+sdk = { git = "https://github.com/LedgerHQ/vanadium.git", package = "vanadium-client-sdk", optional = true }
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"], optional = true }
 
 [lib]

--- a/apps/test/app/Cargo.toml
+++ b/apps/test/app/Cargo.toml
@@ -7,9 +7,14 @@ edition = "2021"
 name = "Test"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
 bs58 = { version = "0.5.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 
 [workspace]

--- a/apps/test/app/justfile
+++ b/apps/test/app/justfile
@@ -4,15 +4,15 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
   cargo build --release
 
-# build for riscv target
+# build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf
+  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # disassembles the riscv binary
 disassemble:

--- a/apps/test/app/src/main.rs
+++ b/apps/test/app/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/apps/test/client/Cargo.toml
+++ b/apps/test/client/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = []
+default = ["target_all"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+target_all = ["sdk/target_all"]
 speculos-tests = []
 debug = ["dep:env_logger", "sdk/debug"]
 
@@ -12,7 +15,7 @@ debug = ["dep:env_logger", "sdk/debug"]
 clap = { version = "4.5.17", features = ["derive"] }
 hex = "0.4.3"
 hidapi = "2.6.3"
-sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk"}
+sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk" }
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
 env_logger = { version = "0.11.8", optional = true }
 

--- a/bench/cases/_baseline/Cargo.toml
+++ b/bench/cases/_baseline/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 name = "Bench"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 
 [workspace]

--- a/bench/cases/_baseline/src/main.rs
+++ b/bench/cases/_baseline/src/main.rs
@@ -1,7 +1,7 @@
 // This test does nothing, and is only used to measure the overhead of running an empty program.
 // It is used to make the measurements more accurate for the other tests, by providing the baseline running time.
 
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/bench/cases/base58enc/Cargo.toml
+++ b/bench/cases/base58enc/Cargo.toml
@@ -7,8 +7,13 @@ edition = "2021"
 name = "Bench"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
 bs58 = { version = "0.5.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 
 [workspace]

--- a/bench/cases/base58enc/src/main.rs
+++ b/bench/cases/base58enc/src/main.rs
@@ -1,6 +1,6 @@
 // This test computes the cost of encoding 32 bytes to base58 using the `bs58` crate.,
 
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/bench/cases/nprimes/Cargo.toml
+++ b/bench/cases/nprimes/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 name = "Bench"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 
 [workspace]

--- a/bench/cases/nprimes/src/main.rs
+++ b/bench/cases/nprimes/src/main.rs
@@ -1,7 +1,7 @@
 // This test computes the number of primes up to 4000 using the Sieve of Eratosthenes algorithm.
 // It measure a relatively memory-intensive operation, which will cause a significant number of page loads and commits.
 
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 extern crate alloc;
 

--- a/bench/cases/sha256/Cargo.toml
+++ b/bench/cases/sha256/Cargo.toml
@@ -7,8 +7,13 @@ edition = "2021"
 name = "Bench"
 stack_size = 65536
 
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
 [dependencies]
-sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 
 [workspace]

--- a/bench/cases/sha256/src/main.rs
+++ b/bench/cases/sha256/src/main.rs
@@ -1,7 +1,7 @@
 // This test computes the SHA256 hash of a message repeatedly, using the SHA256 implementation from the `sha2` crate.
 // It does not use the SDK's hash functionality, which would avoid most of the VM's slowdown by using ECALLs.
 
-#![cfg_attr(target_arch = "riscv32", no_std, no_main)]
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
 
 use sha2::Digest;
 

--- a/bench/justfile
+++ b/bench/justfile
@@ -1,8 +1,8 @@
 run:
   cargo run
 
-# build all the testcases
+# build all the testcases for riscv target (Ledger Vanadium)
 build-cases:
   for case_dir in ./cases/*; do\
-    (cd "$case_dir" && cargo build --release --target=riscv32imc-unknown-none-elf)\
+    (cd "$case_dir" && cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger)\
   done

--- a/cargo-vnd/README.md
+++ b/cargo-vnd/README.md
@@ -36,7 +36,7 @@ These are the currently defined commands:
 **Example:**
 
 ```
-cargo build --release --target riscv32imc-unknown-none-elf
+cargo build --release --target riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
 cargo vnd package
 ```
 

--- a/client-sdk/Cargo.toml
+++ b/client-sdk/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["cargo_toml", "transport"]
+default = ["cargo_toml", "transport", "target_all"]
+
+# Target features - controls which transports and protocol variants are available
+# Note: These features do NOT propagate to app-sdk since client-sdk is always native.
+# They only control which transport protocols/methods are available in the client.
+target_native = []
+target_vanadium_ledger = []
+target_all = ["target_native", "target_vanadium_ledger"]
+
 transport = ["hidapi", "ledger-apdu"]
 debug = ["dep:log", "dep:env_logger"]
 
@@ -13,7 +21,10 @@ test-utils = ["transport"]
 
 [dependencies]
 
-app-sdk = { package = "vanadium-app-sdk", path = "../app-sdk"}
+# app-sdk is only used for shared types (hash module)
+# We use target_native since the client runs natively, regardless of which features
+# are enabled on this crate.
+app-sdk = { package = "vanadium-app-sdk", path = "../app-sdk", default-features = false, features = ["target_native"] }
 
 # If enabled as a feature, the client will load "unpackaged" V-Apps by looking Cargo.toml
 # to reconstruct the manifest. Otherwise, only packaged V-Apps will be loaded.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,7 +19,9 @@ sha2 = { version = "0.10.8", default-features = false }
 postcard = { version = "1.0.8", default-features = false, features = ["alloc"] }
 
 [features]
-default = []
+default = ["target_native"]
+target_native = []
+target_vanadium_ledger = []
 
 # This feature should only be used in the build.rs script app-sdk crate
 wrapped_serializable = []

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,21 @@
 # Compilation targets
 
-With the exception of the Vanadium app itself, which is an embedded Ledger app on the `ARM` target, all the other crates target either the `native` or the `riscv` targets.
+All crates used by V-Apps use explicit features in order to distinguish which compilation environment the V-App is going to run. For most such crates, exactly one of these features must be selected at compilation time.
 
-- The `native` target is what is running in your machine.
-- The `riscv` target is currently `riscv32imc-unknown-none`.
+Here are the currently defined target features:
+
+- `target_native`: indicates compilation of a V-App for the *native* environment, which is what runs on your machine. With this target, V-Apps run as a process that communicates with the client via a socket. This is typically the default and is ***only*** used for development and testing.
+- `target_vanadium_ledger`: indicates compilation of a V-App for execution on the Ledger Vanadium VM app. Depending whether the device is a simulated device on Speculos or a real device, the Transport protocol would use tcp or the HID interface. The actual compilation target for this feature is `riscv32imc-unknown-none-elf`.
+
+The `vanadium-app-sdk`, every V-App and any V-App library using the `vanadium-app-sdk` crate must have a feature for each supported target (and transitively propagate to dependencies, if relevant).
+
+When building for the Ledger target, use:
+```bash
+cargo build --release --target riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+```
+
+The `vanadium-client-sdk` and the V-App clients always compile and run for the native target. They might use the feature flags only to distinguish which transport protocol is supported by clients - and might therefore have multiple (or all) target features simultaneously.
+
 
 > **⚠️ WARNING: The native target is insecure.**<br> While it is possible to compile and run the V-Apps on native targets, this is only intended for development and testing purposes. The cryptographic primitives are not hardened against side channels, or other kinds of attacks.
 
@@ -16,8 +28,8 @@ With the exception of the Vanadium app itself, which is an embedded Ledger app o
 In the above chart, all the crates outside *USERLAND* are developed as part of the Vanadium project.
 
 * `vanadium`: This is a Ledger application, targeting the ARM embedded platform that is used by Ledger devices. It contains the VM, code to register and run V-Apps, and provides the implementation of all the system services (via Risc-V ECALLs) to V-Apps. It interacts with the operating system ([BOLOS](https://www.ledger.com/academy/security/our-custom-operating-system-bolos)) in order to provide access to low level primitives, like communication and the cryptographic accelerator.
-* `vanadium-app-sdk`: The SDK used for developing V-Apps. It has `riscv` and `native` targets, in `no_std` mode.
-* `vanadium-client-sdk`: The SDK used for developing the client of V-Apps. It contains the client code common to all V-Apps; in particular, it manages the outsourced memory of the V-App, providing the content of memory pages (and proofs of correctness) when requested by the VM. It only has the `native` target. 
+* `vanadium-app-sdk`: The SDK used for developing V-Apps. It supports both `target_native` (default) and `target_vanadium_ledger` features, in `no_std` mode for the Ledger target.
+* `vanadium-client-sdk`: The SDK used for developing the client of V-Apps. It contains the client code common to all V-Apps; in particular, it manages the outsourced memory of the V-App, providing the content of memory pages (and proofs of correctness) when requested by the VM. It only runs on native targets. It supports `target_native`, `target_vanadium_ledger`, and `target_all` (default) features to control which transport protocols are available.
 
 ## V-App structure
 
@@ -26,9 +38,9 @@ Currently, all existing V-Apps are in this repository, with a monorepo structure
 In the architecture chart above, each V-App will implement the crates in *USERLAND*: particularly, the V-App itself, the V-App client crate, and any external software using the V-App.
 
 A V-App called `foo` should contain three crates:
-* `vnd-foo`: the code of the app. It has `riscv` and `native` targets, in `no_std` mode.
-* `vnd-foo-client`: contains the client code of the V-App, built using the `vanadium-app-client-sdk` crate. It only has the `native` target. 
-* `vnd-foo-common`: any shared code between the app and client crates. It has `riscv` and `native`, in `no_std` mode.
+* `vnd-foo`: the code of the app. It supports `target_native` (default) and `target_vanadium_ledger` features, in `no_std` mode for the Ledger target.
+* `vnd-foo-client`: contains the client code of the V-App, built using the `vanadium-client-sdk` crate. It only runs on native targets. It supports `target_all` (default), `target_native`, and `target_vanadium_ledger` features to control which transport protocols are available. 
+* `vnd-foo-common`: any shared code between the app and client crates. It supports `target_native` (default) and `target_vanadium_ledger` features, in `no_std` mode.
 
 # Other documentation
 

--- a/ecalls/Cargo.toml
+++ b/ecalls/Cargo.toml
@@ -3,5 +3,10 @@ name = "vanadium-ecalls"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["target_native"]
+target_native = ["common/target_native"]
+target_vanadium_ledger = ["common/target_vanadium_ledger"]
+
 [dependencies]
-common = { path = "../common" }
+common = { path = "../common", default-features = false }

--- a/ecalls/src/lib.rs
+++ b/ecalls/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
-// We make this module empty if not riscv32, otherwise rust-analyzer complains as it cannot
-// compile RISC-V assembly on non-RISC-V targets.
+// We make this module empty if not target_vanadium_ledger, otherwise rust-analyzer complains
+// as it cannot compile RISC-V assembly on non-RISC-V targets.
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "target_vanadium_ledger")]
 mod ecalls_impl;
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "target_vanadium_ledger")]
 pub use ecalls_impl::*;

--- a/libs/base58/Cargo.toml
+++ b/libs/base58/Cargo.toml
@@ -13,8 +13,10 @@ rust-version = "1.56.1"
 exclude = ["tests", "contrib"]
 
 [features]
-default = ["std"]
+default = ["std", "target_native"]
 std = ["hashes/std", "internals/std"]
+target_native = ["hashes/target_native"]
+target_vanadium_ledger = ["hashes/target_vanadium_ledger"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/libs/bitcoin/Cargo.toml
+++ b/libs/bitcoin/Cargo.toml
@@ -7,12 +7,14 @@ repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
 documentation = "https://docs.rs/bitcoin/"
 
 [features]
-default = ["secp-lowmemory"]
+default = ["secp-lowmemory", "target_native"]
 std = []
 rand-std = []
 rand = []
 serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "internals/serde", "units/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
+target_native = ["sdk/target_native", "hashes/target_native", "secp256k1/target_native", "base58/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger", "hashes/target_vanadium_ledger", "secp256k1/target_vanadium_ledger", "base58/target_vanadium_ledger"]
 
 
 [lib]
@@ -32,7 +34,7 @@ hex = { package = "hex-conservative", version = "0.2.0", default-features = fals
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
-sdk = { package = "vanadium-app-sdk", path = "../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../app-sdk", default-features = false }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
 
 base64 = { version = "0.21.3", optional = true, default-features = false, features = ["alloc"] }
@@ -56,3 +58,10 @@ opt-level = 3
 lto = true
 
 [workspace]
+
+[patch.crates-io.bitcoin_hashes]
+path = "../bitcoin_hashes"
+[patch.crates-io.secp256k1]
+path = "../secp256k1"
+[patch.crates-io.base58ck]
+path = "../base58"

--- a/libs/bitcoin_hashes/Cargo.toml
+++ b/libs/bitcoin_hashes/Cargo.toml
@@ -14,20 +14,22 @@ rust-version = "1.56.1"
 exclude = ["tests", "contrib"]
 
 [features]
-default = ["std"]
+default = ["std", "target_native"]
 std = ["alloc", "hex/std", "bitcoin-io/std"]
 alloc = ["hex/alloc"]
 # If you want I/O you must enable either "std" or "io".
 io = ["bitcoin-io"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-sdk = { package = "vanadium-app-sdk", path = "../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../app-sdk", default-features = false }
 
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 

--- a/libs/secp256k1/Cargo.toml
+++ b/libs/secp256k1/Cargo.toml
@@ -18,16 +18,18 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["alloc"]
+default = ["alloc", "target_native"]
 # allow use of Secp256k1::new and related API that requires an allocator
 alloc = []
 lowmemory = []
 # Note that unlike upstream, this doesn't require `std` on vanadium
 global-context = []
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
 
 [dependencies]
 
-sdk = { package = "vanadium-app-sdk", path = "../../app-sdk"}
+sdk = { package = "vanadium-app-sdk", path = "../../app-sdk", default-features = false }
 
 serde = { version = "1.0.103", default-features = false, optional = true }
 


### PR DESCRIPTION
Feature flags makes the target explicit in each crate where it's relevant, instead of relying on the target architecture (e.g. riscv32).

This generalizes and will greatly simplify the addition of future compilation targets for Vanadium.

Closes: #122 