### PR TITLE
HMAC-based code authentication

### DIFF
--- a/apps/bitcoin/client/src/main.rs
+++ b/apps/bitcoin/client/src/main.rs
@@ -380,7 +380,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
     let mut bitcoin_client = BitcoinClient::new(
-        create_default_client("vnd-bitcoin", client_type, Some(print_writer)).await?,
+        create_default_client("vnd-bitcoin", client_type, Some(print_writer), true).await?,
     );
 
     let mut rl = Editor::<CommandCompleter, rustyline::history::DefaultHistory>::new()?;

--- a/apps/rps/client/src/main.rs
+++ b/apps/rps/client/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ClientType::Any
     };
     let mut demo_client =
-        RPSClient::new(create_default_client("vnd-rps", client_type, None).await?);
+        RPSClient::new(create_default_client("vnd-rps", client_type, None, false).await?);
 
     println!("Playing as Alice");
 

--- a/apps/test/client/src/main.rs
+++ b/apps/test/client/src/main.rs
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
     let mut test_client =
-        TestClient::new(create_default_client("vnd-test", client_type, Some(print_writer)).await?);
+        TestClient::new(create_default_client("vnd-test", client_type, Some(print_writer), false).await?);
 
     loop {
         println!("Enter a command:");

--- a/client-sdk/src/apdu.rs
+++ b/client-sdk/src/apdu.rs
@@ -115,6 +115,16 @@ pub fn apdu_register_vapp(serialized_manifest: Vec<u8>) -> APDUCommand {
     }
 }
 
+pub fn apdu_preload_vapp(serialized_manifest: Vec<u8>) -> APDUCommand {
+    APDUCommand {
+        cla: 0xE0,
+        ins: 4,
+        p1: 0,
+        p2: 0,
+        data: serialized_manifest,
+    }
+}
+
 pub fn apdu_run_vapp(serialized_manifest: Vec<u8>) -> APDUCommand {
     APDUCommand {
         cla: 0xE0,

--- a/client-sdk/src/hmac_auth.rs
+++ b/client-sdk/src/hmac_auth.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+
+use common::manifest::Manifest;
+
+/// Magic bytes for the HMAC cache file format.
+const HMAC_FILE_MAGIC: &[u8; 10] = b"VAPP_HMAC\0";
+
+/// Computes the V-App hash from a manifest.
+pub fn compute_vapp_hash(manifest: &Manifest) -> [u8; 32] {
+    use crate::hash::Sha256;
+    manifest.get_vapp_hash::<Sha256, 32>()
+}
+
+/// Returns the `.hmac` file path corresponding to an ELF path.
+pub fn hmac_file_path(elf_path: &str) -> PathBuf {
+    let p = Path::new(elf_path);
+    p.with_extension("hmac")
+}
+
+/// Wraps the content of an HMAC cache file: the per-page HMACs for a V-App's code section.
+#[derive(Debug, Clone)]
+pub struct CodeHmacs {
+    hmacs: Vec<[u8; 32]>,
+}
+
+#[derive(Debug)]
+pub enum CodeHmacsLoadError {
+    Io(std::io::Error),
+    FileTooShort,
+    InvalidMagic,
+    VappHashMismatch,
+    AppIdMismatch,
+    InvalidHmacLength,
+}
+
+impl std::fmt::Display for CodeHmacsLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "I/O error while loading HMAC cache: {err}"),
+            Self::FileTooShort => write!(f, "Invalid HMAC cache format: file too short"),
+            Self::InvalidMagic => write!(f, "Invalid HMAC cache format: wrong magic bytes"),
+            Self::VappHashMismatch => write!(f, "HMAC cache does not match V-App hash"),
+            Self::AppIdMismatch => write!(f, "HMAC cache does not match Vanadium app ID"),
+            Self::InvalidHmacLength => {
+                write!(
+                    f,
+                    "Invalid HMAC cache format: trailing bytes are not 32-byte aligned"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CodeHmacsLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl CodeHmacs {
+    /// Creates a new `CodeHmacs` from a vector of per-page HMACs.
+    pub fn new(hmacs: Vec<[u8; 32]>) -> Self {
+        Self { hmacs }
+    }
+
+    /// Returns a reference to the inner HMAC vector.
+    pub fn as_slice(&self) -> &[[u8; 32]] {
+        &self.hmacs
+    }
+
+    /// Consumes `self` and returns the inner HMAC vector.
+    pub fn into_inner(self) -> Vec<[u8; 32]> {
+        self.hmacs
+    }
+
+    /// Loads HMACs from a cache file, validating the magic, `vapp_hash` and `vanadium_app_id`.
+    ///
+    /// Returns an error if the file can't be read, has wrong format, or has mismatched identifiers.
+    pub fn load(
+        path: &Path,
+        expected_vapp_hash: &[u8; 32],
+        expected_app_id: &[u8; 32],
+    ) -> Result<Self, CodeHmacsLoadError> {
+        let data = std::fs::read(path).map_err(CodeHmacsLoadError::Io)?;
+
+        // Header: 10 (magic) + 32 (vapp_hash) + 32 (app_id) = 74 bytes minimum
+        if data.len() < 74 {
+            return Err(CodeHmacsLoadError::FileTooShort);
+        }
+
+        // Check magic
+        if &data[0..10] != HMAC_FILE_MAGIC.as_slice() {
+            return Err(CodeHmacsLoadError::InvalidMagic);
+        }
+
+        // Check vapp_hash
+        if &data[10..42] != expected_vapp_hash {
+            return Err(CodeHmacsLoadError::VappHashMismatch);
+        }
+
+        // Check vanadium_app_id
+        if &data[42..74] != expected_app_id {
+            return Err(CodeHmacsLoadError::AppIdMismatch);
+        }
+
+        // Remaining bytes must be a multiple of 32
+        let hmac_bytes = &data[74..];
+        if hmac_bytes.len() % 32 != 0 {
+            return Err(CodeHmacsLoadError::InvalidHmacLength);
+        }
+
+        let n = hmac_bytes.len() / 32;
+        let mut hmacs = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut hmac = [0u8; 32];
+            hmac.copy_from_slice(&hmac_bytes[i * 32..(i + 1) * 32]);
+            hmacs.push(hmac);
+        }
+
+        Ok(Self { hmacs })
+    }
+
+    /// Saves HMACs to a cache file with format:
+    ///
+    /// `"VAPP_HMAC\0"` (10 bytes) || `vapp_hash` (32 bytes) || `vanadium_app_id` (32 bytes) || N × 32 bytes of HMACs.
+    pub fn save(
+        &self,
+        path: &Path,
+        vapp_hash: &[u8; 32],
+        vanadium_app_id: &[u8; 32],
+    ) -> std::io::Result<()> {
+        use std::io::Write;
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(HMAC_FILE_MAGIC)?;
+        file.write_all(vapp_hash)?;
+        file.write_all(vanadium_app_id)?;
+        for hmac in &self.hmacs {
+            file.write_all(hmac)?;
+        }
+        Ok(())
+    }
+}

--- a/client-sdk/src/lib.rs
+++ b/client-sdk/src/lib.rs
@@ -9,6 +9,8 @@ mod apdu;
 #[cfg(feature = "transport")]
 pub mod comm;
 #[cfg(feature = "transport")]
+pub mod hmac_auth;
+#[cfg(feature = "transport")]
 pub mod linewriter;
 #[cfg(feature = "transport")]
 pub mod transport;

--- a/client-sdk/src/memory.rs
+++ b/client-sdk/src/memory.rs
@@ -103,6 +103,16 @@ impl MemorySegment {
             pages.push(serialized_page);
         }
 
+        // ensure that the number of pages is a power of two, which is required for the MerkleAccumulator
+        // we pad with empty pages, which are valid pages with all-zero content.
+        let target_len = pages
+            .len()
+            .checked_next_power_of_two()
+            .expect("Too many pages");
+        while pages.len() < target_len {
+            pages.push(get_serialized_page(&[0; PAGE_SIZE], None));
+        }
+
         Self {
             content: MerkleAccumulator::<Sha256, Vec<u8>, 32>::new(pages),
         }

--- a/client-sdk/src/test_utils.rs
+++ b/client-sdk/src/test_utils.rs
@@ -209,12 +209,13 @@ where
 
     TestSetup::new(vanadium_binary, |transport| async move {
         let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
-        let vanadium_client = VanadiumAppClient::with_vapp(vapp_binary, transport, print_writer)
-            .await
-            .expect(&format!(
-                "Failed to create client for vapp binary: {}",
-                vapp_binary
-            ));
+        let vanadium_client =
+            VanadiumAppClient::with_vapp(vapp_binary, transport, print_writer, false)
+                .await
+                .expect(&format!(
+                    "Failed to create client for vapp binary: {}",
+                    vapp_binary
+                ));
 
         create_client(Box::new(vanadium_client))
     })

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -224,7 +224,8 @@ impl<E: std::fmt::Debug + Send + Sync + 'static> VAppEngine<E> {
             }
             ClientCommandCode::SendBufferContinued
             | ClientCommandCode::GetPageProofContinued
-            | ClientCommandCode::CommitPageProofContinued => {
+            | ClientCommandCode::CommitPageProofContinued
+            | ClientCommandCode::GetCodePageHashes => {
                 return Err(VAppEngineError::ResponseError("Unexpected command"));
             }
         };

--- a/common/src/client_commands.rs
+++ b/common/src/client_commands.rs
@@ -861,6 +861,11 @@ impl<'a> Message<'a> for GetCodePageHashesResponse<'a> {
             return Err(MessageDeserializationError::InvalidDataLength);
         }
         let slice_len = hashes_len / 32;
+
+        if slice_len != n_code_pages as usize {
+            return Err(MessageDeserializationError::InvalidDataLength);
+        }
+
         let code_page_hashes = unsafe {
             let ptr = data.as_ptr().add(4) as *const [u8; 32];
             core::slice::from_raw_parts(ptr, slice_len)

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -170,7 +170,7 @@ async fn run_bench_case(
     let print_writer = Box::new(std::io::sink());
 
     vanadium_client
-        .start_vapp(&case.app_path(), Box::new(print_writer))
+        .start_vapp(&case.app_path(), Box::new(print_writer), false)
         .await?;
 
     let mut client = BenchClient::new(vanadium_client);

--- a/vm/.cargo/config.toml
+++ b/vm/.cargo/config.toml
@@ -8,7 +8,7 @@ target = "nanosplus"
 # The value of CUSTOM_IO_APDU_BUFFER_SIZE needs to be compatible with the MAX_APDU_DATA_SIZE
 # constant, taking into account the overhead for APDU headers
 LEDGER_SDK_EXTRA_DEFINES="CUSTOM_IO_APDU_BUFFER_SIZE=600"
-HEAP_SIZE = "nanox: 14336, nanosplus: 31744, flex: 25600, stax: 25600, apex_p: 25600"
+HEAP_SIZE = "nanox: 13824, nanosplus: 31232, flex: 25088, stax: 25088, apex_p: 25088"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -14,6 +14,7 @@ ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.
 
 zeroize = "1.8.1"
 hex-literal = "0.4.1"
+subtle = { version = "2.6.1", default-features = false }
 
 [profile.release]
 opt-level = 3

--- a/vm/build.rs
+++ b/vm/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let raw_heap_size = env::var("HEAP_SIZE").unwrap();
 
     // smallest heap size, tailored for Nano X
-    let base_heap_size = 14336usize;
+    let base_heap_size = 13824usize;
     // heap size for the current target
     let heap_size = parse_heap_size(&raw_heap_size, &target_os);
 

--- a/vm/src/auth.rs
+++ b/vm/src/auth.rs
@@ -80,3 +80,11 @@ impl VMAuthKey {
         result
     }
 }
+
+/// Returns a public identifier that uniquely identifies this instance of the Vanadium app.
+/// This is derived from the auth key, so it is stable across app restarts but changes if the app is reinstalled or upgraded.
+pub fn get_vanadium_app_id() -> [u8; 32] {
+    let tag = b"VND_APP_ID";
+    let auth_key = VMAuthKey::get();
+    auth_key.tagged_hash(tag, b"")
+}

--- a/vm/src/auth.rs
+++ b/vm/src/auth.rs
@@ -1,0 +1,82 @@
+/// This module manages Vanadium's auth_key. This is a 32-byte secret that is generated when the app is first launched,
+/// and is used for anything that needs a permanent bind to the identity of the instance of the app. Therefore, it
+/// doesn't persist if the Vanadium app is reinstalled or upgraded.
+use common::accumulator::Hasher;
+use ledger_device_sdk::NVMData;
+
+use crate::hash::Sha256Hasher;
+use crate::nvm::LazyStorage;
+
+// This key is initialized the first time the Vanadium app is launched.
+#[link_section = ".nvm_data"]
+static mut VM_AUTH_KEY: NVMData<LazyStorage<[u8; 32]>> = NVMData::new(LazyStorage::new());
+
+pub struct VMAuthKey;
+
+impl VMAuthKey {
+    /// Gets a mutable reference to the auth key storage.
+    #[inline(never)]
+    fn get_storage_mut() -> &'static mut LazyStorage<[u8; 32]> {
+        let data = &raw mut VM_AUTH_KEY;
+        unsafe { (*data).get_mut() }
+    }
+
+    /// Gets a reference to the auth key storage.
+    #[inline(never)]
+    fn get_storage_ref() -> &'static LazyStorage<[u8; 32]> {
+        let data = &raw const VM_AUTH_KEY;
+        unsafe { (*data).get_ref() }
+    }
+
+    /// Ensures the auth key is initialized. If uninitialized, generates a new secure 32-byte random key.
+    fn ensure_initialized() {
+        let storage = Self::get_storage_mut();
+        if !storage.is_initialized() {
+            let mut key = [0u8; 32];
+            unsafe {
+                let result = ledger_device_sdk::sys::cx_get_random_bytes(
+                    key.as_mut_ptr() as *mut core::ffi::c_void,
+                    key.len(),
+                );
+                assert!(
+                    result == ledger_device_sdk::sys::CX_OK,
+                    "Failed to generate random bytes"
+                );
+            }
+            storage.initialize(&key);
+        }
+    }
+
+    /// Creates a new `VMAuthKey` instance, ensuring the auth key is initialized.
+    ///
+    /// On first call, generates a secure 32-byte random key if not already initialized.
+    pub fn get() -> Self {
+        Self::ensure_initialized();
+        VMAuthKey
+    }
+
+    /// Computes a tagged hash: `SHA256(SHA256(tag) || auth_key || buffer)`.
+    ///
+    /// This produces a deterministic, domain-separated hash that commits to auth_key.
+    /// It can also be used as a subkey.
+    pub fn tagged_hash(&self, tag: &[u8], buffer: &[u8]) -> [u8; 32] {
+        let storage = Self::get_storage_ref();
+        let auth_key = storage.get_ref(); // panics if not initialized, but initialization is ensured in get()
+
+        // Compute SHA256(tag)
+        let mut tag_hash = [0u8; 32];
+        let mut hasher = Sha256Hasher::new();
+        hasher.update(tag);
+        hasher.digest(&mut tag_hash);
+
+        // Compute SHA256(SHA256(tag) || auth_key || buffer)
+        let mut result = [0u8; 32];
+        let mut hasher = Sha256Hasher::new();
+        hasher.update(&tag_hash);
+        hasher.update(auth_key);
+        hasher.update(buffer);
+        hasher.digest(&mut result);
+
+        result
+    }
+}

--- a/vm/src/handlers/get_app_info.rs
+++ b/vm/src/handlers/get_app_info.rs
@@ -24,6 +24,10 @@ pub fn handler_get_app_info(
     response.push(device_model.len() as u8);
     response.extend_from_slice(device_model);
 
+    // Vanadium app ID
+    response.push(32u8);
+    response.extend_from_slice(&crate::auth::get_vanadium_app_id());
+
     Ok(response)
 }
 

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -20,9 +20,9 @@ use ledger_device_sdk::sys::{
 };
 use ledger_device_sdk::{hash::HashInit, io::DecodedEventType};
 
-use crate::io::{interrupt, InterruptError};
+use crate::io::{interrupt, InterruptError, SerializeToComm};
 
-use super::{outsourced_mem::OutsourcedMemory, SerializeToComm};
+use super::outsourced_mem::OutsourcedMemory;
 
 use zeroize::Zeroizing;
 

--- a/vm/src/handlers/lib/ecall.rs
+++ b/vm/src/handlers/lib/ecall.rs
@@ -20,7 +20,7 @@ use ledger_device_sdk::sys::{
 };
 use ledger_device_sdk::{hash::HashInit, io::DecodedEventType};
 
-use crate::io::interrupt;
+use crate::io::{interrupt, InterruptError};
 
 use super::{outsourced_mem::OutsourcedMemory, SerializeToComm};
 
@@ -285,6 +285,7 @@ pub enum CommEcallError {
     InvalidResponse(&'static str),
     CpuError(String),
     MemoryError(MemoryError),
+    InterruptError(InterruptError),
     UnhandledEcall,
 }
 
@@ -307,6 +308,7 @@ impl core::fmt::Display for CommEcallError {
             }
             CommEcallError::CpuError(e) => write!(f, "Cpu error: {:?}", e),
             CommEcallError::MemoryError(e) => write!(f, "Memory error: {:?}", e),
+            CommEcallError::InterruptError(e) => write!(f, "Interrupt error: {}", e),
             CommEcallError::UnhandledEcall => write!(f, "Unhandled ecall"),
         }
     }
@@ -333,6 +335,12 @@ impl From<LedgerHashContextError> for CommEcallError {
 impl From<MemoryError> for CommEcallError {
     fn from(error: MemoryError) -> Self {
         CommEcallError::MemoryError(error)
+    }
+}
+
+impl From<InterruptError> for CommEcallError {
+    fn from(error: InterruptError) -> Self {
+        CommEcallError::InterruptError(error)
     }
 }
 

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -202,7 +202,9 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
             page_hash_old,
             &new_page_hash,
             cached_page.idx as usize,
-            self.n_pages as usize,
+            (self.n_pages as usize)
+                .checked_next_power_of_two()
+                .expect("Too many pages"),
         );
 
         for el in proof_response.proof.iter() {
@@ -294,7 +296,9 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
             &self.merkle_root,
             &page_hash,
             page_index as usize,
-            self.n_pages as usize,
+            (self.n_pages as usize)
+                .checked_next_power_of_two()
+                .expect("Too many pages"),
         );
 
         for el in page_response.proof.iter() {
@@ -346,7 +350,9 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
 
             // validate decrypted size matches expected page size
             if decrypted_data.len() != PAGE_SIZE {
-                return Err(common::vm::MemoryError::GenericError("Decrypted page size mismatch"));
+                return Err(common::vm::MemoryError::GenericError(
+                    "Decrypted page size mismatch",
+                ));
             }
 
             // safe conversion since we just validated the length

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -173,7 +173,8 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
         )
         .serialize_to_comm(&mut resp);
 
-        let command = interrupt(resp)?;
+        let command =
+            interrupt(resp).map_err(|e| common::vm::MemoryError::GenericError(e.as_str()))?;
 
         // Decode the proof
         let proof_data = command.get_data();
@@ -217,7 +218,8 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
             let mut resp = comm.begin_response();
             CommitPageProofContinuedMessage::new().serialize_to_comm(&mut resp);
 
-            let command = interrupt(resp)?;
+            let command =
+                interrupt(resp).map_err(|e| common::vm::MemoryError::GenericError(e.as_str()))?;
 
             let continued_response = CommitPageProofContinuedResponse::deserialize(
                 &command.get_data(),
@@ -269,7 +271,8 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
         let mut resp = comm.begin_response();
         GetPageMessage::new(self.section_kind, page_index).serialize_to_comm(&mut resp);
 
-        let command = interrupt(resp)?;
+        let command =
+            interrupt(resp).map_err(|e| common::vm::MemoryError::GenericError(e.as_str()))?;
 
         let page_response = GetPageResponse::deserialize(command.get_data())
             .map_err(|_| common::vm::MemoryError::GenericError("Invalid page data"))?;
@@ -316,7 +319,8 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
             let mut resp = comm.begin_response();
             GetPageProofContinuedMessage::new().serialize_to_comm(&mut resp);
 
-            let command = interrupt(resp)?;
+            let command =
+                interrupt(resp).map_err(|e| common::vm::MemoryError::GenericError(e.as_str()))?;
 
             let continued_response =
                 GetPageProofContinuedResponse::deserialize(&command.get_data()).map_err(|_| {

--- a/vm/src/handlers/lib/outsourced_mem.rs
+++ b/vm/src/handlers/lib/outsourced_mem.rs
@@ -384,6 +384,17 @@ impl<'c, const N: usize> OutsourcedMemory<'c, N> {
                 }
             }
             PageProofKind::Hmac => {
+                if page_response.is_encrypted {
+                    return Err(common::vm::MemoryError::GenericError(
+                        "HMAC proof not allowed for encrypted pages",
+                    ));
+                }
+                if page_response.n != 1 || page_response.t != 1 {
+                    return Err(common::vm::MemoryError::GenericError(
+                        "HMAC proof must contain exactly one element",
+                    ));
+                }
+
                 // Expect exactly one 32-byte element
                 if page_response.proof.len() != 1 {
                     return Err(common::vm::MemoryError::GenericError(

--- a/vm/src/handlers/mod.rs
+++ b/vm/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod get_app_info;
 #[cfg(feature = "metrics")]
 pub mod get_metrics;
+pub mod preload_vapp;
 pub mod register_vapp;
 pub mod start_vapp;
 

--- a/vm/src/handlers/preload_vapp.rs
+++ b/vm/src/handlers/preload_vapp.rs
@@ -1,0 +1,134 @@
+use crate::{
+    auth::VMAuthKey,
+    handlers::lib::outsourced_mem::OutsourcedMemory,
+    hash::Sha256Hasher,
+    io::{interrupt, SerializeToComm},
+    AppSW, COMM_BUFFER_SIZE,
+};
+use alloc::vec::Vec;
+use common::{
+    accumulator::{HashOutput, Hasher, MerkleAccumulatorRootComputer, ResettableHasher},
+    client_commands::{GetCodePageHashes, GetCodePageHashesResponse, Message},
+    manifest::Manifest,
+};
+use ledger_device_sdk::{
+    hmac::{sha2::Sha2_256 as HmacSha256, HMACInit},
+    sys,
+};
+
+pub fn handler_preload_vapp(
+    command: ledger_device_sdk::io::Command<COMM_BUFFER_SIZE>,
+) -> Result<Vec<u8>, AppSW> {
+    let data_raw = command.get_data();
+
+    let (manifest, rest) =
+        postcard::take_from_bytes::<Manifest>(data_raw).map_err(|_| AppSW::IncorrectData)?;
+
+    if rest.len() != 0 {
+        return Err(AppSW::IncorrectData); // extra data
+    }
+
+    manifest.validate().map_err(|_| AppSW::IncorrectData)?; // ensure manifest is valid
+
+    // Implements the logic to preload the V-App's code, by receiving all the page hashes from the client, and
+    // sending back the encrypted HMACs; finally, after validating the Merkle root, send the decryption key.
+    // See the documentation in docs/security.md for more details.
+
+    let mut ephemeral_sk = [0u8; 32];
+    unsafe {
+        sys::cx_rng_no_throw(ephemeral_sk.as_mut_ptr(), ephemeral_sk.len());
+    }
+
+    let vapp_hash = manifest.get_vapp_hash::<Sha256Hasher, 32>();
+
+    let auth_key = VMAuthKey::get();
+    let app_auth_key = auth_key.tagged_hash(b"VND_APP_AUTH_KEY", &vapp_hash);
+
+    let mut resp = command.into_response();
+    GetCodePageHashes::new(0, &[]).serialize_to_comm(&mut resp);
+    let mut command = interrupt(resp).map_err(|_| AppSW::IncorrectData)?;
+
+    let n_code_pages_rounded = OutsourcedMemory::<'_, COMM_BUFFER_SIZE>::n_pages_adjusted(
+        manifest.n_code_pages() as usize,
+    );
+
+    let mut n_page_hashes_received = 0usize;
+
+    let mut root_computer =
+        MerkleAccumulatorRootComputer::<32, Sha256Hasher>::new(n_code_pages_rounded);
+
+    let mut hasher = Sha256Hasher::new();
+
+    let mut response_data = [[0u8; 32]; GetCodePageHashesResponse::max_hashes()];
+
+    // the host will send page hashes in batches; for each batch, we respond with encrypted HMACs
+    loop {
+        let data = command.get_data();
+        let batch =
+            GetCodePageHashesResponse::deserialize(data).map_err(|_| AppSW::IncorrectData)?;
+
+        let n_pages_in_batch = batch.n_code_pages;
+        if n_pages_in_batch == 0 {
+            // the client didn't send any page hash, which should only happen once all have been sent
+            break;
+        }
+
+        if n_page_hashes_received + (batch.n_code_pages as usize) > n_code_pages_rounded {
+            return Err(AppSW::IncorrectData); // received too many page hashes
+        }
+
+        for (i_batch, page_hash_i) in batch.code_page_hashes.into_iter().enumerate() {
+            let i = n_page_hashes_received as u32;
+            // Compute page_sk_i = SHA256("VND_HMAC_MASK" ‖ ephemeral_sk ‖ be32(i))
+            hasher.reset();
+            hasher.update(b"VND_HMAC_MASK");
+            hasher.update(&ephemeral_sk);
+            hasher.update(&i.to_be_bytes());
+            let page_sk_i = hasher.finalize_inplace();
+
+            // Compute hmac_i = HMAC-SHA256(key = app_auth_key, msg = "VND_PAGE_TAG" ‖ vapp_hash ‖ be32(i) ‖ page_hash_i)
+            let mut mac = HmacSha256::new(&app_auth_key);
+            mac.update(b"VND_PAGE_TAG")
+                .map_err(|_| AppSW::IncorrectData)?;
+            mac.update(&vapp_hash).map_err(|_| AppSW::IncorrectData)?;
+            mac.update(&i.to_be_bytes())
+                .map_err(|_| AppSW::IncorrectData)?;
+            mac.update(page_hash_i).map_err(|_| AppSW::IncorrectData)?;
+            let mut hmac = [0u8; 32];
+            mac.finalize(&mut hmac).map_err(|_| AppSW::IncorrectData)?;
+
+            // Compute encrypted_hmac_i = hmac_i ⊕ page_sk_i
+            let mut encrypted_hmac_i = [0u8; 32];
+            for j in 0..32 {
+                encrypted_hmac_i[j] = hmac[j] ^ page_sk_i[j];
+            }
+
+            response_data[i_batch] = encrypted_hmac_i;
+
+            // Feed the page hash into the Merkle root computer
+            root_computer.feed(&HashOutput(*page_hash_i));
+
+            n_page_hashes_received += 1;
+        }
+
+        let mut resp = command.into_response();
+        // Send encrypted HMACs, and request the next batch
+        GetCodePageHashes::new(
+            n_page_hashes_received as u32,
+            &response_data[0..(n_pages_in_batch as usize)],
+        )
+        .serialize_to_comm(&mut resp);
+        command = interrupt(resp).map_err(|_| AppSW::IncorrectData)?;
+    }
+
+    if n_page_hashes_received != n_code_pages_rounded {
+        return Err(AppSW::IncorrectData); // received incorrect number of pages
+    }
+
+    let computed_root = root_computer.root();
+    if computed_root.0 != manifest.code_merkle_root {
+        return Err(AppSW::IncorrectData); // Merkle root mismatch
+    }
+
+    Ok(ephemeral_sk.to_vec())
+}

--- a/vm/src/handlers/preload_vapp.rs
+++ b/vm/src/handlers/preload_vapp.rs
@@ -11,7 +11,7 @@ use common::{
     client_commands::{GetCodePageHashes, GetCodePageHashesResponse, Message},
     manifest::Manifest,
 };
-use ledger_device_sdk::sys;
+use ledger_device_sdk::{nbgl::NbglSpinner, sys};
 
 pub fn handler_preload_vapp(
     command: ledger_device_sdk::io::Command<COMM_BUFFER_SIZE>,
@@ -43,6 +43,8 @@ pub fn handler_preload_vapp(
     let mut resp = command.into_response();
     GetCodePageHashes::new(0, &[]).serialize_to_comm(&mut resp);
     let mut command = interrupt(resp).map_err(|_| AppSW::IncorrectData)?;
+
+    NbglSpinner::new().show("Preloading V-App...");
 
     let n_code_pages_rounded = OutsourcedMemory::<'_, COMM_BUFFER_SIZE>::n_pages_adjusted(
         manifest.n_code_pages() as usize,

--- a/vm/src/handlers/start_vapp.rs
+++ b/vm/src/handlers/start_vapp.rs
@@ -93,6 +93,7 @@ pub fn handler_start_vapp(
             n_code_cache_pages / 4,
             n_code_cache_pages / 2,
         )),
+        &vapp_hash,
     );
     let code_seg = MemorySegment::<OutsourcedMemory<'_, COMM_BUFFER_SIZE>>::new(
         manifest.code_start,
@@ -110,6 +111,7 @@ pub fn handler_start_vapp(
         manifest.data_merkle_root.into(),
         aes_ctr.clone(),
         Box::new(LruEvictionStrategy::new(n_data_cache_pages)),
+        &vapp_hash,
     );
     let data_seg = MemorySegment::<OutsourcedMemory<'_, COMM_BUFFER_SIZE>>::new(
         manifest.data_start,
@@ -127,6 +129,7 @@ pub fn handler_start_vapp(
         manifest.stack_merkle_root.into(),
         aes_ctr.clone(),
         Box::new(LruEvictionStrategy::new(n_stack_cache_pages)),
+        &vapp_hash,
     );
     let stack_seg = MemorySegment::<OutsourcedMemory<'_, COMM_BUFFER_SIZE>>::new(
         manifest.stack_start,

--- a/vm/src/io.rs
+++ b/vm/src/io.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use common::client_commands::Message;
 use ledger_device_sdk::io;
 
 use crate::{AppSW, Instruction};
@@ -53,4 +54,16 @@ pub fn interrupt<'a, const N: usize>(
     }
 
     Ok(command)
+}
+
+pub trait SerializeToComm<const N: usize> {
+    fn serialize_to_comm(&self, response: &mut ledger_device_sdk::io::CommandResponse<'_, N>);
+}
+
+impl<'a, T: Message<'a>, const N: usize> SerializeToComm<N> for T {
+    fn serialize_to_comm(&self, response: &mut ledger_device_sdk::io::CommandResponse<'_, N>) {
+        self.serialize_with(|data| {
+            response.append(data).unwrap();
+        });
+    }
 }

--- a/vm/src/io.rs
+++ b/vm/src/io.rs
@@ -1,24 +1,55 @@
+use core::fmt;
+
 use ledger_device_sdk::io;
 
 use crate::{AppSW, Instruction};
 
+/// Error returned by the [`interrupt`] function when the host does not
+/// respond with the expected `Continue` command.
+#[derive(Debug)]
+pub enum InterruptError {
+    /// The APDU response could not be decoded.
+    InvalidResponse,
+    /// The received instruction was not `Continue`.
+    UnsupportedInstruction,
+    /// P1/P2 parameters were not the expected values.
+    WrongParameters,
+}
+
+impl InterruptError {
+    /// Returns a static string description of the error.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            InterruptError::InvalidResponse => "Invalid response",
+            InterruptError::UnsupportedInstruction => "INS not supported",
+            InterruptError::WrongParameters => "Wrong P1/P2",
+        }
+    }
+}
+
+impl fmt::Display for InterruptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 // Helper function to send the InterruptedExecution response, and make sure the next command is 'Continue'
 pub fn interrupt<'a, const N: usize>(
     response: io::CommandResponse<'a, N>,
-) -> Result<io::Command<'a, N>, common::vm::MemoryError> {
+) -> Result<io::Command<'a, N>, InterruptError> {
     let comm = response.send(AppSW::InterruptedExecution).unwrap();
     let command = comm.next_command();
 
     let ins = command
         .decode::<Instruction>()
-        .map_err(|_: io::Reply| common::vm::MemoryError::GenericError("Invalid response"))?;
+        .map_err(|_: io::Reply| InterruptError::InvalidResponse)?;
 
     let Instruction::Continue(p1, p2) = ins else {
         // expected "Continue"
-        return Err(common::vm::MemoryError::GenericError("INS not supported"));
+        return Err(InterruptError::UnsupportedInstruction);
     };
     if (p1, p2) != (0, 0) {
-        return Err(common::vm::MemoryError::GenericError("Wrong P1/P2"));
+        return Err(InterruptError::WrongParameters);
     }
 
     Ok(command)

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -20,6 +20,7 @@
 
 mod aes;
 mod app_ui;
+mod auth;
 mod handlers;
 mod hash;
 mod io;
@@ -211,6 +212,9 @@ impl TryFrom<ApduHeader> for Instruction {
 #[cfg(not(feature = "run_tests"))]
 #[no_mangle]
 extern "C" fn sample_main() {
+    // initialize the auth_key, if not already initialized
+    let _ = crate::auth::VMAuthKey::get();
+
     // Create the communication manager, and configure it to accept only APDU from the 0xe0 class.
     // If any APDU with a wrong class value is received, comm will respond automatically with
     // BadCla status word.


### PR DESCRIPTION
Adds a second mode for authentication of the code pages of V-Apps, based on getting an HMAC for each page hash. As an HMAC is always just 32-bytes, this greatly reduces the bandwidth, especially for larger V-Apps.

In order to avoid for a malicious client to obtain HMACs for invalid pages, it is necessary to send all the page hashes, and validating the corresponding Merkle root against the code Merkle root. A protocol to make sure that the client only receives the HMACs if the correct page hashes were sent is implemented via the `preload_vapp` command of the Vanadium app.

On a successful V-App preload flow, the client stores all the HMACs into an `.hmac` file in the same folder of the V-App's ELF file. This allows to perform the computation of HMACs only once, before running the V-App.

V-Apps can still choose the Merkle-tree based validation, which is reasonable for smaller binaries. In this PR, only the bitcoin V-App is moved to using the HMAC-based authentication.

Future generalizations might allow combining the Merkle tree-based flow with the HMAC-based flow: the client could use any idle time while the V-App is not doing anything to send code pages and obtain the HMAC. Therefore, an app would start with the app normally with the Merkle-tree-based flow, and have a background task to perform the app preloading protocol. Once completed, it would seamlessly switch to the HMAC-based protocol.


Replaces: #184
