### PR TITLE
Support for riscv32imac

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: riscv32imc-unknown-none-elf
+          targets: riscv32imac-unknown-none-elf
           components: rustfmt, clippy
       - name: Cache cargo dirs
         uses: actions/cache@v4
@@ -102,7 +102,7 @@ jobs:
         working-directory: bench
         run: |
           for case_dir in ./cases/*; do
-            (cd "$case_dir" && cargo +stable build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger) || exit 1
+            (cd "$case_dir" && cargo +stable build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger) || exit 1
           done
       - name: Run Speculos with Vanadium binary
         run: |
@@ -318,7 +318,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Add RISC-V target
-        run: rustup target add riscv32imc-unknown-none-elf
+        run: rustup target add riscv32imac-unknown-none-elf
       - name: Install dependencies
         run: |
           sudo apt-get update && \
@@ -332,7 +332,7 @@ jobs:
         run: cargo vnd new --name testapp --template-path "$(pwd)/apps/template/generate"
       - name: Build the app for RISC-V target
         working-directory: testapp/app
-        run: cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+        run: cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
       - name: Build the client
         working-directory: testapp/client
         run: cargo build --release

--- a/.github/workflows/reusable_vapp_build.yaml
+++ b/.github/workflows/reusable_vapp_build.yaml
@@ -32,7 +32,7 @@ on:
       riscv_target:
         description: "RISC-V target triple"
         required: false
-        default: riscv32imc-unknown-none-elf
+        default: riscv32imac-unknown-none-elf
         type: string
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before you begin, ensure you have the following installed:
 
 1.  **Rust & Risc-V Target:**
     ```bash
-    rustup target add riscv32imc-unknown-none-elf
+    rustup target add riscv32imac-unknown-none-elf
     ```
 
 2.  **just** (Command runner):

--- a/app-sdk/.cargo/config.toml
+++ b/app-sdk/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/app-sdk/justfile
+++ b/app-sdk/justfile
@@ -2,7 +2,7 @@
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -10,5 +10,5 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/bitcoin/app/.cargo/config.toml
+++ b/apps/bitcoin/app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/bitcoin/app/justfile
+++ b/apps/bitcoin/app/justfile
@@ -4,7 +4,7 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -12,12 +12,12 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # disassembles the riscv binary
 disassemble:
-  riscv64-linux-gnu-objdump -d target/riscv32imc-unknown-none-elf/release/vnd-bitcoin
+  riscv64-linux-gnu-objdump -d target/riscv32imac-unknown-none-elf/release/vnd-bitcoin
 
 # show the sections of the riscv binary
 show-sections:
-  readelf -S target/riscv32imc-unknown-none-elf/release/vnd-bitcoin
+  readelf -S target/riscv32imac-unknown-none-elf/release/vnd-bitcoin

--- a/apps/bitcoin/benchmarks/cases/bip32_xpub_derive_child/.cargo/config.toml
+++ b/apps/bitcoin/benchmarks/cases/bip32_xpub_derive_child/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/bitcoin/benchmarks/cases/bip32_xpub_deserialize/.cargo/config.toml
+++ b/apps/bitcoin/benchmarks/cases/bip32_xpub_deserialize/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/bitcoin/benchmarks/cases/psbt_parse/.cargo/config.toml
+++ b/apps/bitcoin/benchmarks/cases/psbt_parse/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/bitcoin/benchmarks/justfile
+++ b/apps/bitcoin/benchmarks/justfile
@@ -4,5 +4,5 @@ run:
 # build all the testcases for riscv target (Ledger Vanadium)
 build-cases:
   for case_dir in ./cases/*; do\
-    (cd "$case_dir" && cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger)\
+    (cd "$case_dir" && cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger)\
   done

--- a/apps/bitcoin/client/tests/integration_test.rs
+++ b/apps/bitcoin/client/tests/integration_test.rs
@@ -11,7 +11,7 @@ pub async fn setup() -> TestSetup<BitcoinClient> {
     let vanadium_binary = std::env::var("VANADIUM_BINARY")
         .unwrap_or_else(|_| "../../../vm/target/flex/release/app-vanadium".to_string());
     let vapp_binary = std::env::var("VAPP_BINARY").unwrap_or_else(|_| {
-        "../app/target/riscv32imc-unknown-none-elf/release/vnd-bitcoin".to_string()
+        "../app/target/riscv32imac-unknown-none-elf/release/vnd-bitcoin".to_string()
     });
     setup_test(&vanadium_binary, &vapp_binary, |transport| {
         BitcoinClient::new(transport)

--- a/apps/rps/app/.cargo/config.toml
+++ b/apps/rps/app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/rps/app/justfile
+++ b/apps/rps/app/justfile
@@ -4,7 +4,7 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -12,5 +12,5 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/sadik/app/.cargo/config.toml
+++ b/apps/sadik/app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/sadik/app/justfile
+++ b/apps/sadik/app/justfile
@@ -4,7 +4,7 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -12,12 +12,12 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # disassembles the riscv binary
 disassemble:
-  riscv64-linux-gnu-objdump -d target/riscv32imc-unknown-none-elf/release/vnd-sadik
+  riscv64-linux-gnu-objdump -d target/riscv32imac-unknown-none-elf/release/vnd-sadik
 
 # show the sections of the riscv binary
 show-sections:
-  readelf -S target/riscv32imc-unknown-none-elf/release/vnd-sadik
+  readelf -S target/riscv32imac-unknown-none-elf/release/vnd-sadik

--- a/apps/sadik/client/tests/integration_test.rs
+++ b/apps/sadik/client/tests/integration_test.rs
@@ -11,7 +11,7 @@ pub async fn setup() -> TestSetup<SadikClient> {
     let vanadium_binary = std::env::var("VANADIUM_BINARY")
         .unwrap_or_else(|_| "../../../vm/target/flex/release/app-vanadium".to_string());
     let vapp_binary = std::env::var("VAPP_BINARY").unwrap_or_else(|_| {
-        "../app/target/riscv32imc-unknown-none-elf/release/vnd-sadik".to_string()
+        "../app/target/riscv32imac-unknown-none-elf/release/vnd-sadik".to_string()
     });
     setup_test(&vanadium_binary, &vapp_binary, |transport| {
         SadikClient::new(transport)

--- a/apps/template/app/.cargo/config.toml
+++ b/apps/template/app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/template/app/justfile
+++ b/apps/template/app/justfile
@@ -4,7 +4,7 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -12,5 +12,5 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/template/generate/app/.cargo/config.toml
+++ b/apps/template/generate/app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/template/generate/app/justfile
+++ b/apps/template/generate/app/justfile
@@ -4,7 +4,7 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -12,5 +12,5 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 

--- a/apps/test/app/.cargo/config.toml
+++ b/apps/test/app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/apps/test/app/justfile
+++ b/apps/test/app/justfile
@@ -4,7 +4,7 @@ run:
 # build for both native and riscv targets
 build:
   cargo build --release
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # build for native target
 build-native:
@@ -12,12 +12,12 @@ build-native:
 
 # build for riscv target (Ledger Vanadium)
 build-riscv:
-  cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 
 # disassembles the riscv binary
 disassemble:
-  riscv64-linux-gnu-objdump -d target/riscv32imc-unknown-none-elf/release/vnd-test
+  riscv64-linux-gnu-objdump -d target/riscv32imac-unknown-none-elf/release/vnd-test
 
 # show the sections of the riscv binary
 show-sections:
-  readelf -S target/riscv32imc-unknown-none-elf/release/vnd-test
+  readelf -S target/riscv32imac-unknown-none-elf/release/vnd-test

--- a/apps/test/client/tests/integration_test.rs
+++ b/apps/test/client/tests/integration_test.rs
@@ -10,7 +10,7 @@ pub async fn setup() -> TestSetup<TestClient> {
     let vanadium_binary = std::env::var("VANADIUM_BINARY")
         .unwrap_or_else(|_| "../../../vm/target/flex/release/app-vanadium".to_string());
     let vapp_binary = std::env::var("VAPP_BINARY").unwrap_or_else(|_| {
-        "../app/target/riscv32imc-unknown-none-elf/release/vnd-test".to_string()
+        "../app/target/riscv32imac-unknown-none-elf/release/vnd-test".to_string()
     });
     setup_test(&vanadium_binary, &vapp_binary, |transport| {
         TestClient::new(transport)

--- a/bench/cases/alloc_large/.cargo/config.toml
+++ b/bench/cases/alloc_large/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/alloc_small/.cargo/config.toml
+++ b/bench/cases/alloc_small/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/base58enc/.cargo/config.toml
+++ b/bench/cases/base58enc/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/bignum_mul/.cargo/config.toml
+++ b/bench/cases/bignum_mul/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/bignum_pow/.cargo/config.toml
+++ b/bench/cases/bignum_pow/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/ecdsa_sign/.cargo/config.toml
+++ b/bench/cases/ecdsa_sign/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/ecfp_add/.cargo/config.toml
+++ b/bench/cases/ecfp_add/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/ecfp_scalarmul/.cargo/config.toml
+++ b/bench/cases/ecfp_scalarmul/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/nprimes/.cargo/config.toml
+++ b/bench/cases/nprimes/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/schnorr_sign/.cargo/config.toml
+++ b/bench/cases/schnorr_sign/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/cases/sha256/.cargo/config.toml
+++ b/bench/cases/sha256/.cargo/config.toml
@@ -1,8 +1,8 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32imac-unknown-none-elf"
 
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32imac-unknown-none-elf]
 rustflags = [
   # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
   # read-only non-executable sections in their own segment.

--- a/bench/justfile
+++ b/bench/justfile
@@ -4,5 +4,5 @@ run:
 # build all the testcases for riscv target (Ledger Vanadium)
 build-cases:
   for case_dir in ./cases/*; do\
-    (cd "$case_dir" && cargo build --release --target=riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger)\
+    (cd "$case_dir" && cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger)\
   done

--- a/cargo-vnd/README.md
+++ b/cargo-vnd/README.md
@@ -36,8 +36,8 @@ These are the currently defined commands:
 **Example:**
 
 ```
-cargo build --release --target riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+cargo build --release --target riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 cargo vnd package
 ```
 
-This will create a file like `target/riscv32imc-unknown-none-elf/release/<appname>.vapp`.
+This will create a file like `target/riscv32imac-unknown-none-elf/release/<appname>.vapp`.

--- a/cargo-vnd/src/main.rs
+++ b/cargo-vnd/src/main.rs
@@ -80,11 +80,11 @@ fn main() -> Result<()> {
 
             let elf_path = match app {
                 Some(path) => path,
-                // if the app path is not provided, default to release binary for the riscv32imc target
+                // if the app path is not provided, default to release binary for the riscv32imac target
                 None => cargo_toml_path
                     .parent()
                     .unwrap()
-                    .join("target/riscv32imc-unknown-none-elf/release")
+                    .join("target/riscv32imac-unknown-none-elf/release")
                     .join(vapp_crate_name),
             };
             // if the output path is not provided, default to adding the .vapp extension to the elf

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -2083,7 +2083,7 @@ pub mod client_utils {
         use_hmacs: bool,
     ) -> Result<Box<dyn VAppTransport + Send>, ClientUtilsError> {
         let vapp_path = format!(
-            "../app/target/riscv32imc-unknown-none-elf/release/{}",
+            "../app/target/riscv32imac-unknown-none-elf/release/{}",
             vapp_name
         );
 

--- a/common/src/riscv/decode.rs
+++ b/common/src/riscv/decode.rs
@@ -360,6 +360,30 @@ fn decode_uncompressed(inst: u32) -> Op {
             0x02007033 => Op::Remu { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
             _ => Op::Unknown,
         },
+        // RV32A - Atomic instructions (opcode 0x2F, funct3 = 0b010 for .W)
+        0x0000002f => match inst & 0x0000707f {
+            0x0000202f => match inst & 0xf800707f {
+                0x1000202f => {
+                    if rs2(inst) == 0 {
+                        Op::LrW { rd: rd(inst), rs1: rs1(inst) }
+                    } else {
+                        Op::Unknown
+                    }
+                },
+                0x1800202f => Op::ScW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0x0800202f => Op::AmoswapW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0x0000202f => Op::AmoaddW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0x2000202f => Op::AmoxorW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0x6000202f => Op::AmoandW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0x4000202f => Op::AmoorW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0x8000202f => Op::AmominW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0xa000202f => Op::AmomaxW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0xc000202f => Op::AmominuW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                0xe000202f => Op::AmomaxuW { rd: rd(inst), rs1: rs1(inst), rs2: rs2(inst) },
+                _ => Op::Unknown,
+            },
+            _ => Op::Unknown,
+        },
         // 0x0000000f => match inst & 0x0000707f {
         //     0x0000000f => match inst & 0xffffffff {
         //         0x8330000f => Op::RV_OP_FENCE_TSO,

--- a/common/src/riscv/op.rs
+++ b/common/src/riscv/op.rs
@@ -56,6 +56,19 @@ pub enum Op {
 
     Xori { rd: u8, rs1: u8, imm: i32 },
 
+    // RV32A - Atomic instructions
+    LrW { rd: u8, rs1: u8 },
+    ScW { rd: u8, rs1: u8, rs2: u8 },
+    AmoswapW { rd: u8, rs1: u8, rs2: u8 },
+    AmoaddW { rd: u8, rs1: u8, rs2: u8 },
+    AmoxorW { rd: u8, rs1: u8, rs2: u8 },
+    AmoandW { rd: u8, rs1: u8, rs2: u8 },
+    AmoorW { rd: u8, rs1: u8, rs2: u8 },
+    AmominW { rd: u8, rs1: u8, rs2: u8 },
+    AmomaxW { rd: u8, rs1: u8, rs2: u8 },
+    AmominuW { rd: u8, rs1: u8, rs2: u8 },
+    AmomaxuW { rd: u8, rs1: u8, rs2: u8 },
+
     Ecall,
     Break,
 }

--- a/common/src/vm.rs
+++ b/common/src/vm.rs
@@ -480,31 +480,55 @@ impl<'a, M: PagedMemory> Cpu<'a, M> {
     #[inline]
     fn write_u8<E: fmt::Debug>(&mut self, address: u32, value: u8) -> Result<(), CpuError<E>> {
         if self.stack_seg.contains(address) {
-            return Ok(self.stack_seg.write_u8(address, value)?);
+            self.stack_seg.write_u8(address, value)?;
         } else if self.data_seg.contains(address) {
-            return Ok(self.data_seg.write_u8(address, value)?);
+            self.data_seg.write_u8(address, value)?;
+        } else {
+            return Err(MemoryError::AddressOutOfBounds.into());
         }
-        Err(MemoryError::AddressOutOfBounds.into())
+        // Invalidate reservation if the store touches the reserved 4-byte word
+        if let Some(res) = self.reservation_addr {
+            if address.saturating_sub(res) < 4 && res.saturating_sub(address) < 1 {
+                self.reservation_addr = None;
+            }
+        }
+        Ok(())
     }
 
     #[inline]
     fn write_u16<E: fmt::Debug>(&mut self, address: u32, value: u16) -> Result<(), CpuError<E>> {
         if self.stack_seg.contains(address) {
-            return Ok(self.stack_seg.write_u16(address, value)?);
+            self.stack_seg.write_u16(address, value)?;
         } else if self.data_seg.contains(address) {
-            return Ok(self.data_seg.write_u16(address, value)?);
+            self.data_seg.write_u16(address, value)?;
+        } else {
+            return Err(MemoryError::AddressOutOfBounds.into());
         }
-        Err(MemoryError::AddressOutOfBounds.into())
+        // Invalidate reservation if the store touches the reserved 4-byte word
+        if let Some(res) = self.reservation_addr {
+            if address.saturating_sub(res) < 4 && res.saturating_sub(address) < 2 {
+                self.reservation_addr = None;
+            }
+        }
+        Ok(())
     }
 
     #[inline]
     fn write_u32<E: fmt::Debug>(&mut self, address: u32, value: u32) -> Result<(), CpuError<E>> {
         if self.stack_seg.contains(address) {
-            return Ok(self.stack_seg.write_u32(address, value)?);
+            self.stack_seg.write_u32(address, value)?;
         } else if self.data_seg.contains(address) {
-            return Ok(self.data_seg.write_u32(address, value)?);
+            self.data_seg.write_u32(address, value)?;
+        } else {
+            return Err(MemoryError::AddressOutOfBounds.into());
         }
-        Err(MemoryError::AddressOutOfBounds.into())
+        // Invalidate reservation if the store touches the reserved 4-byte word
+        if let Some(res) = self.reservation_addr {
+            if address.saturating_sub(res) < 4 && res.saturating_sub(address) < 4 {
+                self.reservation_addr = None;
+            }
+        }
+        Ok(())
     }
 
     #[inline(always)]

--- a/common/src/vm.rs
+++ b/common/src/vm.rs
@@ -349,6 +349,8 @@ pub struct Cpu<'a, M: PagedMemory> {
     pub code_seg: MemorySegment<'a, M>,
     pub data_seg: MemorySegment<'a, M>,
     pub stack_seg: MemorySegment<'a, M>,
+    /// Address reserved by LR.W (Load-Reserved); used by SC.W (Store-Conditional).
+    reservation_addr: Option<u32>,
 }
 
 pub trait EcallHandler {
@@ -435,6 +437,7 @@ impl<'a, M: PagedMemory> Cpu<'a, M> {
             code_seg,
             data_seg,
             stack_seg,
+            reservation_addr: None,
         }
     }
 
@@ -706,6 +709,100 @@ impl<'a, M: PagedMemory> Cpu<'a, M> {
             Op::Srli { rd, rs1, imm } => { self.regs[rd as usize] = self.regs[rs1 as usize] >> (imm & 0x1f); },
             Op::Srai { rd, rs1, imm } => { self.regs[rd as usize] = ((self.regs[rs1 as usize] as i32) >> (imm & 0x1f)) as u32; },
             Op::Xori { rd, rs1, imm } => { self.regs[rd as usize] = self.regs[rs1 as usize] ^ (imm as u32); },
+
+            // RV32A - Atomic instructions
+            // In a single-threaded/single-hart VM, atomics are straightforward:
+            // LR.W loads and sets a reservation; SC.W stores only if reservation is valid.
+            // AMO ops perform atomic read-modify-write.
+            Op::LrW { rd, rs1 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 {
+                    return Err("Unaligned LR.W address".into());
+                }
+                let value = self.read_u32(addr)?;
+                self.regs[rd as usize] = value;
+                self.reservation_addr = Some(addr);
+            },
+            Op::ScW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 {
+                    return Err("Unaligned SC.W address".into());
+                }
+                if self.reservation_addr == Some(addr) {
+                    self.write_u32(addr, self.regs[rs2 as usize])?;
+                    self.regs[rd as usize] = 0; // success
+                } else {
+                    self.regs[rd as usize] = 1; // failure
+                }
+                self.reservation_addr = None;
+            },
+            Op::AmoswapW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOSWAP.W address".into()); }
+                let old = self.read_u32(addr)?;
+                self.write_u32(addr, self.regs[rs2 as usize])?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmoaddW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOADD.W address".into()); }
+                let old = self.read_u32(addr)?;
+                self.write_u32(addr, old.wrapping_add(self.regs[rs2 as usize]))?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmoxorW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOXOR.W address".into()); }
+                let old = self.read_u32(addr)?;
+                self.write_u32(addr, old ^ self.regs[rs2 as usize])?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmoandW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOAND.W address".into()); }
+                let old = self.read_u32(addr)?;
+                self.write_u32(addr, old & self.regs[rs2 as usize])?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmoorW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOOR.W address".into()); }
+                let old = self.read_u32(addr)?;
+                self.write_u32(addr, old | self.regs[rs2 as usize])?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmominW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOMIN.W address".into()); }
+                let old = self.read_u32(addr)?;
+                let new = core::cmp::min(old as i32, self.regs[rs2 as usize] as i32) as u32;
+                self.write_u32(addr, new)?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmomaxW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOMAX.W address".into()); }
+                let old = self.read_u32(addr)?;
+                let new = core::cmp::max(old as i32, self.regs[rs2 as usize] as i32) as u32;
+                self.write_u32(addr, new)?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmominuW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOMINU.W address".into()); }
+                let old = self.read_u32(addr)?;
+                let new = core::cmp::min(old, self.regs[rs2 as usize]);
+                self.write_u32(addr, new)?;
+                self.regs[rd as usize] = old;
+            },
+            Op::AmomaxuW { rd, rs1, rs2 } => {
+                let addr = self.regs[rs1 as usize];
+                if addr & 3 != 0 { return Err("Unaligned AMOMAXU.W address".into()); }
+                let old = self.read_u32(addr)?;
+                let new = core::cmp::max(old, self.regs[rs2 as usize]);
+                self.write_u32(addr, new)?;
+                self.regs[rd as usize] = old;
+            },
 
             Op::Ecall => {
                 if let Some(ecall_handler) = ecall_handler {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,13 @@ All crates used by V-Apps use explicit features in order to distinguish which co
 Here are the currently defined target features:
 
 - `target_native`: indicates compilation of a V-App for the *native* environment, which is what runs on your machine. With this target, V-Apps run as a process that communicates with the client via a socket. This is typically the default and is ***only*** used for development and testing.
-- `target_vanadium_ledger`: indicates compilation of a V-App for execution on the Ledger Vanadium VM app. Depending whether the device is a simulated device on Speculos or a real device, the Transport protocol would use tcp or the HID interface. The actual compilation target for this feature is `riscv32imc-unknown-none-elf`.
+- `target_vanadium_ledger`: indicates compilation of a V-App for execution on the Ledger Vanadium VM app. Depending whether the device is a simulated device on Speculos or a real device, the Transport protocol would use tcp or the HID interface. The actual compilation target for this feature is `riscv32imac-unknown-none-elf`.
 
 The `vanadium-app-sdk`, every V-App and any V-App library using the `vanadium-app-sdk` crate must have a feature for each supported target (and transitively propagate to dependencies, if relevant).
 
 When building for the Ledger target, use:
 ```bash
-cargo build --release --target riscv32imc-unknown-none-elf --no-default-features --features target_vanadium_ledger
+cargo build --release --target riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
 ```
 
 The `vanadium-client-sdk` and the V-App clients always compile and run for the native target. They might use the feature flags only to distinguish which transport protocol is supported by clients - and might therefore have multiple (or all) target features simultaneously.

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -53,7 +53,7 @@ struct BenchCase {
 impl BenchCase {
     fn app_path(&self) -> String {
         format!(
-            "cases/{}/target/riscv32imc-unknown-none-elf/release/{}",
+            "cases/{}/target/riscv32imac-unknown-none-elf/release/{}",
             self.case_name, self.crate_name
         )
     }


### PR DESCRIPTION
Adds atomic instructions, in order to support the `riscv32imac` target.

Closes: #89