### PR TITLE
Implement an opaque type for Slip21 keys

### DIFF
--- a/app-sdk/src/slip21.rs
+++ b/app-sdk/src/slip21.rs
@@ -1,12 +1,80 @@
 use crate::ecalls;
 use alloc::vec::Vec;
+use core::ops::Deref;
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+/// An opaque type representing a SLIP-21 derived key.
+///
+/// This type prevents direct access to the key material to mitigate side-channel attacks.
+/// The key is automatically zeroed on drop.
+///
+/// # Security
+///
+/// - Implements constant-time equality comparison to prevent timing attacks.
+/// - Does not implement `Debug` to prevent accidental logging of key material.
+/// - Does not implement `Clone` to limit the number of copies in memory.
+/// - Automatically zeros memory on drop using `Zeroizing`.
+pub struct Slip21Key {
+    key: Zeroizing<[u8; 32]>,
+}
+
+impl Slip21Key {
+    /// Creates a new `Slip21Key` from raw bytes.
+    ///
+    /// # Security
+    ///
+    /// The provided bytes will be stored in a `Zeroizing` wrapper and automatically
+    /// zeroed when this instance is dropped.
+    pub fn from_bytes(key: [u8; 32]) -> Self {
+        Self {
+            key: Zeroizing::new(key),
+        }
+    }
+
+    /// Compares this key with a 32-byte buffer in constant time.
+    ///
+    /// This method provides an explicit constant-time comparison that is safe
+    /// to use for verification purposes without risking timing attacks.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the keys are equal, `false` otherwise.
+    pub fn ct_compare(&self, other: &[u8; 32]) -> bool {
+        self.key.deref().ct_eq(other).into()
+    }
+
+    /// Returns a reference to the raw bytes of the key.
+    ///
+    /// # Warning
+    ///
+    /// Accessing the raw bytes of cryptographic key material is dangerous and can lead to
+    /// side-channel attacks if the bytes are used incorrectly. This method should only be
+    /// used when absolutely necessary, such as when passing the key to cryptographic
+    /// operations that require raw byte access.
+    ///
+    /// When comparing keys, prefer using the `==` operator (which uses constant-time
+    /// comparison) or the `ct_compare` method instead of accessing raw bytes.
+    pub fn dangerous_as_raw_bytes(&self) -> &[u8; 32] {
+        self.key.deref()
+    }
+}
+
+impl PartialEq for Slip21Key {
+    /// Compares two keys in constant time to prevent timing attacks.
+    fn eq(&self, other: &Self) -> bool {
+        self.key.deref().ct_eq(other.key.deref()).into()
+    }
+}
+
+impl Eq for Slip21Key {}
 
 /// Derives a SLIP-21 key node, based on the BIP39 seed.
 /// The key corresponds to the last 32-bytes of the corresponding SLIP-21 node.
 /// The initial 32 bytes (only used for further derivations) are not returned.
 ///
 /// # Returns
-/// A 32-byte array representing the derived SLIP-21 key.
+/// A `Slip21Key` opaque type representing the derived SLIP-21 key.
 ///
 /// # Panics
 /// This function will panic if either:
@@ -17,11 +85,11 @@ use alloc::vec::Vec;
 ///
 /// # Security
 ///
-/// Accessing the raw bytes of the derived key is dangerous and can lead to
-/// side-channel attacks.
-// TODO: it would be better to return an opaque type that doesn't directly allow
-// accessing the raw bytes, as incorrect usage could lead to side channel attacks.
-pub fn derive_slip21_key(labels: &[&[u8]]) -> [u8; 32] {
+/// The returned key is wrapped in an opaque type that:
+/// - Prevents direct access to raw bytes (unless explicitly using `dangerous_as_raw_bytes()`)
+/// - Implements constant-time equality comparison
+/// - Automatically zeros memory on drop
+pub fn derive_slip21_key(labels: &[&[u8]]) -> Slip21Key {
     // compute the total length of the encoded labels as the sum of their lengths,
     // each increased by 1 because of the length prefix.
     let encoded_length = labels.iter().map(|label| label.len() + 1).sum::<usize>();
@@ -51,5 +119,5 @@ pub fn derive_slip21_key(labels: &[&[u8]]) -> [u8; 32] {
     // only return the last 32 bytes, which are the SLIP-21 key
     let mut key = [0u8; 32];
     key.copy_from_slice(&node[32..64]);
-    key
+    Slip21Key::from_bytes(key)
 }

--- a/apps/bitcoin/common/src/account.rs
+++ b/apps/bitcoin/common/src/account.rs
@@ -137,7 +137,8 @@ impl ProofOfRegistration {
     pub fn new(id: &[u8; 32]) -> Self {
         let por_key = sdk::slip21::derive_slip21_key(&[&POR_MAGIC]);
 
-        let mut mac = HmacEngine::<bitcoin::hashes::sha256::Hash>::new(&por_key);
+        let mut mac =
+            HmacEngine::<bitcoin::hashes::sha256::Hash>::new(por_key.dangerous_as_raw_bytes());
         mac.input(id);
         Self(Hmac::<bitcoin::hashes::sha256::Hash>::from_engine(mac).to_byte_array())
     }

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -168,7 +168,9 @@ fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
         },
         Command::DeriveSlip21Key { labels } => {
             let labels_slices: Vec<&[u8]> = labels.iter().map(|v| v.as_slice()).collect();
-            sdk::slip21::derive_slip21_key(&labels_slices).to_vec()
+            sdk::slip21::derive_slip21_key(&labels_slices)
+                .dangerous_as_raw_bytes()
+                .to_vec()
         }
         Command::ECPointOperation { curve, operation } => match curve {
             Curve::Secp256k1 => match operation {

--- a/apps/sadik/client/tests/integration_test.rs
+++ b/apps/sadik/client/tests/integration_test.rs
@@ -268,17 +268,15 @@ async fn test_derive_slip21_key() {
     let label1 = b"Vanadium".to_vec();
 
     // m/b'Vanadium'
-    assert_eq!(
-        client.get_slip21_key(&[&label1]).await.unwrap(),
-        hex!("ba0ff8c27d6a0c9f7cb3346394b7c57306c5922a2f54a7d51352b9c511e155e0").to_vec()
-    );
+    let key1 = client.get_slip21_key(&[&label1]).await.unwrap();
+    let expected1 = hex!("ba0ff8c27d6a0c9f7cb3346394b7c57306c5922a2f54a7d51352b9c511e155e0");
+    assert_eq!(key1, expected1.to_vec());
 
     // m/b'Vanadium'/b'Risc-V'
     let label2 = b"Risc-V".to_vec();
-    assert_eq!(
-        client.get_slip21_key(&[&label1, &label2]).await.unwrap(),
-        hex!("234bbecf423f05569b6de6cbb56cd73cb9c29dec8c6599551a1a5a85bc445e5f").to_vec()
-    );
+    let key2 = client.get_slip21_key(&[&label1, &label2]).await.unwrap();
+    let expected2 = hex!("234bbecf423f05569b6de6cbb56cd73cb9c29dec8c6599551a1a5a85bc445e5f");
+    assert_eq!(key2, expected2.to_vec());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Since they contain symmetric secrets, an opaque type allows to implement some standard hygiene.