### PR TITLE
Add ECALL_MODINV_PRIME

### DIFF
--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -201,6 +201,19 @@ forward_to_ecall! {
         len: usize,
     ) -> u32;
 
+    /// Computes the modular inverse of `a` modulo `p`, storing the result in `r`.
+    /// The modulus `p` must be a prime number. The result is undefined if `p` is not prime.
+    ///
+    /// # Parameters
+    /// - `r`: Pointer to the result buffer.
+    /// - `a`: Pointer to the value to invert.
+    /// - `p`: Pointer to the prime modulus buffer.
+    /// - `len`: Length of `r`, `a`, and `p`.
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
+    pub fn bn_modinv_prime(r: *mut u8, a: *const u8, p: *const u8, len: usize) -> u32;
+
     /// Derives a hierarchical deterministic (HD) node, made of the private key and the corresponding chain code.
     ///
     /// # Parameters

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -35,6 +35,7 @@ delegate_ecall!(bn_addm, u32, (r: *mut u8), (a: *const u8), (b: *const u8), (m: 
 delegate_ecall!(bn_subm, u32, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize));
 delegate_ecall!(bn_multm, u32, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize));
 delegate_ecall!(bn_powm, u32, (r: *mut u8), (a: *const u8), (e: *const u8), (len_e: usize), (m: *const u8), (len: usize));
+delegate_ecall!(bn_modinv_prime, u32, (r: *mut u8), (a: *const u8), (p: *const u8), (len: usize));
 
 delegate_ecall!(derive_hd_node, u32, (curve: u32), (path: *const u32), (path_len: usize), (privkey: *mut u8), (chain_code: *mut u8));
 delegate_ecall!(get_master_fingerprint, u32, (curve: u32));

--- a/apps/sadik/client/src/client.rs
+++ b/apps/sadik/client/src/client.rs
@@ -85,6 +85,20 @@ impl SadikClient {
             .expect("Error sending message"))
     }
 
+    pub async fn bignum_modinv(&mut self, a: &[u8]) -> Result<Vec<u8>, SadikClientError> {
+        let cmd = Command::BigIntOperation {
+            operator: BigIntOperator::Inv,
+            a: a.to_vec(),
+            b: Vec::new(),
+            modular: true,
+        };
+
+        let msg = postcard::to_allocvec(&cmd).expect("Serialization failed");
+        Ok(send_message(&mut self.vapp_transport, &msg)
+            .await
+            .expect("Error sending message"))
+    }
+
     pub async fn derive_hd_node(
         &mut self,
         curve: Curve,

--- a/apps/sadik/client/tests/integration_test.rs
+++ b/apps/sadik/client/tests/integration_test.rs
@@ -156,6 +156,34 @@ async fn test_big_num_mod() {
 }
 
 #[tokio::test]
+async fn test_big_num_mod_inv() {
+    let mut setup = setup().await;
+
+    // all operations are modulo 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+    // (curve order of Secp256k1)
+
+    let one: Vec<u8> = hex!("0000000000000000000000000000000000000000000000000000000000000001").to_vec();
+
+    // inv(1) == 1
+    assert_eq!(
+        setup.client.bignum_modinv(&one).await.unwrap(),
+        one
+    );
+
+    // a * inv(a) == 1 (for a small value)
+    let a = hex!("0000000000000000000000000000000000000000000000000000000000000007");
+    let a_inv = setup.client.bignum_modinv(&a).await.unwrap();
+    let product = setup.client.bignum_operation(BigIntOperator::Mul, &a, &a_inv, true).await.unwrap();
+    assert_eq!(product, one);
+
+    // a * inv(a) == 1 (for a larger value)
+    let b = hex!("a247598432980432940980983408039480095809832048509809580984320985");
+    let b_inv = setup.client.bignum_modinv(&b).await.unwrap();
+    let product = setup.client.bignum_operation(BigIntOperator::Mul, &b, &b_inv, true).await.unwrap();
+    assert_eq!(product, one);
+}
+
+#[tokio::test]
 async fn test_ripemd160() {
     let mut setup = setup().await;
 

--- a/apps/sadik/common/src/lib.rs
+++ b/apps/sadik/common/src/lib.rs
@@ -12,6 +12,7 @@ pub enum BigIntOperator {
     Sub,
     Mul,
     Pow,
+    Inv,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -28,6 +28,7 @@ pub const ECALL_ADDM: u32 = 111;
 pub const ECALL_SUBM: u32 = 112;
 pub const ECALL_MULTM: u32 = 113;
 pub const ECALL_POWM: u32 = 114;
+pub const ECALL_MODINV_PRIME: u32 = 115;
 
 pub const MAX_BIGNUMBER_SIZE: usize = 64;
 

--- a/ecalls/src/ecalls_impl.rs
+++ b/ecalls/src/ecalls_impl.rs
@@ -350,6 +350,7 @@ ecall5!(bn_addm, ECALL_ADDM, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *
 ecall5!(bn_subm, ECALL_SUBM, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize), u32);
 ecall5!(bn_multm, ECALL_MULTM, (r: *mut u8), (a: *const u8), (b: *const u8), (m: *const u8), (len: usize), u32);
 ecall6!(bn_powm, ECALL_POWM, (r: *mut u8), (a: *const u8), (e: *const u8), (len_e: usize), (m: *const u8), (len: usize), u32);
+ecall4!(bn_modinv_prime, ECALL_MODINV_PRIME, (r: *mut u8), (a: *const u8), (p: *const u8), (len: usize), u32);
 
 ecall5!(derive_hd_node, ECALL_DERIVE_HD_NODE, (curve: u32), (path: *const u32), (path_len: usize), (privkey: *mut u8), (chain_code: *mut u8), u32);
 ecall1!(get_master_fingerprint, ECALL_GET_MASTER_FINGERPRINT, (curve: u32), u32);


### PR DESCRIPTION
This completes a reasonable support for all the modular bignum operations.

Modular inverse for arbitrari modulus is not currently implemented in Ledger OS, so we only limit support to prime moduli.