### PR TITLE
Implements hash ECALLs on `target_native`, and generalize ECALL interface

### DIFF
--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -405,12 +405,46 @@ forward_to_ecall! {
         signature: *const u8,
         signature_len: usize,
     ) -> u32;
-}
 
-#[cfg(feature = "target_vanadium_ledger")]
-forward_to_ecall! {
+    /// Initializes a hash context for the specified hash algorithm.
+    ///
+    /// # Parameters
+    /// - `hash_id`: The hash algorithm identifier (see [`common::ecall_constants::HashId`]).
+    /// - `ctx`: Pointer to the opaque context buffer to initialize. The buffer must be at
+    ///   least as large as the corresponding `CTX_*_SIZE` constant defined in
+    ///   [`common::ecall_constants`] for the given `hash_id`.
     pub fn hash_init(hash_id: u32, ctx: *mut u8);
+
+    /// Updates a hash context with additional input data.
+    ///
+    /// # Parameters
+    /// - `hash_id`: The hash algorithm identifier (see [`common::ecall_constants::HashId`]).
+    /// - `ctx`: Pointer to the opaque context buffer previously initialized by [`hash_init`].
+    ///   The buffer must be at least as large as the corresponding `CTX_*_SIZE` constant
+    ///   defined in [`common::ecall_constants`] for the given `hash_id`.
+    /// - `data`: Pointer to the input data buffer.
+    /// - `len`: Length of the input data.
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
     pub fn hash_update(hash_id: u32, ctx: *mut u8, data: *const u8, len: usize) -> u32;
+
+    /// Finalizes a hash computation and writes the digest to the output buffer.
+    ///
+    /// After calling this function the context is consumed and must not be reused
+    /// without a new call to [`hash_init`].
+    ///
+    /// # Parameters
+    /// - `hash_id`: The hash algorithm identifier (see [`common::ecall_constants::HashId`]).
+    /// - `ctx`: Pointer to the opaque context buffer previously initialized by [`hash_init`].
+    ///   The buffer must be at least as large as the corresponding `CTX_*_SIZE` constant
+    ///   defined in [`common::ecall_constants`] for the given `hash_id`.
+    /// - `digest`: Pointer to the output buffer where the digest will be written. The buffer
+    ///   must be large enough to hold the digest for the given `hash_id` (e.g. 32 bytes for
+    ///   SHA-256, 64 bytes for SHA-512, 20 bytes for RIPEMD-160).
+    ///
+    /// # Returns
+    /// 1 on success, 0 on error.
     pub fn hash_final(hash_id: u32, ctx: *mut u8, digest: *const u8) -> u32;
 }
 

--- a/app-sdk/src/ecalls.rs
+++ b/app-sdk/src/ecalls.rs
@@ -427,6 +427,11 @@ forward_to_ecall! {
     ///
     /// # Returns
     /// 1 on success, 0 on error.
+    ///
+    /// # Safety
+    /// The caller is responsible for ensuring that `ctx` was previously initialized via
+    /// [`hash_init`] with the same `hash_id`. Passing an uninitialized context or a
+    /// `hash_id` that differs from the one used during initialization is undefined behaviour.
     pub fn hash_update(hash_id: u32, ctx: *mut u8, data: *const u8, len: usize) -> u32;
 
     /// Finalizes a hash computation and writes the digest to the output buffer.
@@ -445,7 +450,12 @@ forward_to_ecall! {
     ///
     /// # Returns
     /// 1 on success, 0 on error.
-    pub fn hash_final(hash_id: u32, ctx: *mut u8, digest: *const u8) -> u32;
+    ///
+    /// # Safety
+    /// The caller is responsible for ensuring that `ctx` was previously initialized via
+    /// [`hash_init`] with the same `hash_id`. Passing an uninitialized context or a
+    /// `hash_id` that differs from the one used during initialization is undefined behaviour.
+    pub fn hash_final(hash_id: u32, ctx: *mut u8, digest: *mut u8) -> u32;
 }
 
 #[cfg(test)]

--- a/app-sdk/src/ecalls_riscv.rs
+++ b/app-sdk/src/ecalls_riscv.rs
@@ -54,4 +54,4 @@ delegate_ecall!(schnorr_verify, u32, (curve: u32), (mode: u32), (hash_id: u32), 
 // The following ecalls are specific to this target
 delegate_ecall!(hash_init, (hash_id: u32), (ctx: *mut u8));
 delegate_ecall!(hash_update, u32, (hash_id: u32), (ctx: *mut u8), (data: *const u8), (len: usize));
-delegate_ecall!(hash_final, u32, (hash_id: u32), (ctx: *mut u8), (digest: *const u8));
+delegate_ecall!(hash_final, u32, (hash_id: u32), (ctx: *mut u8), (digest: *mut u8));

--- a/app-sdk/src/hash.rs
+++ b/app-sdk/src/hash.rs
@@ -11,7 +11,7 @@ mod hashers {
     /// which can be different for each target.
     macro_rules! impl_hash {
         ($name:ident, $ctx_size:expr, $digest_size:expr) => {
-            #[derive(Clone, PartialEq, Eq, Debug)]
+            #[derive(Clone, Debug)]
             #[repr(C)]
             pub struct $name {
                 ctx: [u8; $ctx_size],
@@ -19,7 +19,7 @@ mod hashers {
 
             impl Hasher<$digest_size> for $name {
                 fn new() -> Self {
-                    let mut res = core::mem::MaybeUninit::<Self>::uninit();
+                    let mut res = core::mem::MaybeUninit::<Self>::zeroed();
 
                     unsafe {
                         ecalls::hash_init(HashId::$name as u32, res.as_mut_ptr() as *mut u8);

--- a/common/src/ecall_constants.rs
+++ b/common/src/ecall_constants.rs
@@ -69,6 +69,17 @@ pub const ECALL_HASH_INIT: u32 = 150;
 pub const ECALL_HASH_UPDATE: u32 = 151;
 pub const ECALL_HASH_DIGEST: u32 = 152;
 
+/// Size in bytes of the hash context structs used by the hash ecalls.
+///
+/// These are the sizes of the opaque context buffers passed to `hash_init`,
+/// `hash_update`, and `hash_final`. Each context must be at least this large.
+/// The sizes are at least 16 bytes larger than what the Ledger OS uses, in
+/// order to have some leeway for different targets where the struct might
+/// be larger.
+pub const CTX_SHA256_SIZE: usize = 128;
+pub const CTX_SHA512_SIZE: usize = 224;
+pub const CTX_RIPEMD160_SIZE: usize = 120;
+
 // Operations for public keys over elliptic curves
 pub const ECALL_ECFP_ADD_POINT: u32 = 160;
 pub const ECALL_ECFP_SCALAR_MULT: u32 = 161;

--- a/ecalls/src/ecalls_impl.rs
+++ b/ecalls/src/ecalls_impl.rs
@@ -369,4 +369,4 @@ ecall8!(schnorr_verify, ECALL_SCHNORR_VERIFY, (curve: u32), (mode: u32), (hash_i
 // The following ecalls are specific to this target
 ecall2v!(hash_init, ECALL_HASH_INIT, (hash_id: u32), (ctx: *mut u8));
 ecall4!(hash_update, ECALL_HASH_UPDATE, (hash_id: u32), (ctx: *mut u8), (data: *const u8), (len: usize), u32);
-ecall3!(hash_final, ECALL_HASH_DIGEST, (hash_id: u32), (ctx: *mut u8), (digest: *const u8), u32);
+ecall3!(hash_final, ECALL_HASH_DIGEST, (hash_id: u32), (ctx: *mut u8), (digest: *mut u8), u32);


### PR DESCRIPTION
Increased the size of the hash context, so that it is an opaque blob that different implementation can set to a different size, while keeping the ECALL interface unchanged.

Fixed the ABI of the `hash_final` ECALL, where the `digest` was incorrectly marked as `const`.