### PR TITLE
Benchmarks improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,37 +51,23 @@ jobs:
       builder: ledger-app-builder
       cargo_ledger_build_args: "--features run_tests"
 
-  # Build benchmark runner crate for native target
-  build_benchmark_runner:
-    name: benchmark runner, Build on native target
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Cache cargo dirs
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-bench-runner-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-bench-runner-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -y libudev-dev pkg-config
-      - name: Clone
-        uses: actions/checkout@v4
-      - name: Build benchmark runner
-        working-directory: bench
-        run: cargo build
+  # build a custom binary for the Vanadium VM with metrics and blind_registration enabled
+  # this allows to collact useful metrics during benchmarks
+  build_vanadium_app_for_benchmarks:
+    name: Build application using the reusable workflow
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_build.yml@v1
+    with:
+      upload_app_binaries_artifact: "vanadium_binaries_for_benchmarks"
+      builder: ledger-app-builder
+      cargo_ledger_build_args: "--features metrics,blind_registration"
 
-  # Build benchmark testcases
-  # Even if we don't run them in the CI, it's good to ensure they can at least compile
+
+  # Build and run benchmark testcases on speculos
+  # This also collect execution metrics and uploads them as artifacts
   build_benchmark_test_cases:
-    name: benchmark test cases, Build on Risc-V target
+    name: Build and run benchmark V-Apps on Speculos, collect metrics
     runs-on: ubuntu-latest
+    needs: [build_vanadium_app_for_benchmarks]
     steps:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -97,14 +83,39 @@ jobs:
           key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-bench-
+      - name: Install Speculos
+        run: |
+          pip install speculos
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y libudev-dev pkg-config && \
+          sudo apt-get install -y qemu-user-static libvncserver-dev
       - name: Clone
         uses: actions/checkout@v4
+      - name: Download Vanadium binaries for benchmarks
+        uses: actions/download-artifact@v4
+        with:
+          name: vanadium_binaries_for_benchmarks
+          path: ./vanadium_binaries_for_benchmarks
       - name: Build app
         working-directory: bench
         run: |
           for case_dir in ./cases/*; do
             (cd "$case_dir" && cargo +stable build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger) || exit 1
           done
+      - name: Run Speculos with Vanadium binary
+        run: |
+          speculos --display headless vanadium_binaries_for_benchmarks/flex/release/app-vanadium &
+          sleep 2
+      - name: Run benchmarks on Speculos with metrics
+        working-directory: bench
+        run: cargo run --features speculos,metrics
+      - name: Upload benchmark metrics
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark_metrics
+          path: bench/*.metrics
 
   # VM app tests in speculos
   

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+# metrics files generated while running the benchmarks
+*.metrics

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,10 +6,16 @@ edition = "2024"
 [features]
 default = ["debug"]
 speculos = []  # runs against an existing speculos instance instead of the real device
-debug = ["dep:env_logger", "sdk/debug"]  # allows showing prints from benchmark V-Apps 
+debug = ["dep:env_logger", "sdk/debug"]  # allows showing prints from benchmark V-Apps
+
+# collects and saves metrics for each benchmark run
+# requires the Vanadium app to also be compiled with the "metrics" feature
+metrics = ["sdk/metrics"]
 
 [dependencies]
+common = { path = "../common" }
 hidapi = "2.6.3"
+hex = "0.4.3"
 sdk = { package = "vanadium-client-sdk", path = "../client-sdk"}
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
 env_logger = { version = "0.11.8", optional = true }

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -3,7 +3,13 @@ name = "vanadium-benchmarks"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["debug"]
+speculos = []  # runs against an existing speculos instance instead of the real device
+debug = ["dep:env_logger", "sdk/debug"]  # allows showing prints from benchmark V-Apps 
+
 [dependencies]
 hidapi = "2.6.3"
 sdk = { package = "vanadium-client-sdk", path = "../client-sdk"}
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
+env_logger = { version = "0.11.8", optional = true }

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -13,3 +13,4 @@ hidapi = "2.6.3"
 sdk = { package = "vanadium-client-sdk", path = "../client-sdk"}
 tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
 env_logger = { version = "0.11.8", optional = true }
+toml = "0.8.23"

--- a/bench/README.md
+++ b/bench/README.md
@@ -6,7 +6,19 @@ This directory contains several benchmarks Vanadium VM. Each benchmark measures 
 
 - Each benchmark case is located in the `cases/` directory, and it's a full V-App as its own crate.
 - The main runner is in `src/main.rs`.
-- Testcases are defined in the `TEST_CASES` array in `main.rs`.
+- Benchmark cases are auto-discovered from `cases/*/Cargo.toml`.
+
+## Case metadata
+
+Each case can set benchmark-specific metadata in its `Cargo.toml`:
+
+```toml
+[package.metadata.benchmark]
+repetitions = 10
+```
+
+- `repetitions` is optional (defaults to `10` if omitted).
+- The baseline case is selected with `baseline = true`, or by using the `_baseline` directory name. This should be a test for an app that does nothing, in order to subtract its running time from each other test, for a more precise estimate.
 
 ## Build the testcases
 
@@ -26,7 +38,13 @@ To run all benchmark testcases:
 cargo run
 ```
 
-To run only specific testcases, pass one or more substrings of the testcase names as command line arguments. Only testcases whose names include at least one of the arguments will be run. For example:
+To list all discovered cases and their configured run counts:
+
+```sh
+cargo run -- --list
+```
+
+To run only specific testcases, pass one or more substrings of the testcase names as command line arguments. Only testcases whose name includes at least one of the arguments will be run. For example:
 
 ```sh
 cargo run -- sha256 base58

--- a/bench/cases/_baseline/Cargo.toml
+++ b/bench/cases/_baseline/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "Bench baseline"
 stack_size = 65536
 
+[package.metadata.benchmark]
+baseline = true
+repetitions = 1
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/alloc_large/.cargo/config.toml
+++ b/bench/cases/alloc_large/.cargo/config.toml
@@ -1,0 +1,13 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+
+
+[target.riscv32imc-unknown-none-elf]
+rustflags = [
+  # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
+  # read-only non-executable sections in their own segment.
+  "-Clink-arg=--no-rosegment",
+]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/bench/cases/alloc_large/Cargo.toml
+++ b/bench/cases/alloc_large/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vndbench-alloc_large"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.vapp]
+name = "Bench Alloc-Large"
+stack_size = 65536
+
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
+[dependencies]
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
+
+[workspace]

--- a/bench/cases/alloc_large/Cargo.toml
+++ b/bench/cases/alloc_large/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench Alloc-Large"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 12
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/alloc_large/src/main.rs
+++ b/bench/cases/alloc_large/src/main.rs
@@ -1,0 +1,42 @@
+// This benchmark stresses the allocator by creating (and immediately dropping)
+// a handful of very large Vec instances, emphasizing big heap allocations.
+// This should be dominated by the cost of page swaps.
+
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
+
+use alloc::vec::Vec;
+
+extern crate alloc;
+
+sdk::bootstrap!();
+
+const BASE_VEC_LEN: usize = 2 * 1024; // 2 KiB
+const LEN_VARIATIONS: usize = 4;
+const LEN_STEP: usize = 1 * 1024; // 1 KiB increments
+
+pub fn main() {
+    let msg: [u8; 8] = sdk::xrecv(8).try_into().expect("Expected 8 bytes");
+    let n_reps = u64::from_be_bytes(msg);
+
+    let mut checksum: u64 = 0;
+
+    for rep in 0..n_reps {
+        let seed = rep as u8;
+
+        let len = BASE_VEC_LEN + (rep as usize % LEN_VARIATIONS) * LEN_STEP;
+        let mut data = Vec::with_capacity(len);
+
+        for i in 0..len {
+            let value = seed.wrapping_add((rep as u8).wrapping_mul(17));
+            data.push(value.wrapping_add(i as u8));
+        }
+
+        checksum ^= data.iter().fold(0u64, |acc, &byte| acc + byte as u64);
+        core::hint::black_box(&data);
+        // `data` drops here before the next iteration, forcing frequent allocations.
+    }
+
+    core::hint::black_box(checksum);
+
+    sdk::exit(0);
+}

--- a/bench/cases/alloc_small/.cargo/config.toml
+++ b/bench/cases/alloc_small/.cargo/config.toml
@@ -1,0 +1,13 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+
+
+[target.riscv32imc-unknown-none-elf]
+rustflags = [
+  # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
+  # read-only non-executable sections in their own segment.
+  "-Clink-arg=--no-rosegment",
+]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/bench/cases/alloc_small/Cargo.toml
+++ b/bench/cases/alloc_small/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench Alloc-Small"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 25
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/alloc_small/Cargo.toml
+++ b/bench/cases/alloc_small/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vndbench-alloc_small"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.vapp]
+name = "Bench Alloc-Small"
+stack_size = 65536
+
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
+[dependencies]
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
+
+[workspace]

--- a/bench/cases/alloc_small/src/main.rs
+++ b/bench/cases/alloc_small/src/main.rs
@@ -1,0 +1,44 @@
+// This benchmark stresses the allocator by creating (and immediately dropping)
+// many short-lived Vec instances filled with small amounts of data.
+
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
+
+use alloc::vec::Vec;
+
+extern crate alloc;
+
+sdk::bootstrap!();
+
+const VECS_PER_REPETITION: usize = 64;
+const BASE_VEC_LEN: usize = 16;
+const LEN_VARIATIONS: usize = 8;
+
+pub fn main() {
+    let msg: [u8; 8] = sdk::xrecv(8).try_into().expect("Expected 8 bytes");
+    let n_reps = u64::from_be_bytes(msg);
+
+    let mut checksum: u64 = 0;
+
+    for rep in 0..n_reps {
+        let seed = rep as u8;
+
+        // Create many vectors with varying length (but generally small)
+        for vec_index in 0..VECS_PER_REPETITION {
+            let len = BASE_VEC_LEN + (vec_index % LEN_VARIATIONS);
+            let mut data = Vec::with_capacity(len);
+
+            for i in 0..len {
+                let value = seed.wrapping_add((vec_index as u8).wrapping_mul(17));
+                data.push(value.wrapping_add(i as u8));
+            }
+
+            checksum ^= data.iter().fold(0u64, |acc, &byte| acc + byte as u64);
+            core::hint::black_box(&data);
+            // `data` drops here before the next iteration, forcing frequent allocations.
+        }
+    }
+
+    core::hint::black_box(checksum);
+
+    sdk::exit(0);
+}

--- a/bench/cases/base58enc/Cargo.toml
+++ b/bench/cases/base58enc/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench Base58"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 10
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/ecdsa_sign/.cargo/config.toml
+++ b/bench/cases/ecdsa_sign/.cargo/config.toml
@@ -1,0 +1,13 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+
+
+[target.riscv32imc-unknown-none-elf]
+rustflags = [
+  # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
+  # read-only non-executable sections in their own segment.
+  "-Clink-arg=--no-rosegment",
+]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/bench/cases/ecdsa_sign/Cargo.toml
+++ b/bench/cases/ecdsa_sign/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench ECDSA-Sign"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 25
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/ecdsa_sign/Cargo.toml
+++ b/bench/cases/ecdsa_sign/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vndbench-ecdsa_sign"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.vapp]
+name = "Bench ECDSA-Sign"
+stack_size = 65536
+
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
+[dependencies]
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
+
+[workspace]

--- a/bench/cases/ecdsa_sign/src/main.rs
+++ b/bench/cases/ecdsa_sign/src/main.rs
@@ -1,0 +1,27 @@
+// This test computes computes an ECDSA signature using the app-sdk (therefore, with the appropriate ECALLs).
+
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
+
+use sdk::curve::Secp256k1;
+
+extern crate alloc;
+
+sdk::bootstrap!();
+
+pub fn main() {
+    let private_key_raw = [0x01; 32];
+    let private_key = sdk::curve::EcfpPrivateKey::<Secp256k1, 32>::new(private_key_raw);
+    let msg: [u8; 8] = sdk::xrecv(8).try_into().expect("Expected 8 bytes");
+    let n_reps = u64::from_be_bytes(msg);
+
+    let mut data = [0u8; 32];
+    for _ in 0..n_reps {
+        let sig = private_key.ecdsa_sign_hash(&data).unwrap();
+        // copy the first 32 bytes of the signature back into data, so that the next iteration will sign new data
+        data.copy_from_slice(&sig[..32]);
+    }
+
+    core::hint::black_box(data);
+
+    sdk::exit(0);
+}

--- a/bench/cases/nprimes/Cargo.toml
+++ b/bench/cases/nprimes/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench NPrimes"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 1
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/schnorr_sign/.cargo/config.toml
+++ b/bench/cases/schnorr_sign/.cargo/config.toml
@@ -1,0 +1,13 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+
+
+[target.riscv32imc-unknown-none-elf]
+rustflags = [
+  # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
+  # read-only non-executable sections in their own segment.
+  "-Clink-arg=--no-rosegment",
+]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/bench/cases/schnorr_sign/Cargo.toml
+++ b/bench/cases/schnorr_sign/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vndbench-schnorr_sign"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.vapp]
+name = "Bench Schnorr-Sign"
+stack_size = 65536
+
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
+[dependencies]
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
+
+[workspace]

--- a/bench/cases/schnorr_sign/Cargo.toml
+++ b/bench/cases/schnorr_sign/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench Schnorr-Sign"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 25
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/cases/schnorr_sign/src/main.rs
+++ b/bench/cases/schnorr_sign/src/main.rs
@@ -1,0 +1,30 @@
+// This test computes computes an ECDSA signature using the app-sdk (therefore, with the appropriate ECALLs).
+
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
+
+use sdk::curve::Secp256k1;
+
+extern crate alloc;
+
+sdk::bootstrap!();
+
+pub fn main() {
+    let private_key_raw = [0x01; 32];
+    let private_key = sdk::curve::EcfpPrivateKey::<Secp256k1, 32>::new(private_key_raw);
+    let msg: [u8; 8] = sdk::xrecv(8).try_into().expect("Expected 8 bytes");
+    let n_reps = u64::from_be_bytes(msg);
+
+    let mut data = [0u8; 32];
+
+    for _ in 0..n_reps {
+        let sig = private_key
+            .schnorr_sign(&data, None)
+            .expect("Signing failed");
+        // copy the first 32 bytes of the signature back into data, so that the next iteration will sign new data
+        data.copy_from_slice(&sig[..32]);
+    }
+
+    core::hint::black_box(data);
+
+    sdk::exit(0);
+}

--- a/bench/cases/sha256/Cargo.toml
+++ b/bench/cases/sha256/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "Bench Sha256"
 stack_size = 65536
 
+[package.metadata.benchmark]
+repetitions = 10
+
 [features]
 default = ["target_native"]
 target_native = ["sdk/target_native"]

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -19,9 +19,13 @@ mod client;
 // The name must be the same as the folder name in cases/ directory,
 // and the crate must be named "vndbench-<name>".
 const TEST_CASES: &[(&str, u64)] = &[
-    ("nprimes", 1),    // counts the number of primes up to a given number
-    ("base58enc", 10), // computes the base58 encoding of a 32-byte message using the bs58 crate
-    ("sha256", 10),    // computes the SHA256 hash of a 32-byte message (without using ECALLs)
+    ("nprimes", 1),       // counts the number of primes up to a given number
+    ("base58enc", 10),    // computes the base58 encoding of a 32-byte message using the bs58 crate
+    ("sha256", 10),       // computes the SHA256 hash of a 32-byte message (without using ECALLs)
+    ("ecdsa_sign", 25),   // computes ECDSA signatures (using ECALLs)
+    ("schnorr_sign", 25), // computes Schnorr signatures (using ECALLs)
+    ("alloc_small", 25),  // allocates and deallocates many small vectors to stress the allocator
+    ("alloc_large", 12), // allocates and deallocates many large vectors to allocate and swap to/from external memory
 ];
 
 // Helper function to run a benchmark case and return (total_ms, avg_ms)

--- a/client-sdk/Cargo.toml
+++ b/client-sdk/Cargo.toml
@@ -10,11 +10,14 @@ default = ["cargo_toml", "transport", "target_all"]
 # Note: These features do NOT propagate to app-sdk since client-sdk is always native.
 # They only control which transport protocols/methods are available in the client.
 target_native = []
-target_vanadium_ledger = []
+target_vanadium_ledger = ["common/target_vanadium_ledger"]
 target_all = ["target_native", "target_vanadium_ledger"]
 
 transport = ["hidapi", "ledger-apdu"]
 debug = ["dep:log", "dep:env_logger"]
+
+# Enable metrics collection - requires the Vanadium app to be built with the "metrics" feature
+metrics = []
 
 # utilities for integration tests
 test-utils = ["transport"]

--- a/client-sdk/src/apdu.rs
+++ b/client-sdk/src/apdu.rs
@@ -124,3 +124,16 @@ pub fn apdu_run_vapp(serialized_manifest: Vec<u8>) -> APDUCommand {
         data: serialized_manifest,
     }
 }
+
+/// APDU command to get metrics for the last executed V-App.
+/// Only available when the "metrics" feature is enabled on the Vanadium app.
+#[cfg(feature = "metrics")]
+pub fn apdu_get_metrics() -> APDUCommand {
+    APDUCommand {
+        cla: 0xE0,
+        ins: 0xF0,
+        p1: 0,
+        p2: 0,
+        data: Vec::new(),
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,8 @@ pub mod comm;
 pub mod constants;
 pub mod ecall_constants;
 pub mod manifest;
+#[cfg(feature = "target_vanadium_ledger")]
+pub mod metrics;
 pub mod ux;
 pub mod vm;
 

--- a/common/src/metrics.rs
+++ b/common/src/metrics.rs
@@ -1,0 +1,39 @@
+/// Metrics collected during the execution of a V-App.
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "serde_json", derive(serde::Serialize, serde::Deserialize))]
+pub struct VAppMetrics {
+    /// Name of the V-App (null-padded to 32 bytes)
+    pub vapp_name: [u8; 32],
+    /// Hash of the V-App
+    pub vapp_hash: [u8; 32],
+    /// Number of instructions executed
+    pub instruction_count: u64,
+    /// Number of page loads from the host
+    pub page_loads: u32,
+    /// Number of page commits to the host
+    pub page_commits: u32,
+}
+
+impl VAppMetrics {
+    pub const fn new() -> Self {
+        Self {
+            vapp_name: [0u8; 32],
+            vapp_hash: [0u8; 32],
+            instruction_count: 0,
+            page_loads: 0,
+            page_commits: 0,
+        }
+    }
+
+    /// Checks if metrics have been recorded (i.e., if a V-App has run)
+    pub fn is_valid(&self) -> bool {
+        // Check if vapp_hash is non-zero
+        self.vapp_hash.iter().any(|&b| b != 0)
+    }
+
+    /// Get the V-App name as a string (strip null padding)
+    pub fn get_vapp_name(&self) -> &str {
+        let len = self.vapp_name.iter().position(|&b| b == 0).unwrap_or(32);
+        core::str::from_utf8(&self.vapp_name[..len]).unwrap_or("")
+    }
+}

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Salvatore Ingala"]
 edition = "2021"
 
 [dependencies]
-common = { path = "../common" }
+common = { path = "../common", features=["target_vanadium_ledger"]}
 serde = {version="1.0.192", default-features = false, features = ["derive"]}
 hex = { version = "0.4.3", default-features = false }
 numtoa = "0.2.4"

--- a/vm/src/handlers/get_metrics.rs
+++ b/vm/src/handlers/get_metrics.rs
@@ -1,0 +1,62 @@
+use alloc::vec::Vec;
+
+use crate::{AppSW, COMM_BUFFER_SIZE};
+use common::metrics::VAppMetrics;
+
+/// Global storage for the last V-App's metrics
+static mut LAST_VAPP_METRICS: VAppMetrics = VAppMetrics::new();
+
+/// Sets the metrics for the last executed V-App.
+/// # Safety
+/// This function is not thread-safe, but is safe in the single-threaded Ledger environment.
+pub fn set_last_metrics(metrics: VAppMetrics) {
+    unsafe {
+        LAST_VAPP_METRICS = metrics;
+    }
+}
+
+/// Gets the metrics for the last executed V-App.
+fn get_last_metrics() -> VAppMetrics {
+    unsafe { LAST_VAPP_METRICS }
+}
+
+/// Handler for the GetMetrics command.
+/// Returns the metrics for the last V-App that exited.
+///
+/// Response format:
+/// - 32 bytes: V-App name (null-padded)
+/// - 32 bytes: V-App hash
+/// - 8 bytes: instruction count (big-endian)
+/// - 4 bytes: page loads (big-endian)
+/// - 4 bytes: page commits (big-endian)
+///
+/// Total: 80 bytes
+pub fn handler_get_metrics(
+    _command: ledger_device_sdk::io::Command<COMM_BUFFER_SIZE>,
+) -> Result<Vec<u8>, AppSW> {
+    let metrics = get_last_metrics();
+
+    if !metrics.is_valid() {
+        // No V-App has run yet, return error
+        return Err(AppSW::IncorrectData);
+    }
+
+    let mut response = Vec::with_capacity(80);
+
+    // V-App name (32 bytes)
+    response.extend_from_slice(&metrics.vapp_name);
+
+    // V-App hash (32 bytes)
+    response.extend_from_slice(&metrics.vapp_hash);
+
+    // Instruction count (8 bytes, big-endian)
+    response.extend_from_slice(&metrics.instruction_count.to_be_bytes());
+
+    // Page loads (4 bytes, big-endian)
+    response.extend_from_slice(&metrics.page_loads.to_be_bytes());
+
+    // Page commits (4 bytes, big-endian)
+    response.extend_from_slice(&metrics.page_commits.to_be_bytes());
+
+    Ok(response)
+}

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -1440,7 +1440,7 @@ impl<'a, const N: usize> CommEcallHandler<'a, N> {
 
         let mut msg_local = vec![0; 128];
         cpu.get_segment::<E>(msg.0)?
-            .read_buffer(msg.0, &mut msg_local)?;
+            .read_buffer(msg.0, &mut msg_local[..msg_len])?;
 
         // Schnorr signatures are at most 64 bytes long.
         let mut signature_local: [u8; 64] = [0; 64];

--- a/vm/src/handlers/mod.rs
+++ b/vm/src/handlers/mod.rs
@@ -1,4 +1,6 @@
 pub mod get_app_info;
+#[cfg(feature = "metrics")]
+pub mod get_metrics;
 pub mod register_vapp;
 pub mod start_vapp;
 


### PR DESCRIPTION
Added the 'metrics' feature to the Vanadium app client, and a corresponding get_metrics command to the Vanadium app, to return the collected metrics during the app's execution.

Improved the benchmarks test suite to make it easier to add new testcases, by autodiscovering them from the `/cases` folder.

Added the `--list` command to list existing testcases.

Added the 'metrics' feature to the benchmark test suite, to collect and log to file each testcase's execution metrics after execution.
Added CI job to run benchmarks on speculos with the 'metrics' feature on Vanadium, and upload the collected metrics as an artifact.

Added new benchmarks:
- Allocations of small and large vectors
- ECDSA and Schnorr signatures (using corresponding ECALLs)