### PR TITLE
Persistent storage

### DIFF
--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -77,6 +77,28 @@ forward_to_ecall! {
     /// The event code.
     pub fn get_event(data: *mut EventData) -> u32;
 
+    /// Reads a 32-byte value from the specified storage slot.
+    ///
+    /// # Parameters
+    /// - `slot_index`: The index of the storage slot to read (0 to n_storage_slots-1).
+    /// - `buffer`: Pointer to a 32-byte buffer to store the read value.
+    /// - `buffer_size`: Size of the buffer (must be 32).
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
+    pub fn storage_read(slot_index: u32, buffer: *mut u8, buffer_size: usize) -> u32;
+
+    /// Writes a 32-byte value to the specified storage slot.
+    ///
+    /// # Parameters
+    /// - `slot_index`: The index of the storage slot to write (0 to n_storage_slots-1).
+    /// - `buffer`: Pointer to the 32-byte buffer containing the value to write.
+    /// - `buffer_size`: Size of the buffer (must be 32).
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
+    pub fn storage_write(slot_index: u32, buffer: *const u8, buffer_size: usize) -> u32;
+
     /// Shows a page.
     ///
     /// # Parameters

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -22,9 +22,13 @@ delegate_ecall!(xrecv, usize, (buffer: *mut u8), (size: usize));
 delegate_ecall!(print, (buffer: *const u8), (size: usize));
 
 delegate_ecall!(get_event, u32, (data: *mut EventData));
+delegate_ecall!(get_device_property, u32, (property: u32));
+
+delegate_ecall!(storage_read, u32, (slot_index: u32), (buffer: *mut u8), (buffer_size: usize));
+delegate_ecall!(storage_write, u32, (slot_index: u32), (buffer: *const u8), (buffer_size: usize));
+
 delegate_ecall!(show_page, u32, (page_desc: *const u8), (page_desc_len: usize));
 delegate_ecall!(show_step, u32, (step_desc: *const u8), (step_desc_len: usize));
-delegate_ecall!(get_device_property, u32, (property: u32));
 
 delegate_ecall!(bn_modm, u32, (r: *mut u8), (n: *const u8), (len: usize), (m: *const u8), (len_m: usize));
 delegate_ecall!(bn_addm, u32, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize));

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -21,6 +21,7 @@ pub mod curve;
 pub mod hash;
 pub mod rand;
 pub mod slip21;
+pub mod storage;
 pub mod ux;
 
 pub use app::{App, AppBuilder};

--- a/app-sdk/src/storage.rs
+++ b/app-sdk/src/storage.rs
@@ -1,0 +1,59 @@
+use crate::ecalls;
+pub use common::constants::STORAGE_SLOT_SIZE;
+
+/// Reads a 32-byte value from the specified storage slot.
+///
+/// # Parameters
+/// - `slot_index`: The index of the storage slot to read (0 to n_storage_slots-1).
+///
+/// # Returns
+/// A `Result` containing the 32-byte array on success, or an error message on failure.
+///
+/// # Examples
+/// ```no_run
+/// use vanadium_app_sdk::storage::read_slot;
+///
+/// match read_slot(0) {
+///     Ok(data) => println!("Read data: {:?}", data),
+///     Err(e) => eprintln!("Error reading storage: {}", e),
+/// }
+/// ```
+pub fn read_slot(slot_index: u32) -> Result<[u8; STORAGE_SLOT_SIZE], &'static str> {
+    let mut buffer = [0u8; STORAGE_SLOT_SIZE];
+    let result = ecalls::storage_read(slot_index, buffer.as_mut_ptr(), STORAGE_SLOT_SIZE);
+
+    if result == 1 {
+        Ok(buffer)
+    } else {
+        Err("Failed to read from storage slot")
+    }
+}
+
+/// Writes a 32-byte value to the specified storage slot.
+///
+/// # Parameters
+/// - `slot_index`: The index of the storage slot to write (0 to n_storage_slots-1).
+/// - `data`: A reference to the 32-byte array to write.
+///
+/// # Returns
+/// A `Result` indicating success or an error message on failure.
+///
+/// # Examples
+/// ```no_run
+/// use vanadium_app_sdk::storage::write_slot;
+///
+/// let data = [0u8; 32];
+/// match write_slot(0, &data) {
+///     Ok(()) => println!("Data written successfully"),
+///     Err(e) => eprintln!("Error writing storage: {}", e),
+/// }
+/// ```
+pub fn write_slot(slot_index: u32, data: &[u8; STORAGE_SLOT_SIZE]) -> Result<(), &'static str> {
+    let result = ecalls::storage_write(slot_index, data.as_ptr(), STORAGE_SLOT_SIZE);
+
+    if result == 1 {
+        Ok(())
+    } else {
+        Err("Failed to write to storage slot")
+    }
+}

--- a/apps/sadik/app/Cargo.toml
+++ b/apps/sadik/app/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [package.metadata.vapp]
 name = "Sadik"
 stack_size = 65536
+n_storage_slots = 4
 
 [features]
 default = ["target_native"]

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -267,6 +267,16 @@ fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
 
             vec![]
         }
+        Command::WriteStorage { slot, data } => {
+            let mut storage_data = [0u8; 32];
+            let len = core::cmp::min(data.len(), 32);
+            storage_data[..len].copy_from_slice(&data[..len]);
+            sdk::storage::write_slot(slot, &storage_data).expect("Failed to write storage");
+            vec![]
+        }
+        Command::ReadStorage { slot } => sdk::storage::read_slot(slot)
+            .expect("Failed to read storage")
+            .to_vec(),
     };
 
     response

--- a/apps/sadik/client/src/client.rs
+++ b/apps/sadik/client/src/client.rs
@@ -238,6 +238,29 @@ impl SadikClient {
             .expect("Error sending message"))
     }
 
+    pub async fn write_storage(
+        &mut self,
+        slot: u32,
+        data: &[u8],
+    ) -> Result<Vec<u8>, SadikClientError> {
+        let cmd = Command::WriteStorage {
+            slot,
+            data: data.to_vec(),
+        };
+        let msg = postcard::to_allocvec(&cmd).expect("Serialization failed");
+        Ok(send_message(&mut self.vapp_transport, &msg)
+            .await
+            .expect("Error sending message"))
+    }
+
+    pub async fn read_storage(&mut self, slot: u32) -> Result<Vec<u8>, SadikClientError> {
+        let cmd = Command::ReadStorage { slot };
+        let msg = postcard::to_allocvec(&cmd).expect("Serialization failed");
+        Ok(send_message(&mut self.vapp_transport, &msg)
+            .await
+            .expect("Error sending message"))
+    }
+
     pub async fn exit(&mut self) -> Result<i32, &'static str> {
         match send_message(&mut self.vapp_transport, &[]).await {
             Ok(_) => Err("Exit message shouldn't return!"),

--- a/apps/sadik/common/src/lib.rs
+++ b/apps/sadik/common/src/lib.rs
@@ -76,6 +76,13 @@ pub enum Command {
     Sleep {
         n_ticks: u32,
     },
+    WriteStorage {
+        slot: u32,
+        data: Vec<u8>,
+    },
+    ReadStorage {
+        slot: u32,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/cargo-vnd/src/main.rs
+++ b/cargo-vnd/src/main.rs
@@ -218,6 +218,19 @@ fn create_vapp_package(
     }
     let stack_size = stack_size as u32;
 
+    let n_storage_slots = vapp_metadata
+        .get("n_storage_slots")
+        .and_then(|v| v.as_integer())
+        .unwrap_or(0);
+
+    if n_storage_slots < 0 || n_storage_slots > constants::MAX_STORAGE_SLOTS as i64 {
+        return Err(anyhow::anyhow!(
+            "n_storage_slots must be between 0 and {}",
+            constants::MAX_STORAGE_SLOTS
+        ));
+    }
+    let n_storage_slots = n_storage_slots as u32;
+
     // we might make it configurable in the future; for now, use a fixed value
     let stack_start = constants::DEFAULT_STACK_START;
     let stack_end = stack_start + stack_size;
@@ -265,6 +278,7 @@ fn create_vapp_package(
         stack_start,
         stack_end,
         stack_merkle_root,
+        n_storage_slots,
     )
     .map_err(|e| anyhow::anyhow!(e))
     .context("Failed to create VApp manifest")?;

--- a/cargo-vnd/src/main.rs
+++ b/cargo-vnd/src/main.rs
@@ -218,10 +218,12 @@ fn create_vapp_package(
     }
     let stack_size = stack_size as u32;
 
-    let n_storage_slots = vapp_metadata
-        .get("n_storage_slots")
-        .and_then(|v| v.as_integer())
-        .unwrap_or(0);
+    let n_storage_slots = match vapp_metadata.get("n_storage_slots") {
+        None => 0,
+        Some(value) => value
+            .as_integer()
+            .context("n_storage_slots is not a number")?,
+    };
 
     if n_storage_slots < 0 || n_storage_slots > constants::MAX_STORAGE_SLOTS as i64 {
         return Err(anyhow::anyhow!(

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -981,11 +981,15 @@ fn load_elf_and_manifest(
                 .ok_or("Stack size is not a number")?;
             let stack_size = stack_size as u32;
 
-            let n_storage_slots = vapp_metadata
-                .get("n_storage_slots")
-                .ok_or("n_storage_slots missing in metadata")?
-                .as_integer()
-                .ok_or("n_storage_slots is not a number")?;
+            let n_storage_slots = match vapp_metadata.get("n_storage_slots") {
+                None => 0,
+                Some(value) => value
+                    .as_integer()
+                    .ok_or("n_storage_slots is not a number")?,
+            };
+            if n_storage_slots < 0 || n_storage_slots > u32::MAX as i64 {
+                return Err("n_storage_slots is out of range".into());
+            }
             let n_storage_slots = n_storage_slots as u32;
 
             let stack_start = DEFAULT_STACK_START;

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -981,6 +981,13 @@ fn load_elf_and_manifest(
                 .ok_or("Stack size is not a number")?;
             let stack_size = stack_size as u32;
 
+            let n_storage_slots = vapp_metadata
+                .get("n_storage_slots")
+                .ok_or("n_storage_slots missing in metadata")?
+                .as_integer()
+                .ok_or("n_storage_slots is not a number")?;
+            let n_storage_slots = n_storage_slots as u32;
+
             let stack_start = DEFAULT_STACK_START;
             let stack_end = stack_start + stack_size;
 
@@ -1014,6 +1021,7 @@ fn load_elf_and_manifest(
                 stack_start,
                 stack_end,
                 stack_merkle_root,
+                n_storage_slots,
             )?
         }
     };

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -19,6 +19,10 @@ pub const MAX_STACK_SIZE: usize = 1 << 27; // 128 MiB
 /// acceptable address on the stack.
 pub const DEFAULT_STACK_START: u32 = 0xf0000000;
 
+// Storage slots for persistent data
+pub const STORAGE_SLOT_SIZE: usize = 32; // 32 bytes per slot
+pub const MAX_STORAGE_SLOTS: u32 = 4;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -18,6 +18,10 @@ pub const DEVICE_PROPERTY_SCREEN_SIZE: u32 = 0x02;
 // bitmask of device features (to be defined)
 pub const DEVICE_PROPERTY_FEATURES: u32 = 0x03;
 
+// Persistent storage
+pub const ECALL_STORAGE_READ: u32 = 20;
+pub const ECALL_STORAGE_WRITE: u32 = 21;
+
 // Big numbers
 pub const ECALL_MODM: u32 = 110;
 pub const ECALL_ADDM: u32 = 111;

--- a/common/src/manifest.rs
+++ b/common/src/manifest.rs
@@ -26,6 +26,7 @@ pub struct Manifest {
     pub stack_start: u32,
     pub stack_end: u32,
     pub stack_merkle_root: [u8; 32],
+    pub n_storage_slots: u32,
 }
 
 impl Manifest {
@@ -44,6 +45,7 @@ impl Manifest {
         stack_start: u32,
         stack_end: u32,
         stack_merkle_root: [u8; 32],
+        n_storage_slots: u32,
     ) -> Result<Self, &'static str> {
         if vapp_name.len() > APP_NAME_MAX_LEN {
             return Err("vapp_name is too long");
@@ -72,6 +74,9 @@ impl Manifest {
         if vapp_version.starts_with(' ') || vapp_version.ends_with(' ') {
             return Err("vapp_version must not start or end with a space");
         }
+        if n_storage_slots > crate::constants::MAX_STORAGE_SLOTS {
+            return Err("n_storage_slots exceeds maximum allowed");
+        }
 
         Ok(Self {
             manifest_version,
@@ -87,6 +92,7 @@ impl Manifest {
             stack_start,
             stack_end,
             stack_merkle_root,
+            n_storage_slots,
         })
     }
 
@@ -170,6 +176,9 @@ impl Manifest {
         hasher.update(&self.stack_start.to_be_bytes());
         hasher.update(&self.stack_end.to_be_bytes());
         hasher.update(&self.stack_merkle_root);
+
+        // Hash storage configuration
+        hasher.update(&self.n_storage_slots.to_be_bytes());
 
         hasher.finalize()
     }

--- a/common/src/manifest.rs
+++ b/common/src/manifest.rs
@@ -26,6 +26,7 @@ pub struct Manifest {
     pub stack_start: u32,
     pub stack_end: u32,
     pub stack_merkle_root: [u8; 32],
+    #[serde(default)]
     pub n_storage_slots: u32,
 }
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -8,6 +8,7 @@ While the exact specifications of the Manifest are (at this stage) are still lik
 - The V-App's name and version
 - The V-App's entry point
 - the start, end and the initial Merkle root of the code, data and stack segments of the binary.
+- the number of persistent storage slots, if needed.
 
 The [cargo-vnd](../cargo-vnd) tool computes most of those fields from the compiled binary, producing a packaged binary that contains the Manifest added to it.
 
@@ -23,6 +24,10 @@ The name is shown when the V-App is registered onto the device.
 [package.metadata.vapp]
 name = "My App"
 stack_size = 131072
+n_storage_slots = 2
 ```
 
-If omitted, the stack size defaults to 65536 bytes.
+If omitted:
+- `stack_size` defaults to 65536 bytes.
+- `n_storage_slots` defaults to 0.
+

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,3 +40,9 @@ Once the user approves, the V-App is stored in a persistent registry on the devi
 When launching a V-App, the Vanadium VM verifies that the V-App hash matches one of the registered entries before allowing execution.
 
 Note: The V-App registry is cleared if the Vanadium app is deleted or reinstalled.
+
+# Persistent storage
+
+For apps that store any data in persistent storage, Vanadium guarantees isolation between V-Apps, preventing one app to access the store of other apps.
+
+The stored data has the same physical tamper-resistance as the Vanadium app binary itself.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,14 @@
+V-Apps can use persistent storage on the device, using the `storage` module in the V-App SDK.
+
+Storage is organized in 32-byte slots, and it is currently limited to at most 4 slots per application. Therefore, V-Apps can store a total of 128 bytes.
+
+V-Apps that want to use storage must declare it using the `n_storage_slots` in the [manifest](manifest) in their Cargo.toml.
+
+## Needing more storage?
+
+A V-App that needs more than the small amount of supported persistent storage might achieve a similar effect by outsourcing the (encrypted) storage to the client, and only storing a commitment in the actual V-App storage.
+
+> **⚠️ Important:**<br>
+Like for Vanadium's code and RAM outsourcing, depending on the implementation, **this might leak the storage access pattern**, therefore developers need to be careful to make sure that this does not have security implications. See [security.md](security.md) for a discussion on this topic.
+
+Most real-world usages of persistent storage are not related to low-level cryptography, and are therefore not expected to be impacted by this potential side channel.

--- a/ecalls/src/ecalls_impl.rs
+++ b/ecalls/src/ecalls_impl.rs
@@ -342,6 +342,9 @@ ecall2!(show_page, ECALL_SHOW_PAGE, (page_desc: *const u8), (page_desc_len: usiz
 ecall2!(show_step, ECALL_SHOW_STEP, (step_desc: *const u8), (step_desc_len: usize), u32);
 ecall1!(get_device_property, ECALL_GET_DEVICE_PROPERTY, (property: u32), u32);
 
+ecall3!(storage_read, ECALL_STORAGE_READ, (slot_index: u32), (buffer: *mut u8), (buffer_size: usize), u32);
+ecall3!(storage_write, ECALL_STORAGE_WRITE, (slot_index: u32), (buffer: *const u8), (buffer_size: usize), u32);
+
 ecall5!(bn_modm, ECALL_MODM, (r: *mut u8), (n: *const u8), (len: usize), (m: *const u8), (len_m: usize), u32);
 ecall5!(bn_addm, ECALL_ADDM, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize), u32);
 ecall5!(bn_subm, ECALL_SUBM, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize), u32);

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -10,7 +10,7 @@ use common::{
         BufferType, Message, MessageDeserializationError, ReceiveBufferMessage,
         ReceiveBufferResponse, SendBufferContinuedMessage, SendBufferMessage,
     },
-    constants::STORAGE_SLOT_SIZE,
+    constants::{MAX_STORAGE_SLOTS, STORAGE_SLOT_SIZE},
     ecall_constants::{self, *},
     ux::Deserializable,
     vm::{Cpu, CpuError, EcallHandler, MemoryError},
@@ -373,6 +373,8 @@ impl<'a, const N: usize> CommEcallHandler<'a, N> {
         vapp_hash: [u8; 32],
         n_storage_slots: u32,
     ) -> Self {
+        assert!(n_storage_slots <= MAX_STORAGE_SLOTS);
+
         Self {
             comm,
             ux_handler: init_ux_handler(),
@@ -546,7 +548,7 @@ impl<'a, const N: usize> CommEcallHandler<'a, N> {
         }
 
         // Validate slot index
-        if slot_index >= self.n_storage_slots {
+        if slot_index >= self.n_storage_slots || slot_index >= MAX_STORAGE_SLOTS {
             return Ok(0); // Invalid slot index
         }
 
@@ -581,7 +583,7 @@ impl<'a, const N: usize> CommEcallHandler<'a, N> {
         }
 
         // Validate slot index
-        if slot_index >= self.n_storage_slots {
+        if slot_index >= self.n_storage_slots || slot_index >= MAX_STORAGE_SLOTS {
             return Ok(0); // Invalid slot index
         }
 

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -524,6 +524,34 @@ impl<'a, const N: usize> CommEcallHandler<'a, N> {
         self.handle_send_buffer::<E>(cpu, buffer, size, BufferType::Print)
     }
 
+    fn handle_storage_read<E: fmt::Debug>(
+        &self,
+        _cpu: &mut Cpu<OutsourcedMemory<'_, N>>,
+        _slot_index: u32,
+        _buffer: GuestPointer,
+        _buffer_size: usize,
+    ) -> Result<u32, CommEcallError> {
+        // TODO: Implement NVRAM reading
+        // For now, return error to indicate unimplemented
+        Err(CommEcallError::GenericError(
+            "storage_read not yet implemented",
+        ))
+    }
+
+    fn handle_storage_write<E: fmt::Debug>(
+        &self,
+        _cpu: &mut Cpu<OutsourcedMemory<'_, N>>,
+        _slot_index: u32,
+        _buffer: GuestPointer,
+        _buffer_size: usize,
+    ) -> Result<u32, CommEcallError> {
+        // TODO: Implement NVRAM writing
+        // For now, return error to indicate unimplemented
+        Err(CommEcallError::GenericError(
+            "storage_write not yet implemented",
+        ))
+    }
+
     fn handle_bn_modm<E: fmt::Debug>(
         &self,
         cpu: &mut Cpu<OutsourcedMemory<'_, N>>,
@@ -1607,6 +1635,8 @@ fn get_ecall_name(ecall_code: u32) -> String {
         ECALL_ECFP_ADD_POINT => "ecfp_add_point".into(),
         ECALL_ECFP_SCALAR_MULT => "ecfp_scalar_mult".into(),
         ECALL_GET_RANDOM_BYTES => "get_random_bytes".into(),
+        ECALL_STORAGE_READ => "storage_read".into(),
+        ECALL_STORAGE_WRITE => "storage_write".into(),
         ECALL_ECDSA_SIGN => "ecdsa_sign".into(),
         ECALL_ECDSA_VERIFY => "ecdsa_verify".into(),
         ECALL_SCHNORR_SIGN => "schnorr_sign".into(),
@@ -1669,6 +1699,24 @@ impl<'a, const N: usize> EcallHandler for CommEcallHandler<'a, N> {
             ECALL_GET_EVENT => {
                 reg!(A0) = self.handle_get_event::<CommEcallError>(cpu, GPreg!(A0))?;
             }
+
+            ECALL_STORAGE_READ => {
+                reg!(A0) = self.handle_storage_read::<CommEcallError>(
+                    cpu,
+                    reg!(A0),
+                    GPreg!(A1),
+                    reg!(A2) as usize,
+                )?;
+            }
+            ECALL_STORAGE_WRITE => {
+                reg!(A0) = self.handle_storage_write::<CommEcallError>(
+                    cpu,
+                    reg!(A0),
+                    GPreg!(A1),
+                    reg!(A2) as usize,
+                )?;
+            }
+
             ECALL_SHOW_PAGE => {
                 self.handle_show_page::<CommEcallError>(cpu, GPreg!(A0), reg!(A1) as usize)?;
 

--- a/vm/src/handlers/register_vapp.rs
+++ b/vm/src/handlers/register_vapp.rs
@@ -22,6 +22,8 @@ pub fn handler_register_vapp(
         return Err(AppSW::IncorrectData); // extra data
     }
 
+    manifest.validate().map_err(|_| AppSW::IncorrectData)?; // ensure manifest is valid
+
     #[cfg(any(target_os = "stax", target_os = "flex"))]
     const VANADIUM_ICON: NbglGlyph =
         NbglGlyph::from_include(include_gif!("icons/vanadium_64x64.gif", NBGL));

--- a/vm/src/handlers/start_vapp.rs
+++ b/vm/src/handlers/start_vapp.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use alloc::{boxed::Box, rc::Rc};
 
 use common::client_commands::SectionKind;
+use common::constants::MAX_STORAGE_SLOTS;
 use common::manifest::Manifest;
 use common::vm::{Cpu, MemorySegment};
 
@@ -30,6 +31,10 @@ pub fn handler_start_vapp(
 
     if rest.len() != 0 {
         return Err(AppSW::IncorrectData); // extra data
+    }
+
+    if manifest.n_storage_slots > MAX_STORAGE_SLOTS {
+        return Err(AppSW::IncorrectData); // too many storage slots in manifest
     }
 
     // Compute the vapp_hash and verify the app is registered

--- a/vm/src/handlers/start_vapp.rs
+++ b/vm/src/handlers/start_vapp.rs
@@ -135,7 +135,8 @@ pub fn handler_start_vapp(
     cpu.regs[2] = (manifest.stack_end - 4) & !3;
     assert!(cpu.pc % 2 == 0, "Unaligned entrypoint");
 
-    let mut ecall_handler = CommEcallHandler::new(comm.clone());
+    let mut ecall_handler =
+        CommEcallHandler::new(comm.clone(), vapp_hash, manifest.n_storage_slots);
 
     #[cfg(feature = "metrics")]
     let mut instr_count = 0;

--- a/vm/src/handlers/start_vapp.rs
+++ b/vm/src/handlers/start_vapp.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use alloc::{boxed::Box, rc::Rc};
 
 use common::client_commands::SectionKind;
-use common::constants::MAX_STORAGE_SLOTS;
 use common::manifest::Manifest;
 use common::vm::{Cpu, MemorySegment};
 
@@ -33,9 +32,7 @@ pub fn handler_start_vapp(
         return Err(AppSW::IncorrectData); // extra data
     }
 
-    if manifest.n_storage_slots > MAX_STORAGE_SLOTS {
-        return Err(AppSW::IncorrectData); // too many storage slots in manifest
-    }
+    manifest.validate().map_err(|_| AppSW::IncorrectData)?; // ensure manifest is valid
 
     // Compute the vapp_hash and verify the app is registered
     let vapp_hash = manifest.get_vapp_hash::<Sha256Hasher, 32>();

--- a/vm/src/vapp.rs
+++ b/vm/src/vapp.rs
@@ -1,4 +1,7 @@
-use common::manifest::{Manifest, APP_NAME_MAX_LEN, APP_VERSION_MAX_LEN};
+use common::{
+    constants::MAX_STORAGE_SLOTS,
+    manifest::{Manifest, APP_NAME_MAX_LEN, APP_VERSION_MAX_LEN},
+};
 use ledger_device_sdk::NVMData;
 
 use crate::nvm::LazyStorage;
@@ -19,6 +22,8 @@ pub struct VAppEntry {
     pub vapp_name: [u8; APP_NAME_MAX_LEN],
     /// V-App version, null-padded to 32 bytes.
     pub vapp_version: [u8; APP_VERSION_MAX_LEN],
+    /// Storage slots for persistent data (4 slots of 32 bytes each).
+    pub storage_slots: [[u8; 32]; MAX_STORAGE_SLOTS as usize],
 }
 
 impl VAppEntry {
@@ -28,6 +33,7 @@ impl VAppEntry {
             vapp_hash: [0u8; 32],
             vapp_name: [0u8; APP_NAME_MAX_LEN],
             vapp_version: [0u8; APP_VERSION_MAX_LEN],
+            storage_slots: [[0u8; 32]; MAX_STORAGE_SLOTS as usize],
         }
     }
 
@@ -78,7 +84,7 @@ pub struct VAppStore;
 impl VAppStore {
     /// Gets a mutable reference to the storage array.
     #[inline(never)]
-    fn get_storage_mut() -> &'static mut [LazyStorage<VAppEntry>; MAX_REGISTERED_VAPPS] {
+    pub fn get_storage_mut() -> &'static mut [LazyStorage<VAppEntry>; MAX_REGISTERED_VAPPS] {
         let data = &raw mut VAPP_STORE;
         unsafe { (*data).get_mut() }
     }

--- a/vm/src/vapp.rs
+++ b/vm/src/vapp.rs
@@ -1,5 +1,5 @@
 use common::{
-    constants::MAX_STORAGE_SLOTS,
+    constants::{MAX_STORAGE_SLOTS, STORAGE_SLOT_SIZE},
     manifest::{Manifest, APP_NAME_MAX_LEN, APP_VERSION_MAX_LEN},
 };
 use ledger_device_sdk::NVMData;
@@ -22,8 +22,8 @@ pub struct VAppEntry {
     pub vapp_name: [u8; APP_NAME_MAX_LEN],
     /// V-App version, null-padded to 32 bytes.
     pub vapp_version: [u8; APP_VERSION_MAX_LEN],
-    /// Storage slots for persistent data (4 slots of 32 bytes each).
-    pub storage_slots: [[u8; 32]; MAX_STORAGE_SLOTS as usize],
+    /// Storage slots for persistent data (4 slots of STORAGE_SLOT_SIZE bytes each).
+    pub storage_slots: [[u8; STORAGE_SLOT_SIZE]; MAX_STORAGE_SLOTS as usize],
 }
 
 impl VAppEntry {
@@ -33,7 +33,7 @@ impl VAppEntry {
             vapp_hash: [0u8; 32],
             vapp_name: [0u8; APP_NAME_MAX_LEN],
             vapp_version: [0u8; APP_VERSION_MAX_LEN],
-            storage_slots: [[0u8; 32]; MAX_STORAGE_SLOTS as usize],
+            storage_slots: [[0u8; STORAGE_SLOT_SIZE]; MAX_STORAGE_SLOTS as usize],
         }
     }
 


### PR DESCRIPTION
Adds support for persistent storage in V-Apps.

Storage is limited to up to 4 slots of 32 bytes each, and it's isolated among V-Apps.