### PR TITLE
Vanadium goes `async`

### DIFF
--- a/app-sdk/Cargo.toml
+++ b/app-sdk/Cargo.toml
@@ -8,6 +8,7 @@ common = { path = "../common", default-features = false }
 critical-section = "1.1.2"
 subtle = { version="2.6.1", default-features = false }
 hex-literal = "0.4.1"
+vanadium_macros = { path = "../macros" }
 zeroize = "1.8.1"
 
 # target_vanadium_ledger dependencies (optional)

--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -6,6 +6,7 @@ use common::ux::TagValue;
 
 use crate::{
     comm::MessageError,
+    executor::block_on,
     ux::{has_page_api, step_pos},
     ux_generated,
 };
@@ -169,7 +170,7 @@ where
             self.ux_dirty = false;
         }
 
-        let ev = crate::ux::get_event();
+        let ev = block_on(crate::ux::get_event());
         match (self.current_view, ev) {
             // Page API navigation
             (View::HomePage, Action(Quit)) => crate::ecalls::exit(0),
@@ -351,14 +352,14 @@ where
         long_press: bool,
     ) -> bool {
         self.set_ux_dirty();
-        crate::ux::review_pairs(
+        block_on(crate::ux::review_pairs(
             intro_text,
             intro_subtext,
             pairs,
             final_text,
             final_button_text,
             long_press,
-        )
+        ))
     }
 
     /// Shows a progress indicator with the provided status text.
@@ -393,7 +394,7 @@ where
         reject: &str,
     ) -> bool {
         self.set_ux_dirty();
-        crate::ux::show_confirm_reject(title, text, confirm, reject)
+        block_on(crate::ux::show_confirm_reject(title, text, confirm, reject))
     }
 
     /// Shows a temporary informational screen with an icon and message.

--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -1,8 +1,10 @@
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     vec::Vec,
 };
 use common::ux::TagValue;
+use core::{future::Future, pin::Pin};
 
 use crate::{
     comm::MessageError,
@@ -12,8 +14,9 @@ use crate::{
 };
 
 /// A Handler is a function that is called when a message is received from the host, and
-/// returns the app's response.
-pub type Handler<S = ()> = fn(&mut App<S>, &[u8]) -> Vec<u8>;
+/// returns the app's response asynchronously.
+pub type Handler<S = ()> =
+    for<'a> fn(&'a mut App<S>, &'a [u8]) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum View {
@@ -160,10 +163,10 @@ where
     ///
     /// This method enters a loop where it continuously processes user interface events and checks for incoming messages.
     /// It will not return until a message is received or an error occurs.
-    pub fn exchange(&mut self, msg: &[u8]) -> Result<Vec<u8>, MessageError> {
+    pub async fn exchange(&mut self, msg: &[u8]) -> Result<Vec<u8>, MessageError> {
         crate::comm::send_message(msg);
         loop {
-            self.process_ux_events(false);
+            self.process_ux_events(false).await;
             match crate::comm::receive_message() {
                 Ok(msg) => return Ok(msg),
                 Err(crate::comm::MessageError::NoMessage) => continue,
@@ -178,7 +181,7 @@ where
         self.cleanup_ticks = 0;
     }
 
-    fn process_ux_events(&mut self, show_dashboard: bool) {
+    async fn process_ux_events(&mut self, show_dashboard: bool) {
         use common::ux::Action::*;
         use common::ux::Event::{Action, Ticker};
 
@@ -191,7 +194,7 @@ where
             self.ux_dirty = false;
         }
 
-        let ev = block_on(crate::ux::get_event());
+        let ev = crate::ux::get_event().await;
         match (self.current_view, ev) {
             // Page API navigation
             (View::HomePage, Action(Quit)) => crate::ecalls::exit(0),
@@ -306,22 +309,28 @@ where
     /// It never returns, as it keeps the app running until sdk::exit() is called,
     /// or a fatal error occurs.
     fn run_loop(&mut self) -> ! {
-        loop {
-            self.process_ux_events(true);
+        block_on(async {
+            loop {
+                self.process_ux_events(true).await;
 
-            let req_msg = match crate::comm::receive_message() {
-                Ok(msg) => msg,
-                Err(crate::comm::MessageError::NoMessage) => continue, // TODO: should we wait before retrying, to avoid spamming the channel?
-                Err(e) => panic!("Communication error: {}", e),
-            };
-            let resp_msg = (self.handler)(self, &req_msg);
-            crate::comm::send_message(&resp_msg);
-        }
+                let req_msg = match crate::comm::receive_message() {
+                    Ok(msg) => msg,
+                    Err(crate::comm::MessageError::NoMessage) => continue, // TODO: should we wait before retrying, to avoid spamming the channel?
+                    Err(e) => panic!("Communication error: {}", e),
+                };
+                let handler = self.handler;
+                let resp_msg = handler(self, &req_msg).await;
+                crate::comm::send_message(&resp_msg);
+            }
+        })
     }
 
     /// This is only useful to produce a valid app instance in tests.
     pub fn singleton() -> Self {
-        AppBuilder::new("test_app", "0.0.1", |_app, _msg| Vec::new()).build()
+        AppBuilder::new("test_app", "0.0.1", |_app, _msg| {
+            Box::pin(async { Vec::new() })
+        })
+        .build()
     }
 
     /// Returns a reference to the cached home info page, computing it if needed.
@@ -403,7 +412,7 @@ where
     /// * `long_press` - When true, the final approval may require a long press gesture instead of a simple confirm.
     ///
     /// Returns `true` if the user confirms/approves on the final screen; `false` if the user aborts (e.g. quits or rejects).
-    pub fn review_pairs(
+    pub async fn review_pairs(
         &mut self,
         intro_text: &str,
         intro_subtext: &str,
@@ -413,14 +422,15 @@ where
         long_press: bool,
     ) -> bool {
         self.set_ux_dirty();
-        block_on(crate::ux::review_pairs(
+        crate::ux::review_pairs(
             intro_text,
             intro_subtext,
             pairs,
             final_text,
             final_button_text,
             long_press,
-        ))
+        )
+        .await
     }
 
     /// Shows a progress indicator with the provided status text.
@@ -447,7 +457,7 @@ where
     /// * `reject` - Label for the reject/abort action.
     ///
     /// Returns `true` if the user selects the confirm action; `false` if the user selects reject.
-    pub fn show_confirm_reject(
+    pub async fn show_confirm_reject(
         &mut self,
         title: &str,
         text: &str,
@@ -455,7 +465,7 @@ where
         reject: &str,
     ) -> bool {
         self.set_ux_dirty();
-        block_on(crate::ux::show_confirm_reject(title, text, confirm, reject))
+        crate::ux::show_confirm_reject(title, text, confirm, reject).await
     }
 
     /// Shows a temporary informational screen with an icon and message.

--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -121,6 +121,27 @@ pub struct App<S = ()> {
     pub state: S,
 }
 
+/// Handle to a task spawned with [`App::spawn_task`].
+///
+/// The task runs cooperatively, interleaved with any subsequent UX flow
+/// driven by [`App::review_pairs`]. Retrieve the result by calling
+/// [`TaskHandle::take`] once the UX flow has returned.
+pub struct TaskHandle<T>(alloc::rc::Rc<core::cell::RefCell<Option<T>>>);
+
+impl<T> TaskHandle<T> {
+    /// Returns the result of the task.
+    ///
+    /// If the task has not finished yet , this polls the executor until it is ready.
+    pub fn take(self) -> T {
+        loop {
+            if let Some(val) = self.0.borrow_mut().take() {
+                return val;
+            }
+            crate::executor::poll_once();
+        }
+    }
+}
+
 impl<S> App<S>
 where
     S: Default,
@@ -325,6 +346,46 @@ where
             self.home_info_page = Some(raw);
         }
         self.home_info_page.as_ref().unwrap() // safe, just populated
+    }
+
+    /// Spawns a task that runs cooperatively during a UX flow.
+    ///
+    /// The future is registered with the SDK executor. [`review_pairs`] drives
+    /// that executor while waiting for user input, so the task overlaps
+    /// with the time the user spends reading the on-screen content.
+    ///
+    /// The future **should** call [`crate::executor::yield_now`] periodically
+    /// (e.g. after each iteration or chunk of work) to keep the UI responsive.
+    ///
+    /// Returns a [`TaskHandle`] from which the result is retrieved after
+    /// the UX flow returns.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use vanadium_app_sdk::executor::yield_now;
+    ///
+    /// let handle = app.spawn_task(async move {
+    ///     let mut results = Vec::new();
+    ///     for job in jobs {
+    ///         results.push(process(job));
+    ///         yield_now().await;
+    ///     }
+    ///     results
+    /// });
+    /// ```
+    pub fn spawn_task<T: 'static>(
+        &mut self,
+        work: impl core::future::Future<Output = T> + 'static,
+    ) -> TaskHandle<T> {
+        use alloc::rc::Rc;
+        use core::cell::RefCell;
+        let cell: Rc<RefCell<Option<T>>> = Rc::new(RefCell::new(None));
+        let cell2 = cell.clone();
+        crate::executor::spawn(async move {
+            *cell2.borrow_mut() = Some(work.await);
+        });
+        TaskHandle(cell)
     }
 
     // --- UX Flows ---

--- a/app-sdk/src/app.rs
+++ b/app-sdk/src/app.rs
@@ -4,7 +4,12 @@ use alloc::{
     vec::Vec,
 };
 use common::ux::TagValue;
-use core::{future::Future, pin::Pin};
+use core::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use crate::{
     comm::MessageError,
@@ -124,23 +129,82 @@ pub struct App<S = ()> {
     pub state: S,
 }
 
+/// Trait for checking whether a spawned task has completed.
+///
+/// This is implemented by [`TaskHandle<T>`] and enables [`App::await_all`]
+/// to accept handles of different result types.
+pub trait IsReady {
+    /// Returns `true` if the task has completed and the result is available.
+    fn is_ready(&self) -> bool;
+}
+
 /// Handle to a task spawned with [`App::spawn_task`].
 ///
 /// The task runs cooperatively, interleaved with any subsequent UX flow
 /// driven by [`App::review_pairs`]. Retrieve the result by calling
 /// [`TaskHandle::take`] once the UX flow has returned.
-pub struct TaskHandle<T>(alloc::rc::Rc<core::cell::RefCell<Option<T>>>);
+///
+/// **Cancellation:** if the handle is dropped without calling [`take`],
+/// the background task is cancelled on the next executor poll.  This lets
+/// you interrupt incomplete work simply by dropping the handle.
+pub struct TaskHandle<T> {
+    result: alloc::rc::Rc<core::cell::RefCell<Option<T>>>,
+    cancelled: alloc::rc::Rc<Cell<bool>>,
+    taken: Cell<bool>,
+}
+
+impl<T> IsReady for TaskHandle<T> {
+    fn is_ready(&self) -> bool {
+        self.result.borrow().is_some()
+    }
+}
 
 impl<T> TaskHandle<T> {
     /// Returns the result of the task.
     ///
-    /// If the task has not finished yet , this polls the executor until it is ready.
+    /// If the task has not finished yet, this polls the executor until it is ready.
     pub fn take(self) -> T {
+        self.taken.set(true);
         loop {
-            if let Some(val) = self.0.borrow_mut().take() {
+            if let Some(val) = self.result.borrow_mut().take() {
                 return val;
             }
             crate::executor::poll_once();
+        }
+    }
+}
+
+impl<T> Drop for TaskHandle<T> {
+    fn drop(&mut self) {
+        if !self.taken.get() {
+            self.cancelled.set(true);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CancellableFuture – wraps a user future and aborts when the flag is set
+// ---------------------------------------------------------------------------
+
+struct CancellableFuture<F> {
+    inner: F,
+    cancelled: alloc::rc::Rc<Cell<bool>>,
+}
+
+impl<F: Future> Future for CancellableFuture<F> {
+    type Output = Option<F::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: `cancelled` is `Unpin` (Rc<Cell<bool>>); we only pin-project
+        // to `inner`, which is structurally pinned.
+        let this = unsafe { self.get_unchecked_mut() };
+        if this.cancelled.get() {
+            return Poll::Ready(None);
+        }
+        let inner = unsafe { Pin::new_unchecked(&mut this.inner) };
+        match inner.poll(cx) {
+            Poll::Ready(val) => Poll::Ready(Some(val)),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -391,10 +455,74 @@ where
         use core::cell::RefCell;
         let cell: Rc<RefCell<Option<T>>> = Rc::new(RefCell::new(None));
         let cell2 = cell.clone();
+        let cancelled: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+        let cancelled2 = cancelled.clone();
         crate::executor::spawn(async move {
-            *cell2.borrow_mut() = Some(work.await);
+            let wrapper = CancellableFuture {
+                inner: work,
+                cancelled: cancelled2,
+            };
+            if let Some(val) = wrapper.await {
+                *cell2.borrow_mut() = Some(val);
+            }
         });
-        TaskHandle(cell)
+        TaskHandle {
+            result: cell,
+            cancelled,
+            taken: Cell::new(false),
+        }
+    }
+
+    // --- Task helpers ---
+
+    /// Waits for the given task to complete, returning its result.
+    ///
+    /// If the task is not yet ready, a spinner with the given `text` is
+    /// displayed while polling. If the task is already complete when this
+    /// method is called, no spinner is shown and the result is returned
+    /// immediately.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let handle = app.spawn_task(async move { heavy_computation().await });
+    /// // ... run a UX flow concurrently ...
+    /// let result = app.await_task("Processing...", handle);
+    /// ```
+    pub fn await_task<T>(&mut self, text: &str, handle: TaskHandle<T>) -> T {
+        if !handle.is_ready() {
+            self.show_spinner(text);
+        }
+        handle.take()
+    }
+
+    /// Waits for **all** of the given tasks to complete.
+    ///
+    /// If any task is still pending, a spinner with the given `text` is
+    /// displayed and the executor is polled until every task reports ready.
+    /// If all tasks are already complete, no spinner is shown.
+    ///
+    /// After this method returns, each individual [`TaskHandle::take`] will
+    /// return immediately.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let h1 = app.spawn_task(async { first_job().await });
+    /// let h2 = app.spawn_task(async { second_job().await });
+    /// // ... drive a UX flow ...
+    /// app.await_all("Processing...", &[&h1, &h2]);
+    /// let r1 = h1.take();
+    /// let r2 = h2.take();
+    /// ```
+    pub fn await_all(&mut self, text: &str, handles: &[&dyn IsReady]) {
+        if handles.iter().all(|h| h.is_ready()) {
+            return;
+        }
+        self.show_spinner(text);
+        while !handles.iter().all(|h| h.is_ready()) {
+            crate::executor::poll_once();
+        }
     }
 
     // --- UX Flows ---

--- a/app-sdk/src/executor.rs
+++ b/app-sdk/src/executor.rs
@@ -1,0 +1,299 @@
+//! Cooperative single-threaded async executor for V-Apps.
+//!
+//! V-Apps run in a strictly single-threaded environment (one RISC-V core, no RTOS) so a
+//! simple spin-loop executor without any thread-safe waker infrastructure is both correct
+//! and efficient.
+//!
+//! # How it works
+//!
+//! 1. Background tasks are registered with [`spawn`].  Each task is a `'static` future
+//!    that produces `()`.
+//! 2. A "root" future (typically the entire message-handler flow for one request) is driven
+//!    to completion by [`block_on`].
+//! 3. Every time the root future returns `Poll::Pending`, `block_on` calls [`poll_once`] to
+//!    advance all registered background tasks by one step.
+//! 4. [`yield_now`] is a helper that yields `Poll::Pending` exactly once and then
+//!    immediately completes.  Background tasks call it after each expensive step (e.g. after
+//!    signing one input) to let the UX event loop run.
+//!
+//! A no-op waker ([`Waker::noop`]) is used because tasks are polled eagerly in every
+//! `block_on` spin iteration – there is nothing to wake up.
+
+use alloc::{boxed::Box, vec::Vec};
+use core::{
+    cell::RefCell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+// ---------------------------------------------------------------------------
+// Task
+// ---------------------------------------------------------------------------
+
+struct Task(Pin<Box<dyn Future<Output = ()>>>);
+
+// ---------------------------------------------------------------------------
+// Executor
+// ---------------------------------------------------------------------------
+
+/// A cooperative, `no_std` single-threaded executor.
+pub struct Executor {
+    tasks: Vec<Task>,
+}
+
+impl Executor {
+    /// Creates an empty executor.
+    pub const fn new() -> Self {
+        Self { tasks: Vec::new() }
+    }
+
+    /// Adds a background task.  The future must be `'static`.
+    pub fn spawn(&mut self, future: impl Future<Output = ()> + 'static) {
+        self.tasks.push(Task(Box::pin(future)));
+    }
+
+    /// Polls every pending task once.  Completed tasks are dropped.
+    fn poll_tasks(tasks: &mut Vec<Task>) {
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(&waker);
+        let mut i = 0;
+        while i < tasks.len() {
+            match tasks[i].0.as_mut().poll(&mut cx) {
+                Poll::Ready(()) => {
+                    // swap_remove is O(1); order among tasks does not matter.
+                    tasks.swap_remove(i);
+                }
+                Poll::Pending => {
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    /// Returns `true` if no background tasks are pending.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global executor (single-threaded, no locking needed)
+// ---------------------------------------------------------------------------
+
+struct ExecutorCell(RefCell<Executor>);
+
+// SAFETY: V-Apps are single-threaded; there is no concurrent access.
+unsafe impl Sync for ExecutorCell {}
+
+static GLOBAL_EXECUTOR: ExecutorCell = ExecutorCell(RefCell::new(Executor::new()));
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Registers a `'static` background future to be polled cooperatively inside
+/// any active [`block_on`] call.
+pub fn spawn(future: impl Future<Output = ()> + 'static) {
+    GLOBAL_EXECUTOR.0.borrow_mut().spawn(future);
+}
+
+/// Advances all pending background tasks by one round of polling.
+///
+/// Tasks that call [`spawn`] during polling are picked up in the same round.
+pub fn poll_once() {
+    // Take the task list out of the RefCell so that tasks being polled can
+    // re-entrantly call `spawn()` without hitting a double-borrow panic.
+    let mut tasks = core::mem::take(&mut GLOBAL_EXECUTOR.0.borrow_mut().tasks);
+    Executor::poll_tasks(&mut tasks);
+    // Merge back: append any tasks that were spawned while we were polling.
+    let mut exec = GLOBAL_EXECUTOR.0.borrow_mut();
+    if exec.tasks.is_empty() {
+        exec.tasks = tasks;
+    } else {
+        // New tasks were spawned during polling; keep them and append survivors.
+        exec.tasks.append(&mut tasks);
+    }
+}
+
+/// Drives `future` to completion, polling registered background tasks
+/// ([`spawn`]-ed) on every `Poll::Pending` from the root future.
+///
+/// This is intentionally *not* re-entrant.  Nesting `block_on` calls will cause
+/// the inner call to drive the same global executor, which may be surprising.
+/// For V-App use there is typically only one active `block_on` call at a time.
+///
+/// # Important
+///
+/// The root future **must** eventually resolve through polling alone.  There is
+/// no I/O reactor; if the root future and every background task return
+/// `Poll::Pending` indefinitely the executor will spin forever.
+pub fn block_on<T, F: Future<Output = T>>(future: F) -> T {
+    // Pin the future on the stack; no heap allocation required.
+    let mut future = core::pin::pin!(future);
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => return val,
+            Poll::Pending => {
+                poll_once();
+            }
+        }
+    }
+}
+
+/// Yields control back to the executor, allowing other tasks and UX events
+/// to be processed.
+///
+/// Background tasks performing substantial work should call this periodically
+/// (e.g. every loop iteration or after processing each item) to keep the UI
+/// responsive.
+///
+/// ```ignore
+/// let handle = app.spawn_background(async {
+///     for chunk in data.chunks(64) {
+///         process(chunk);
+///         yield_now().await;
+///     }
+///     result
+/// });
+/// ```
+pub async fn yield_now() {
+    pending_once().await;
+}
+
+/// Returns a future that yields [`Poll::Pending`] exactly once, then completes.
+fn pending_once() -> impl Future<Output = ()> {
+    let mut yielded = false;
+    core::future::poll_fn(move |_cx| {
+        if yielded {
+            Poll::Ready(())
+        } else {
+            yielded = true;
+            Poll::Pending
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::rc::Rc;
+    use core::cell::Cell;
+
+    #[test]
+    fn block_on_immediately_ready() {
+        let val = block_on(async { 42 });
+        assert_eq!(val, 42);
+    }
+
+    #[test]
+    fn yield_now_yields_then_completes() {
+        let mut fut = core::pin::pin!(yield_now());
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(&waker);
+
+        // First poll: Pending
+        assert!(fut.as_mut().poll(&mut cx).is_pending());
+        // Second poll: Ready
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn spawn_and_poll_once_completes_task() {
+        let done = Rc::new(Cell::new(false));
+        let done2 = done.clone();
+
+        let mut exec = Executor::new();
+        exec.spawn(async move {
+            done2.set(true);
+        });
+
+        assert!(!exec.is_empty());
+        Executor::poll_tasks(&mut exec.tasks);
+        assert!(exec.is_empty());
+        assert!(done.get());
+    }
+
+    #[test]
+    fn multiple_tasks_some_finish_early() {
+        let finished = Rc::new(Cell::new(0u32));
+
+        let mut exec = Executor::new();
+
+        // Task 1: completes immediately
+        let f = finished.clone();
+        exec.spawn(async move {
+            f.set(f.get() + 1);
+        });
+
+        // Task 2: yields once, then completes
+        let f = finished.clone();
+        exec.spawn(async move {
+            yield_now().await;
+            f.set(f.get() + 1);
+        });
+
+        // Task 3: completes immediately
+        let f = finished.clone();
+        exec.spawn(async move {
+            f.set(f.get() + 1);
+        });
+
+        // First round: tasks 1 and 3 complete, task 2 yields
+        Executor::poll_tasks(&mut exec.tasks);
+        assert_eq!(exec.tasks.len(), 1);
+        assert_eq!(finished.get(), 2);
+
+        // Second round: task 2 completes
+        Executor::poll_tasks(&mut exec.tasks);
+        assert!(exec.is_empty());
+        assert_eq!(finished.get(), 3);
+    }
+
+    #[test]
+    fn block_on_with_background_task() {
+        let result = Rc::new(Cell::new(0u32));
+        let r = result.clone();
+
+        // Spawn a background task that sets a value after yielding
+        spawn(async move {
+            yield_now().await;
+            r.set(42);
+        });
+
+        // block_on a future that waits for the background task
+        let r2 = result.clone();
+        let val = block_on(async move {
+            // Yield to let the background task run
+            yield_now().await;
+            // Yield once more; the background task should have completed
+            yield_now().await;
+            r2.get()
+        });
+
+        assert_eq!(val, 42);
+    }
+
+    #[test]
+    fn reentrant_spawn_during_poll() {
+        // Verify that a task can call spawn() during polling without panicking.
+        let done = Rc::new(Cell::new(false));
+        let done2 = done.clone();
+
+        spawn(async move {
+            // Spawn a new task from inside a running task
+            spawn(async move {
+                done2.set(true);
+            });
+        });
+
+        // First poll_once: runs the outer task, which spawns the inner task
+        poll_once();
+        // Second poll_once: runs the inner task
+        poll_once();
+        assert!(done.get());
+    }
+}

--- a/app-sdk/src/executor.rs
+++ b/app-sdk/src/executor.rs
@@ -152,7 +152,7 @@ pub fn block_on<T, F: Future<Output = T>>(future: F) -> T {
 /// responsive.
 ///
 /// ```ignore
-/// let handle = app.spawn_background(async {
+/// let handle = app.spawn_task(async {
 ///     for chunk in data.chunks(64) {
 ///         process(chunk);
 ///         yield_now().await;

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -26,6 +26,7 @@ pub mod storage;
 pub mod ux;
 
 pub use app::{App, AppBuilder};
+pub use vanadium_macros::handler;
 
 mod ecalls;
 

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -18,6 +18,7 @@ pub mod app;
 pub mod bignum;
 pub mod comm;
 pub mod curve;
+pub mod executor;
 pub mod hash;
 pub mod rand;
 pub mod slip21;

--- a/app-sdk/src/lib.rs
+++ b/app-sdk/src/lib.rs
@@ -25,7 +25,7 @@ pub mod slip21;
 pub mod storage;
 pub mod ux;
 
-pub use app::{App, AppBuilder};
+pub use app::{App, AppBuilder, IsReady, TaskHandle};
 pub use vanadium_macros::handler;
 
 mod ecalls;

--- a/app-sdk/src/ux.rs
+++ b/app-sdk/src/ux.rs
@@ -44,13 +44,16 @@ pub(crate) fn show_step_raw(step: &[u8]) {
 }
 
 /// Blocks until an event is received, then returns it.
-pub fn get_event() -> Event {
+pub async fn get_event() -> Event {
     loop {
         let mut event_data = EventData::default();
         // SAFETY: event_data is a properly aligned, initialized EventData on the stack.
         let event_code = EventCode::from(unsafe { ecalls::get_event(&mut event_data) });
         match event_code {
             EventCode::Ticker => {
+                // Give a chance to the executor to make progress on registered tasks
+                crate::executor::yield_now().await;
+
                 return Event::Ticker;
             }
             EventCode::Action => {
@@ -66,14 +69,11 @@ pub fn get_event() -> Event {
 }
 
 // waits for a number of ticker events
-pub fn wait(n: u32) {
+pub async fn wait(n: u32) {
     let mut n_tickers = 0u32;
     loop {
-        let mut event_data = EventData::default();
-        // SAFETY: event_data is a properly aligned, initialized EventData on the stack.
-        let event_code = EventCode::from(unsafe { ecalls::get_event(&mut event_data) });
-        match event_code {
-            EventCode::Ticker => {
+        match get_event().await {
+            Event::Ticker => {
                 n_tickers += 1;
                 if n_tickers >= n {
                     return;
@@ -85,16 +85,16 @@ pub fn wait(n: u32) {
 }
 
 // Like get_event, but it ignores any event that is not an Action
-pub fn get_action() -> Action {
+pub async fn get_action() -> Action {
     loop {
-        if let Event::Action(action) = get_event() {
+        if let Event::Action(action) = get_event().await {
             return action;
         }
     }
 }
 
 // implementation of review_pairs() for the page API
-fn __page_review_pairs(
+async fn __page_review_pairs(
     intro_text: &str,
     intro_subtext: &str,
     pairs: &[TagValue],
@@ -159,7 +159,7 @@ fn __page_review_pairs(
 
         // Process events
         loop {
-            match get_event() {
+            match get_event().await {
                 Event::Action(Action::PreviousPage) if active_page > 0 => {
                     active_page -= 1;
                     break;
@@ -181,7 +181,7 @@ fn __page_review_pairs(
 }
 
 // implementation of review_pairs() for the step API
-fn __step_review_pairs(
+async fn __step_review_pairs(
     intro_text: &str,
     intro_subtext: &str,
     pairs: &[TagValue],
@@ -226,7 +226,7 @@ fn __step_review_pairs(
         }
 
         loop {
-            match get_event() {
+            match get_event().await {
                 Event::Action(action) => {
                     if action == Action::NextPage && cur_step < n_steps - 1 {
                         cur_step += 1;
@@ -249,7 +249,7 @@ fn __step_review_pairs(
 }
 
 // Temporary function; similar to nbgl_useCaseReview
-pub fn review_pairs(
+pub async fn review_pairs(
     intro_text: &str,
     intro_subtext: &str,
     pairs: &[TagValue],
@@ -266,6 +266,7 @@ pub fn review_pairs(
             final_button_text,
             long_press,
         )
+        .await
     } else {
         __step_review_pairs(
             intro_text,
@@ -275,6 +276,7 @@ pub fn review_pairs(
             final_button_text,
             long_press,
         )
+        .await
     }
 }
 
@@ -286,14 +288,14 @@ pub fn show_spinner(text: &str) {
     }
 }
 
-pub fn show_info(icon: Icon, text: &str) {
+pub async fn show_info(icon: Icon, text: &str) {
     if has_page_api() {
         ux_generated::show_page_info(icon, text);
     } else {
         ux_generated::show_step_info_single(text);
     }
 
-    wait(20); // Wait for 20 ticker events (about 2 seconds)
+    wait(20).await; // Wait for 20 ticker events (about 2 seconds)
 }
 
 // computes the correct constant among SINGLE_STEP, FIRST_STEP, LAST_STEP, NEITHER_FIRST_NOR_LAST_STEP
@@ -304,13 +306,13 @@ pub(crate) const fn step_pos(n_steps: u32, cur_step: u32) -> u8 {
     has_left_arrow << 1 | has_right_arrow
 }
 
-pub fn show_confirm_reject(title: &str, text: &str, confirm: &str, reject: &str) -> bool {
+pub async fn show_confirm_reject(title: &str, text: &str, confirm: &str, reject: &str) -> bool {
     if has_page_api() {
         ux_generated::show_page_confirm_reject(title, text, confirm, reject);
 
         // wait until a button is pressed
         loop {
-            match get_event() {
+            match get_event().await {
                 Event::Action(action) => {
                     if action == Action::Reject {
                         return false;
@@ -338,7 +340,7 @@ pub fn show_confirm_reject(title: &str, text: &str, confirm: &str, reject: &str)
             }
 
             loop {
-                match get_event() {
+                match get_event().await {
                     Event::Action(action) => {
                         if action == Action::NextPage && cur_step < n_steps - 1 {
                             cur_step += 1;

--- a/apps/async/README.md
+++ b/apps/async/README.md
@@ -1,0 +1,65 @@
+This is a simple app to demonstrate the async features of Vanadium V-Apps.
+
+- [app](app) contains the Risc-V app for Vanadium.
+- [client](client) folder contains the client of the app, and a simple CLI interface.
+
+The `client` is a library crate (see [lib.rs](client/src/lib.rs)), but it also has a test executable ([main.rs](client/src/main.rs)) to interact with the app from the command line.
+
+## Build the V-App
+
+If you installed [just](https://github.com/casey/just), simply running `just` from the `app` folder will build both the
+Risc-V and the native binaries.
+
+### Risc-V
+
+In order to build the app for the Risc-V target, enter the `app` folder and run:
+
+   ```sh
+   cargo build --release --target=riscv32imac-unknown-none-elf
+   ```
+
+### Native
+
+In order to build the app for the native target, enter the `app` folder and run:
+
+   ```sh
+  cargo build --release
+   ```
+
+## Run the V-App
+
+### Native target
+
+Make sure you built the V-App for the native target.
+
+On a terminal in the `app` folder, simply run:
+
+   ```sh
+   cargo run
+   ```
+
+On a different terminal in the `client` folder, run:
+
+   ```sh
+   cargo run -- --native
+   ```
+
+Note: you can customize the hostname and port of the app by setting the `VAPP_ADDRESS` environment variable.
+
+### RISC-V
+
+Make sure you built the V-App for the RISC-V target.
+
+Launch Vanadium on speculos. Then execute:
+
+From the `client` folder
+
+   ```sh
+   cargo run
+   ```
+
+If you want to run the V-app on a real device, launch the Vanadium app on the device, then execute instead:
+
+   ```sh
+   cargo run -- --hid
+   ```

--- a/apps/async/app/.cargo/config.toml
+++ b/apps/async/app/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.riscv32imac-unknown-none-elf]
+rustflags = [
+  # The VM expects ELF binaries with 2 segments (rx and rw). Don't put
+  # read-only non-executable sections in their own segment.
+  "-Clink-arg=--no-rosegment",
+]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/apps/async/app/.vscode/settings.json
+++ b/apps/async/app/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.cargo.target": "x86_64-unknown-linux-gnu",
+    "rust-analyzer.cargo.allTargets": false
+}

--- a/apps/async/app/Cargo.toml
+++ b/apps/async/app/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vnd-async"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.vapp]
+name = "Async"
+stack_size = 65536
+
+[features]
+default = ["target_native"]
+target_native = ["sdk/target_native"]
+target_vanadium_ledger = ["sdk/target_vanadium_ledger"]
+
+[dependencies]
+hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
+postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
+serde = { version = "1.0.215", default-features = false, features = ["alloc", "derive"] }
+client = { package = "vnd-async-client", path = "../client", default-features = false}
+
+[dev-dependencies]
+sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false, features = ["test-mode", "target_native"] }
+
+[workspace]

--- a/apps/async/app/justfile
+++ b/apps/async/app/justfile
@@ -1,0 +1,16 @@
+run:
+  cargo run
+
+# build for both native and riscv targets
+build:
+  cargo build --release
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
+
+# build for native target
+build-native:
+  cargo build --release
+
+# build for riscv target (Ledger Vanadium)
+build-riscv:
+  cargo build --release --target=riscv32imac-unknown-none-elf --no-default-features --features target_vanadium_ledger
+

--- a/apps/async/app/src/main.rs
+++ b/apps/async/app/src/main.rs
@@ -1,0 +1,120 @@
+#![cfg_attr(feature = "target_vanadium_ledger", no_std, no_main)]
+
+extern crate alloc;
+
+use alloc::{vec, vec::Vec};
+use sdk::{executor::yield_now, ux::Icon, App, AppBuilder};
+
+use client::Command;
+
+sdk::bootstrap!();
+
+/// Number of inner iterations per `do_work` call.
+/// Tune this constant so that a single `do_work` call takes ~0.2 s.
+const WORK_ITERATIONS: u32 = 100_000;
+
+/// A single unit of pure local computation.
+/// Performs `WORK_ITERATIONS` arithmetic steps on `value` and returns the result.
+fn do_work(value: u64) -> u64 {
+    let mut acc = value;
+    sdk::println!("Doing work");
+    for i in 0..WORK_ITERATIONS {
+        acc = acc
+            .wrapping_mul(6364136223846793061)
+            .wrapping_add(i as u64 | 1);
+    }
+    acc
+}
+
+/// Calls `do_work` `n` times, chaining the output of each call as the input of the next.
+fn compute_work(n: u32) -> Vec<u8> {
+    let mut val: u64 = n as u64;
+    for _ in 0..n {
+        val = do_work(val);
+    }
+    val.to_le_bytes().to_vec()
+}
+
+/// Same computation as [`compute_work`], but yields periodically so the
+/// executor can drive UX flows concurrently.
+async fn compute_work_yielding(n: u32) -> Vec<u8> {
+    let mut val: u64 = n as u64;
+    for _ in 0..n {
+        val = do_work(val);
+        yield_now().await;
+    }
+    val.to_le_bytes().to_vec()
+}
+
+#[cfg(not(test))]
+async fn show_ui(app: &mut App) -> bool {
+    app.show_confirm_reject(
+        "Do you want to do the thing?",
+        "Make sure you want to do it.",
+        "Do it!",
+        "Reject",
+    )
+    .await
+}
+
+#[cfg(test)]
+async fn show_ui(_app: &mut App) -> bool {
+    true
+}
+
+/// Does all work first (blocking), then shows the UI.
+async fn do_work_sync(app: &mut App, n: u32) -> Vec<u8> {
+    app.show_spinner("Processing...");
+
+    let result = compute_work(n);
+    let approved = show_ui(app).await;
+
+    if approved {
+        app.show_info(Icon::Success, "The thing was done!");
+        result
+    } else {
+        app.show_info(Icon::Failure, "No thing done.");
+        vec![]
+    }
+}
+
+/// Spawns work in a background task, shows the UI concurrently,
+/// then waits for the worker to complete and shows a message.
+async fn do_work_async(app: &mut App, n: u32) -> Vec<u8> {
+    let handle = app.spawn_task(async move { compute_work_yielding(n).await });
+
+    let approved = show_ui(app).await;
+
+    if approved {
+        let result = app.await_task("Processing...", handle);
+        app.show_info(Icon::Success, "The thing was done!");
+        result
+    } else {
+        drop(handle); // cancels the background task immediately
+        app.show_info(Icon::Failure, "No thing done.");
+        vec![]
+    }
+}
+
+#[sdk::handler]
+async fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
+    if msg.is_empty() {
+        sdk::exit(0);
+    }
+
+    let command: Command = match postcard::from_bytes(msg) {
+        Ok(cmd) => cmd,
+        Err(_) => return vec![], // Return an empty response on error
+    };
+
+    match command {
+        Command::DoWorkSync { n } => do_work_sync(app, n).await,
+        Command::DoWorkAsync { n } => do_work_async(app, n).await,
+    }
+}
+
+pub fn main() {
+    AppBuilder::new("Async", env!("CARGO_PKG_VERSION"), process_message)
+        .description("Async Work Example")
+        .run();
+}

--- a/apps/async/app/src/main.rs
+++ b/apps/async/app/src/main.rs
@@ -10,8 +10,10 @@ use client::Command;
 sdk::bootstrap!();
 
 /// Number of inner iterations per `do_work` call.
-/// Tune this constant so that a single `do_work` call takes ~0.2 s.
-const WORK_ITERATIONS: u32 = 100_000;
+/// Tune this constant so that a single `do_work` call takes ~0.1-0.2s.
+const WORK_ITERATIONS: u32 = 100_000; // on speculos
+
+// const WORK_ITERATIONS: u32 = 2_250; // on the real device
 
 /// A single unit of pure local computation.
 /// Performs `WORK_ITERATIONS` arithmetic steps on `value` and returns the result.

--- a/apps/async/client/.cargo/config.toml
+++ b/apps/async/client/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"

--- a/apps/async/client/Cargo.toml
+++ b/apps/async/client/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "vnd-async-client"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["client", "target_all"]
+client = ["dep:tokio", "dep:clap"]
+target_native = ["dep:sdk", "sdk/target_native"]
+target_vanadium_ledger = ["dep:sdk", "sdk/target_vanadium_ledger"]
+target_all = ["dep:sdk", "sdk/target_all"]
+speculos-tests = []
+
+[dependencies]
+# Dependencies used in the 'common' part of this crate, used without the 'client' feature.
+# They must compile in no_std
+postcard = { version = "1.1.1", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.215", default-features = false, features = ["alloc", "derive"] }
+
+# All the following dependencies are only present if the 'client' feature is enabled.
+# They do not require no_std
+clap = { version = "4.5.17", features = ["derive"], optional = true }
+sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk", optional = true }
+
+tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"], optional = true }
+
+[lib]
+name = "vnd_async_client"
+path = "src/lib.rs"
+
+[[bin]]
+name = "vnd_async_cli"
+path = "src/main.rs"
+
+
+[workspace]

--- a/apps/async/client/src/client.rs
+++ b/apps/async/client/src/client.rs
@@ -1,0 +1,47 @@
+use crate::Command;
+
+use alloc::vec::Vec;
+use sdk::{
+    comm::{send_message, SendMessageError},
+    vanadium_client::{VAppExecutionError, VAppTransport},
+};
+
+pub struct Client {
+    vapp_transport: Box<dyn VAppTransport + Send>,
+}
+
+impl Client {
+    pub fn new(vapp_transport: Box<dyn VAppTransport + Send>) -> Self {
+        Self { vapp_transport }
+    }
+
+    pub async fn do_work_sync(
+        &mut self,
+        n: u32,
+    ) -> Result<Vec<u8>, Box<dyn core::error::Error>> {
+        let command = Command::DoWorkSync { n };
+        let msg = postcard::to_allocvec(&command).map_err(|_| "Serialization failed")?;
+        let response = send_message(&mut self.vapp_transport, &msg).await?;
+        Ok(response)
+    }
+
+    pub async fn do_work_async(
+        &mut self,
+        n: u32,
+    ) -> Result<Vec<u8>, Box<dyn core::error::Error>> {
+        let command = Command::DoWorkAsync { n };
+        let msg = postcard::to_allocvec(&command).map_err(|_| "Serialization failed")?;
+        let response = send_message(&mut self.vapp_transport, &msg).await?;
+        Ok(response)
+    }
+
+    pub async fn exit(&mut self) -> Result<i32, Box<dyn core::error::Error>> {
+        match send_message(&mut self.vapp_transport, &[]).await {
+            Ok(_) => Err("Exit message shouldn't return!".into()),
+            Err(SendMessageError::VAppExecutionError(VAppExecutionError::AppExited(code))) => {
+                Ok(code)
+            }
+            Err(_) => Err("Unexpected error".into()),
+        }
+    }
+}

--- a/apps/async/client/src/common.rs
+++ b/apps/async/client/src/common.rs
@@ -1,0 +1,9 @@
+extern crate alloc;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum Command {
+    DoWorkSync { n: u32 },
+    DoWorkAsync { n: u32 },
+}

--- a/apps/async/client/src/lib.rs
+++ b/apps/async/client/src/lib.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(not(feature = "client"), no_std)]
+
+extern crate alloc;
+
+mod common;
+pub use common::Command;
+
+#[cfg(feature = "client")]
+mod client;
+
+#[cfg(feature = "client")]
+pub use client::*;

--- a/apps/async/client/src/main.rs
+++ b/apps/async/client/src/main.rs
@@ -1,0 +1,82 @@
+use clap::Parser;
+use vnd_async_client::Client;
+
+use sdk::{
+    linewriter::FileLineWriter,
+    vanadium_client::client_utils::{create_default_client, ClientType},
+};
+use std::io::BufRead;
+
+#[derive(Parser)]
+#[command(name = "Async", about = "Run the Async V-App on Vanadium")]
+struct Args {
+    /// Path to the ELF file of the V-App (if not the default one)
+    app: Option<String>,
+
+    /// Use the HID interface for a real device, instead of Speculos
+    #[arg(long, group = "interface")]
+    hid: bool,
+
+    /// Use Speculos emulator interface
+    #[arg(long, group = "interface")]
+    sym: bool,
+
+    /// Use the native interface
+    #[arg(long, group = "interface")]
+    native: bool,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let client_type = if args.hid {
+        ClientType::Hid
+    } else if args.native {
+        ClientType::Native
+    } else if args.sym {
+        ClientType::Tcp
+    } else {
+        ClientType::Any
+    };
+    let print_writer = Box::new(FileLineWriter::new("print.log", true, true));
+    let mut client = Client::new(
+        create_default_client("vnd-async", client_type, Some(print_writer), false).await?,
+    );
+
+    loop {
+        println!("Enter '<repetitions> sync|async' (or empty line to quit):");
+        let mut msg = String::new();
+        std::io::stdin()
+            .lock()
+            .read_line(&mut msg)
+            .expect("Failed to read line");
+
+        let msg = msg.trim().to_string();
+        if msg.is_empty() {
+            break;
+        }
+
+        let mut parts = msg.splitn(2, ' ');
+        let n: u32 = match parts.next().unwrap_or("").parse() {
+            Ok(num) => num,
+            Err(_) => {
+                println!("Invalid input. Expected format: '<number> sync|async'");
+                continue;
+            }
+        };
+        let mode = parts.next().unwrap_or("").trim();
+
+        let _response = if mode.eq_ignore_ascii_case("sync") {
+            client.do_work_sync(n).await?
+        } else if mode.eq_ignore_ascii_case("async") {
+            client.do_work_async(n).await?
+        } else {
+            println!("Invalid mode '{}'. Expected 'sync' or 'async'.", mode);
+            continue;
+        };
+    }
+    let exit_code = client.exit().await?;
+    println!("V-App exited with code: {}", exit_code);
+    Ok(())
+}

--- a/apps/async/vapp.code-workspace
+++ b/apps/async/vapp.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "./app"
+    },
+    {
+      "path": "./client"
+    }
+  ]
+}

--- a/apps/bitcoin/README.md
+++ b/apps/bitcoin/README.md
@@ -29,7 +29,7 @@ The `client` is a library crate (see [lib.rs](client/src/lib.rs)), but it also h
 In order to build the app for the Risc-V target, enter the `app` folder and run:
 
    ```sh
-   cargo build --release --target=riscv32imc-unknown-none-elf
+   cargo build --release --target=riscv32imac-unknown-none-elf
    ```
 
 ### Native

--- a/apps/bitcoin/app/src/handlers/get_address.rs
+++ b/apps/bitcoin/app/src/handlers/get_address.rs
@@ -7,7 +7,7 @@ use common::{
 use common::errors::Error;
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -> bool {
+async fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -> bool {
     use alloc::vec;
     use sdk::ux::{Icon, TagValue};
 
@@ -31,14 +31,16 @@ fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -
     } else {
         ("Verify Bitcoin", "address")
     };
-    let approved = app.review_pairs(
-        intro_text,
-        intro_subtext,
-        &pairs,
-        "The address is correct",
-        "Confirm",
-        false,
-    );
+    let approved = app
+        .review_pairs(
+            intro_text,
+            intro_subtext,
+            &pairs,
+            "The address is correct",
+            "Confirm",
+            false,
+        )
+        .await;
 
     if approved {
         app.show_info(Icon::Success, "Address verified");
@@ -50,11 +52,11 @@ fn display_address(app: &mut sdk::App, account_name: Option<&str>, addr: &str) -
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_address(_app: &mut sdk::App, _account_name: Option<&str>, _addr: &str) -> bool {
+async fn display_address(_app: &mut sdk::App, _account_name: Option<&str>, _addr: &str) -> bool {
     true
 }
 
-pub fn handle_get_address(
+pub async fn handle_get_address(
     app: &mut sdk::App,
     name: Option<&str>,
     account: &common::message::Account,
@@ -91,7 +93,7 @@ pub fn handle_get_address(
         .map_err(|_| Error::InvalidWalletPolicy)?;
 
     if display {
-        if !display_address(app, name, &address) {
+        if !display_address(app, name, &address).await {
             return Err(Error::UserRejected);
         }
     }
@@ -139,7 +141,7 @@ mod tests {
         let hmac =
             ProofOfRegistration::new(&wallet_policy.get_id(account_name)).dangerous_as_bytes();
 
-        let resp = handle_get_address(
+        let resp = sdk::executor::block_on(handle_get_address(
             &mut sdk::App::singleton(),
             Some(account_name),
             &account,
@@ -149,7 +151,7 @@ mod tests {
                 address_index: 0,
             }),
             false,
-        )
+        ))
         .unwrap();
 
         assert_eq!(

--- a/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
+++ b/apps/bitcoin/app/src/handlers/get_extended_pubkey.rs
@@ -25,7 +25,7 @@ fn get_pubkey_fingerprint(pubkey: &EcfpPublicKey<Secp256k1, 32>) -> u32 {
 }
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
+async fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
     use alloc::{string::ToString, vec};
     use sdk::ux::{Icon, TagValue};
 
@@ -38,23 +38,25 @@ fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
         ("Verify Bitcoin", "extended public key")
     };
 
-    let approved = app.review_pairs(
-        intro_text,
-        intro_subtext,
-        &vec![
-            TagValue {
-                tag: "Path".into(),
-                value: path.to_string(),
-            },
-            TagValue {
-                tag: "Public key".into(),
-                value: xpub.into(),
-            },
-        ],
-        "Verify public key",
-        "Confirm",
-        false,
-    );
+    let approved = app
+        .review_pairs(
+            intro_text,
+            intro_subtext,
+            &vec![
+                TagValue {
+                    tag: "Path".into(),
+                    value: path.to_string(),
+                },
+                TagValue {
+                    tag: "Public key".into(),
+                    value: xpub.into(),
+                },
+            ],
+            "Verify public key",
+            "Confirm",
+            false,
+        )
+        .await;
     if approved {
         app.show_info(Icon::Success, "Public key verified");
     } else {
@@ -65,11 +67,11 @@ fn display_xpub(app: &mut sdk::App, xpub: &str, path: &[u32]) -> bool {
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_xpub(_app: &mut sdk::App, _xpub: &str, _path: &[u32]) -> bool {
+async fn display_xpub(_app: &mut sdk::App, _xpub: &str, _path: &[u32]) -> bool {
     true
 }
 
-pub fn handle_get_extended_pubkey(
+pub async fn handle_get_extended_pubkey(
     app: &mut sdk::App,
     bip32_path: &common::message::Bip32Path,
     display: bool,
@@ -114,7 +116,7 @@ pub fn handle_get_extended_pubkey(
 
     if display {
         let xpub_base58 = bitcoin::base58::encode_check(&xpub);
-        if !display_xpub(app, &xpub_base58, &bip32_path.0) {
+        if !display_xpub(app, &xpub_base58, &bip32_path.0).await {
             return Err(Error::UserRejected);
         }
     }
@@ -189,11 +191,11 @@ mod tests {
         for (path, expected_xpub) in testcases {
             // decode the derivation path into a Vec<u32>
 
-            let response = handle_get_extended_pubkey(
+            let response = sdk::executor::block_on(handle_get_extended_pubkey(
                 &mut sdk::App::singleton(),
                 &common::message::Bip32Path(parse_derivation_path(path).unwrap()),
                 false,
-            )
+            ))
             .unwrap();
 
             assert_eq!(

--- a/apps/bitcoin/app/src/handlers/register_account.rs
+++ b/apps/bitcoin/app/src/handlers/register_account.rs
@@ -6,7 +6,7 @@ use common::{
 };
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_wallet_policy(
+async fn display_wallet_policy(
     app: &mut sdk::App,
     name: &str,
     wallet_policy: &bip388::WalletPolicy,
@@ -37,14 +37,16 @@ fn display_wallet_policy(
     } else {
         ("Register Bitcoin", "account")
     };
-    let approved = app.review_pairs(
-        intro_text,
-        intro_subtext,
-        &pairs,
-        "Confirm registration",
-        "Register",
-        false,
-    );
+    let approved = app
+        .review_pairs(
+            intro_text,
+            intro_subtext,
+            &pairs,
+            "Confirm registration",
+            "Register",
+            false,
+        )
+        .await;
 
     if approved {
         app.show_info(Icon::Success, "Account registered");
@@ -56,7 +58,7 @@ fn display_wallet_policy(
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_wallet_policy(
+async fn display_wallet_policy(
     _app: &mut sdk::App,
     _name: &str,
     _wallet_policy: &bip388::WalletPolicy,
@@ -64,7 +66,7 @@ fn display_wallet_policy(
     true
 }
 
-pub fn handle_register_account(
+pub async fn handle_register_account(
     app: &mut sdk::App,
     name: &str,
     account: &common::message::Account,
@@ -74,7 +76,7 @@ pub fn handle_register_account(
 
     // TODO: necessary sanity checks on the wallet policy
 
-    if !display_wallet_policy(app, name, &wallet_policy) {
+    if !display_wallet_policy(app, name, &wallet_policy).await {
         return Err(Error::UserRejected);
     }
 
@@ -128,7 +130,11 @@ mod tests {
         let wallet_policy: bip388::WalletPolicy = (&account).try_into().unwrap();
         let expected_account_id = wallet_policy.get_id(account_name);
 
-        let resp = handle_register_account(&mut sdk::App::singleton(), account_name, &account);
+        let resp = sdk::executor::block_on(handle_register_account(
+            &mut sdk::App::singleton(),
+            account_name,
+            &account,
+        ));
 
         assert_eq!(
             resp,

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -37,37 +37,39 @@ use crate::constants::COIN_TICKER;
 use sdk::ux::Icon;
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_warning_high_fee(app: &mut sdk::App, fee_percent: u64) -> bool {
+async fn display_warning_high_fee(app: &mut sdk::App, fee_percent: u64) -> bool {
     app.show_confirm_reject(
         "High fees",
         &format!("Transaction fee fraction is higher than {}%", fee_percent),
         "Continue",
         "Reject",
     )
+    .await
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_warning_high_fee(_app: &mut sdk::App, _fee_percent: u64) -> bool {
+async fn display_warning_high_fee(_app: &mut sdk::App, _fee_percent: u64) -> bool {
     true
 }
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_warning_unverified_inputs(app: &mut sdk::App) -> bool {
+async fn display_warning_unverified_inputs(app: &mut sdk::App) -> bool {
     app.show_confirm_reject(
         "Unverified inputs",
         "Some inputs could not be verified.\nReject if you're not sure.",
         "Continue",
         "Reject",
     )
+    .await
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_warning_unverified_inputs(_app: &mut sdk::App) -> bool {
+async fn display_warning_unverified_inputs(_app: &mut sdk::App) -> bool {
     true
 }
 
 #[cfg(not(any(test, feature = "autoapprove")))]
-fn display_transaction(app: &mut sdk::App, pairs: &[TagValue]) -> bool {
+async fn display_transaction(app: &mut sdk::App, pairs: &[TagValue]) -> bool {
     // message on speculos or real device
 
     let button_text = if sdk::ux::has_page_api() {
@@ -89,10 +91,11 @@ fn display_transaction(app: &mut sdk::App, pairs: &[TagValue]) -> bool {
         button_text,
         true,
     )
+    .await
 }
 
 #[cfg(any(test, feature = "autoapprove"))]
-fn display_transaction(_app: &mut sdk::App, _pairs: &[TagValue]) -> bool {
+async fn display_transaction(_app: &mut sdk::App, _pairs: &[TagValue]) -> bool {
     true
 }
 
@@ -203,7 +206,7 @@ fn sign_input_schnorr(
     })
 }
 
-pub fn handle_sign_psbt(app: &mut sdk::App, psbt: &[u8]) -> Result<Response, Error> {
+pub async fn handle_sign_psbt(app: &mut sdk::App, psbt: &[u8]) -> Result<Response, Error> {
     app.show_spinner("Processing...");
 
     let psbt = fastpsbt::Psbt::parse(&psbt).map_err(|_| Error::FailedToDeserializePsbt)?;
@@ -421,14 +424,14 @@ pub fn handle_sign_psbt(app: &mut sdk::App, psbt: &[u8]) -> Result<Response, Err
     // show necessary warnings
 
     if warn_unverified_inputs {
-        if !display_warning_unverified_inputs(app) {
+        if !display_warning_unverified_inputs(app).await {
             return Err(Error::UserRejected);
         }
     }
     if inputs_total_amount >= crate::constants::THRESHOLD_WARN_HIGH_FEES_AMOUNT {
         let fee_percent = fee.saturating_mul(100) / inputs_total_amount;
         if fee_percent >= crate::constants::THRESHOLD_WARN_HIGH_FEES_PERCENT {
-            if !display_warning_high_fee(app, fee_percent) {
+            if !display_warning_high_fee(app, fee_percent).await {
                 return Err(Error::UserRejected);
             }
         }
@@ -520,7 +523,7 @@ pub fn handle_sign_psbt(app: &mut sdk::App, psbt: &[u8]) -> Result<Response, Err
         value: format!("{} {}", fee, COIN_TICKER),
     });
 
-    if !display_transaction(app, &pairs) {
+    if !display_transaction(app, &pairs).await {
         #[cfg(not(any(test, feature = "autoapprove")))]
         app.show_info(Icon::Failure, "Transaction rejected");
 
@@ -682,8 +685,11 @@ mod tests {
 
         prepare_psbt(&mut psbt, &[(&wallet_policy, account_name, &por)]).unwrap();
 
-        let response =
-            handle_sign_psbt(&mut sdk::App::singleton(), &serialize_as_psbtv2(&psbt)).unwrap();
+        let response = sdk::executor::block_on(handle_sign_psbt(
+            &mut sdk::App::singleton(),
+            &serialize_as_psbtv2(&psbt),
+        ))
+        .unwrap();
 
         assert_eq!(response, Response::PsbtSigned(vec![
             PartialSignature {
@@ -711,8 +717,11 @@ mod tests {
             ProofOfRegistration::new(&wallet_policy.get_id(account_name)).dangerous_as_bytes();
         prepare_psbt(&mut psbt, &[(&wallet_policy, &account_name, &por)]).unwrap();
 
-        let response =
-            handle_sign_psbt(&mut sdk::App::singleton(), &serialize_as_psbtv2(&psbt)).unwrap();
+        let response = sdk::executor::block_on(handle_sign_psbt(
+            &mut sdk::App::singleton(),
+            &serialize_as_psbtv2(&psbt),
+        ))
+        .unwrap();
 
         assert_eq!(response, Response::PsbtSigned(vec![
             PartialSignature {
@@ -741,8 +750,11 @@ mod tests {
             ProofOfRegistration::new(&wallet_policy.get_id(account_name)).dangerous_as_bytes();
         prepare_psbt(&mut psbt, &[(&wallet_policy, &account_name, &por)]).unwrap();
 
-        let response =
-            handle_sign_psbt(&mut sdk::App::singleton(), &serialize_as_psbtv2(&psbt)).unwrap();
+        let response = sdk::executor::block_on(handle_sign_psbt(
+            &mut sdk::App::singleton(),
+            &serialize_as_psbtv2(&psbt),
+        ))
+        .unwrap();
 
         let Response::PsbtSigned(partial_signatures) = response else {
             panic!("Expected PsbtSigned response");

--- a/apps/bitcoin/app/src/main.rs
+++ b/apps/bitcoin/app/src/main.rs
@@ -14,32 +14,40 @@ use sdk::{App, AppBuilder};
 
 sdk::bootstrap!();
 
-fn handle_request(app: &mut App, request: &Request) -> Result<Response, common::errors::Error> {
+async fn handle_request(
+    app: &mut App,
+    request: &Request,
+) -> Result<Response, common::errors::Error> {
     match request {
         Request::GetVersion => todo!(),
         Request::Exit => sdk::exit(0),
         Request::GetMasterFingerprint => handle_get_master_fingerprint(app),
         Request::GetExtendedPubkey { path, display } => {
-            handle_get_extended_pubkey(app, path, *display)
+            handle_get_extended_pubkey(app, path, *display).await
         }
-        Request::RegisterAccount { name, account } => handle_register_account(app, name, account),
+        Request::RegisterAccount { name, account } => {
+            handle_register_account(app, name, account).await
+        }
         Request::GetAddress {
             name,
             account,
             por,
             coordinates,
             display,
-        } => handle_get_address(app, name.as_deref(), account, por, coordinates, *display),
-        Request::SignPsbt { psbt } => handle_sign_psbt(app, psbt),
+        } => handle_get_address(app, name.as_deref(), account, por, coordinates, *display).await,
+        Request::SignPsbt { psbt } => handle_sign_psbt(app, psbt).await,
     }
 }
 
-fn process_message(app: &mut App, request: &[u8]) -> Vec<u8> {
+#[sdk::handler]
+async fn process_message(app: &mut App, request: &[u8]) -> Vec<u8> {
     let Ok(request) = postcard::from_bytes(request) else {
         return postcard::to_allocvec(&Response::Error(common::errors::Error::InvalidRequest))
             .unwrap();
     };
-    let response = handle_request(app, &request).unwrap_or_else(|e| Response::Error(e));
+    let response = handle_request(app, &request)
+        .await
+        .unwrap_or_else(|e| Response::Error(e));
     postcard::to_allocvec(&response).unwrap()
 }
 

--- a/apps/rps/README.md
+++ b/apps/rps/README.md
@@ -16,7 +16,7 @@ Risc-V and the native binaries.
 In order to build the app for the Risc-V target, enter the `app` folder and run:
 
    ```sh
-   cargo build --release --target=riscv32imc-unknown-none-elf
+   cargo build --release --target=riscv32imac-unknown-none-elf
    ```
 
 ### Native

--- a/apps/rps/app/src/main.rs
+++ b/apps/rps/app/src/main.rs
@@ -33,7 +33,7 @@ fn display_move(move_num: u8) -> &'static str {
 // Shows the game summary and the app's chosen move
 // Returns true if the user accepts
 #[cfg(not(test))]
-fn show_game_ui(app: &mut App<RPSGame>, c_a: &[u8; 32], m_b: u8) -> bool {
+async fn show_game_ui(app: &mut App<RPSGame>, c_a: &[u8; 32], m_b: u8) -> bool {
     app.show_confirm_reject(
         "Game started",
         &format!(
@@ -43,11 +43,11 @@ fn show_game_ui(app: &mut App<RPSGame>, c_a: &[u8; 32], m_b: u8) -> bool {
         ),
         "Continue game",
         "Cancel",
-    )
+    ).await
 }
 
 #[cfg(test)]
-fn show_game_ui(_app: &mut App<RPSGame>, _c_a: &[u8; 32], _m_b: u8) -> bool {
+async fn show_game_ui(_app: &mut App<RPSGame>, _c_a: &[u8; 32], _m_b: u8) -> bool {
     true
 }
 
@@ -106,11 +106,11 @@ pub enum Command {
     Reveal { m_a: u8, r_a: [u8; 32] },
 }
 
-fn process_commit_command(app: &mut App<RPSGame>, c_a: [u8; 32]) -> Vec<u8> {
+async fn process_commit_command(app: &mut App<RPSGame>, c_a: [u8; 32]) -> Vec<u8> {
     // Generate a uniform random move in [0, 2]
     let m_b = random_move();
 
-    if show_game_ui(app, &c_a, m_b) {
+    if show_game_ui(app, &c_a, m_b).await {
         // Create a new game only if accepted
         app.state = RPSGame {
             is_game_active: true,
@@ -151,7 +151,8 @@ fn process_reveal_command(app: &mut App<RPSGame>, m_a: u8, r_a: [u8; 32]) -> Vec
     vec![winner]
 }
 
-fn process_message(app: &mut App<RPSGame>, msg: &[u8]) -> Vec<u8> {
+#[sdk::handler]
+async fn process_message(app: &mut App<RPSGame>, msg: &[u8]) -> Vec<u8> {
     if msg.is_empty() {
         sdk::exit(0);
     }
@@ -163,12 +164,12 @@ fn process_message(app: &mut App<RPSGame>, msg: &[u8]) -> Vec<u8> {
 
     match command {
         Command::Commit { c_a } => {
-            let to_send = process_commit_command(app, c_a);
+            let to_send = process_commit_command(app, c_a).await;
             if to_send.is_empty() {
                 return vec![];
             }
             app.show_spinner("Waiting for Alice");
-            let response = match app.exchange(&to_send) {
+            let response = match app.exchange(&to_send).await {
                 Ok(resp) => resp,
                 Err(_) => return vec![],
             };
@@ -206,7 +207,7 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let res = process_commit_command(&mut app, c_a);
+        let res = sdk::executor::block_on(process_commit_command(&mut app, c_a));
         assert!(res.len() == 1);
         let m_b = res[0];
         assert!(m_b <= 2, "Invalid move: {}", m_b);

--- a/apps/sadik/README.md
+++ b/apps/sadik/README.md
@@ -13,7 +13,7 @@ The [client/tests](client/tests) folder contains integration tests to run with S
 In order to build the app for the Risc-V target, enter the `app` folder and run:
 
    ```sh
-   cargo build --release --target=riscv32imc-unknown-none-elf
+   cargo build --release --target=riscv32imac-unknown-none-elf
    ```
 
 ### Native

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -267,7 +267,7 @@ fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
         Command::Sleep { n_ticks } => {
             let mut count = 0;
             loop {
-                match sdk::ux::get_event() {
+                match sdk::executor::block_on(sdk::ux::get_event()) {
                     sdk::ux::Event::Ticker => {
                         count += 1;
                         if count == n_ticks {

--- a/apps/sadik/app/src/main.rs
+++ b/apps/sadik/app/src/main.rs
@@ -40,7 +40,8 @@ fn parse_pubkey(pubkey: &[u8]) -> EcfpPublicKey<sdk::curve::Secp256k1, 32> {
     )
 }
 
-fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
+#[sdk::handler]
+async fn process_message(_app: &mut App, msg: &[u8]) -> Vec<u8> {
     let command: Command = postcard::from_bytes(&msg).expect("Deserialization failed");
 
     let response: Vec<u8> = match command {

--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -15,7 +15,7 @@ Risc-V and the native binaries.
 In order to build the app for the Risc-V target, enter the `app` folder and run:
 
    ```sh
-   cargo build --release --target=riscv32imc-unknown-none-elf
+   cargo build --release --target=riscv32imac-unknown-none-elf
    ```
 
 ### Native

--- a/apps/template/app/src/main.rs
+++ b/apps/template/app/src/main.rs
@@ -20,7 +20,7 @@ const H: u32 = 0x80000000u32;
 
 // Shows the message to the user and asks for confirmation to sign
 #[cfg(not(test))]
-fn show_message_ui(app: &mut App, msg: &str) -> bool {
+async fn show_message_ui(app: &mut App, msg: &str) -> bool {
     use alloc::format;
 
     let approved = app.show_confirm_reject(
@@ -28,23 +28,23 @@ fn show_message_ui(app: &mut App, msg: &str) -> bool {
         &format!("Message: {}", msg),
         "Sign message",
         "Reject",
-    );
+    ).await;
 
     approved
 }
 
 #[cfg(test)]
-fn show_message_ui(_app: &mut App, _msg: &str) -> bool {
+async fn show_message_ui(_app: &mut App, _msg: &str) -> bool {
     true
 }
 
-fn process_sign_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
+async fn process_sign_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     let msg_str = match from_utf8(msg) {
         Ok(m) => m,
         Err(_) => return vec![],
     };
 
-    if show_message_ui(app, msg_str) {
+    if show_message_ui(app, msg_str).await {
         let path: Vec<u32> = [H + 9999].to_vec();
         let hd_node = sdk::curve::Secp256k1::derive_hd_node(&path).expect("This shouldn't happen");
         let privkey: EcfpPrivateKey<sdk::curve::Secp256k1, 32> = EcfpPrivateKey::new(
@@ -66,7 +66,8 @@ fn process_sign_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     }
 }
 
-fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
+#[sdk::handler]
+async fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     if msg.is_empty() {
         sdk::exit(0);
     }
@@ -77,7 +78,7 @@ fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     };
 
     match command {
-        Command::SignMessage { msg } => process_sign_message(app, &msg),
+        Command::SignMessage { msg } => process_sign_message(app, &msg).await,
     }
 }
 
@@ -99,7 +100,7 @@ mod tests {
 
         let msg = b"Hello, Vanadium!";
         let msg_hash = sdk::hash::Sha256::hash(msg);
-        let sig = process_sign_message(&mut app, msg);
+        let sig = sdk::executor::block_on(process_sign_message(&mut app, msg));
 
         let path: Vec<u32> = [H + 9999].to_vec();
         let hd_node = sdk::curve::Secp256k1::derive_hd_node(&path).expect("This shouldn't happen");

--- a/apps/template/generate/README.md
+++ b/apps/template/generate/README.md
@@ -15,7 +15,7 @@ Risc-V and the native binaries.
 In order to build the app for the Risc-V target, enter the `app` folder and run:
 
    ```sh
-   cargo build --release --target=riscv32imc-unknown-none-elf
+   cargo build --release --target=riscv32imac-unknown-none-elf
    ```
 
 ### Native

--- a/apps/template/generate/app/src/main.rs
+++ b/apps/template/generate/app/src/main.rs
@@ -20,7 +20,7 @@ const H: u32 = 0x80000000u32;
 
 // Shows the message to the user and asks for confirmation to sign
 #[cfg(not(test))]
-fn show_message_ui(app: &mut App, msg: &str) -> bool {
+async fn show_message_ui(app: &mut App, msg: &str) -> bool {
     use alloc::format;
 
     let approved = app.show_confirm_reject(
@@ -28,23 +28,23 @@ fn show_message_ui(app: &mut App, msg: &str) -> bool {
         &format!("Message: {}", msg),
         "Sign message",
         "Reject",
-    );
+    ).await;
 
     approved
 }
 
 #[cfg(test)]
-fn show_message_ui(_app: &mut App, _msg: &str) -> bool {
+async fn show_message_ui(_app: &mut App, _msg: &str) -> bool {
     true
 }
 
-fn process_sign_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
+async fn process_sign_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     let msg_str = match from_utf8(msg) {
         Ok(m) => m,
         Err(_) => return vec![],
     };
 
-    if show_message_ui(app, msg_str) {
+    if show_message_ui(app, msg_str).await {
         let path: Vec<u32> = [H + 9999].to_vec();
         let hd_node = sdk::curve::Secp256k1::derive_hd_node(&path).expect("This shouldn't happen");
         let privkey: EcfpPrivateKey<sdk::curve::Secp256k1, 32> = EcfpPrivateKey::new(
@@ -66,7 +66,8 @@ fn process_sign_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     }
 }
 
-fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
+#[sdk::handler]
+async fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     if msg.is_empty() {
         sdk::exit(0);
     }
@@ -77,7 +78,7 @@ fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
     };
 
     match command {
-        Command::SignMessage { msg } => process_sign_message(app, &msg),
+        Command::SignMessage { msg } => process_sign_message(app, &msg).await,
     }
 }
 
@@ -99,7 +100,7 @@ mod tests {
 
         let msg = b"Hello, Vanadium!";
         let msg_hash = sdk::hash::Sha256::hash(msg);
-        let sig = process_sign_message(&mut app, msg);
+        let sig = sdk::executor::block_on(process_sign_message(&mut app, msg));
 
         let path: Vec<u32> = [H + 9999].to_vec();
         let hd_node = sdk::curve::Secp256k1::derive_hd_node(&path).expect("This shouldn't happen");

--- a/apps/test/app/src/handlers/show_ux_screen.rs
+++ b/apps/test/app/src/handlers/show_ux_screen.rs
@@ -1,4 +1,5 @@
 use alloc::{vec, vec::Vec};
+use sdk::executor::block_on;
 
 pub fn handle_show_ux_screen(data: &[u8]) -> Vec<u8> {
     if data.len() != 1 {
@@ -8,22 +9,27 @@ pub fn handle_show_ux_screen(data: &[u8]) -> Vec<u8> {
     let screen_id = data[0];
     match screen_id {
         0 => {
-            sdk::ux::show_info(sdk::ux::Icon::Success, "Oh yeah!");
-            sdk::ux::wait(10);
+            block_on(sdk::ux::show_info(sdk::ux::Icon::Success, "Oh yeah!"));
+            block_on(sdk::ux::wait(10));
         }
         1 => {
-            sdk::ux::show_info(sdk::ux::Icon::Failure, "Oh no!");
-            sdk::ux::wait(10);
+            block_on(sdk::ux::show_info(sdk::ux::Icon::Failure, "Oh no!"));
+            block_on(sdk::ux::wait(10));
         }
         2 => {
             sdk::ux::show_spinner("Loading...");
-            sdk::ux::wait(10);
+            block_on(sdk::ux::wait(10));
         }
         3 => {
-            sdk::ux::show_confirm_reject("Confirm", "Do you want to confirm?", "Yes", "No");
+            block_on(sdk::ux::show_confirm_reject(
+                "Confirm",
+                "Do you want to confirm?",
+                "Yes",
+                "No",
+            ));
         }
         4 => {
-            sdk::ux::review_pairs(
+            block_on(sdk::ux::review_pairs(
                 "Review the pairs",
                 "It's important",
                 &vec![
@@ -51,7 +57,7 @@ pub fn handle_show_ux_screen(data: &[u8]) -> Vec<u8> {
                 "Hope you checked",
                 "Confirm",
                 true,
-            );
+            ));
         }
         _ => panic!("Unknown screen id"),
     }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = "2.0"
+syn = { version = "2.0", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-error2 = { version = "2.0", default-features = false }

--- a/macros/src/handler.rs
+++ b/macros/src/handler.rs
@@ -1,0 +1,73 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse2, FnArg, ItemFn, Lifetime, ReturnType, Type};
+
+/// Rewrite the top-level reference in a parameter type to use `'a`.
+fn inject_lifetime(arg: &FnArg) -> FnArg {
+    match arg {
+        FnArg::Typed(pat_type) => {
+            let ty = &*pat_type.ty;
+            if let Type::Reference(type_ref) = ty {
+                let mut new_ref = type_ref.clone();
+                new_ref.lifetime = Some(Lifetime::new("'a", proc_macro2::Span::call_site()));
+                let new_ty = Type::Reference(new_ref);
+                let mut new_pat_type = pat_type.clone();
+                new_pat_type.ty = Box::new(new_ty);
+                FnArg::Typed(new_pat_type)
+            } else {
+                arg.clone()
+            }
+        }
+        other => other.clone(),
+    }
+}
+
+pub fn handler_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input: ItemFn = match parse2(item) {
+        Ok(f) => f,
+        Err(e) => return e.to_compile_error(),
+    };
+
+    // Validate that the function is async
+    if input.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(&input.sig.fn_token, "#[handler] requires an async fn")
+            .to_compile_error();
+    }
+
+    // Validate that it has exactly 2 parameters
+    if input.sig.inputs.len() != 2 {
+        return syn::Error::new_spanned(
+            &input.sig.inputs,
+            "#[handler] function must have exactly 2 parameters: (&mut App<S>, &[u8])",
+        )
+        .to_compile_error();
+    }
+
+    // Extract the return type (should be Vec<u8>)
+    let ret_ty = match &input.sig.output {
+        ReturnType::Default => {
+            return syn::Error::new_spanned(&input.sig, "#[handler] function must return Vec<u8>")
+                .to_compile_error();
+        }
+        ReturnType::Type(_, ty) => ty.clone(),
+    };
+
+    let vis = &input.vis;
+    let fn_name = &input.sig.ident;
+    let attrs = &input.attrs;
+    let body = &input.block;
+
+    // Extract and rewrite the two parameters with 'a lifetime
+    let params: Vec<_> = input.sig.inputs.iter().collect();
+    let param0 = inject_lifetime(&params[0]);
+    let param1 = inject_lifetime(&params[1]);
+
+    let output = quote! {
+        #(#attrs)*
+        #vis fn #fn_name<'a>(#param0, #param1) -> ::core::pin::Pin<::alloc::boxed::Box<dyn ::core::future::Future<Output = #ret_ty> + 'a>> {
+            ::alloc::boxed::Box::pin(async move #body)
+        }
+    };
+
+    output
+}

--- a/macros/src/handler.rs
+++ b/macros/src/handler.rs
@@ -1,6 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse2, FnArg, ItemFn, Lifetime, ReturnType, Type};
+use syn::{
+    parse2, FnArg, GenericArgument, GenericParam, ItemFn, Lifetime, LifetimeParam, PathArguments,
+    ReturnType, Type,
+};
 
 /// Rewrite the top-level reference in a parameter type to use `'a`.
 fn inject_lifetime(arg: &FnArg) -> FnArg {
@@ -22,7 +25,71 @@ fn inject_lifetime(arg: &FnArg) -> FnArg {
     }
 }
 
-pub fn handler_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+/// Check that the first parameter is `&mut App<S>` (a mutable reference to App with one generic argument).
+fn is_valid_app_param(arg: &FnArg) -> bool {
+    if let FnArg::Typed(pat_type) = arg {
+        if let Type::Reference(type_ref) = &*pat_type.ty {
+            if type_ref.mutability.is_some() {
+                if let Type::Path(type_path) = &*type_ref.elem {
+                    let segs = &type_path.path.segments;
+                    if segs.len() == 1 && segs[0].ident == "App" {
+                        return matches!(
+                            segs[0].arguments,
+                            PathArguments::AngleBracketed(_) | PathArguments::None
+                        );
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Check that the second parameter is `&[u8]` (a shared reference to a byte slice).
+fn is_valid_bytes_param(arg: &FnArg) -> bool {
+    if let FnArg::Typed(pat_type) = arg {
+        if let Type::Reference(type_ref) = &*pat_type.ty {
+            if type_ref.mutability.is_none() {
+                if let Type::Slice(slice_type) = &*type_ref.elem {
+                    if let Type::Path(type_path) = &*slice_type.elem {
+                        let segs = &type_path.path.segments;
+                        return segs.len() == 1
+                            && segs[0].ident == "u8"
+                            && segs[0].arguments.is_none();
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Check that the return type is `Vec<u8>`.
+fn is_valid_return_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        let segs = &type_path.path.segments;
+        if segs.len() == 1 && segs[0].ident == "Vec" {
+            if let PathArguments::AngleBracketed(args) = &segs[0].arguments {
+                if args.args.len() == 1 {
+                    if let GenericArgument::Type(Type::Path(inner)) = &args.args[0] {
+                        let inner_segs = &inner.path.segments;
+                        return inner_segs.len() == 1
+                            && inner_segs[0].ident == "u8"
+                            && inner_segs[0].arguments.is_none();
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn handler_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new_spanned(attr, "#[handler] does not take any arguments")
+            .to_compile_error();
+    }
+
     let input: ItemFn = match parse2(item) {
         Ok(f) => f,
         Err(e) => return e.to_compile_error(),
@@ -43,13 +110,39 @@ pub fn handler_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
         .to_compile_error();
     }
 
-    // Extract the return type (should be Vec<u8>)
+    let params: Vec<_> = input.sig.inputs.iter().collect();
+
+    // Validate the first parameter is &mut App<S>
+    if !is_valid_app_param(params[0]) {
+        return syn::Error::new_spanned(
+            params[0],
+            "#[handler] first parameter must be `&mut App<S>`",
+        )
+        .to_compile_error();
+    }
+
+    // Validate the second parameter is &[u8]
+    if !is_valid_bytes_param(params[1]) {
+        return syn::Error::new_spanned(params[1], "#[handler] second parameter must be `&[u8]`")
+            .to_compile_error();
+    }
+
+    // Extract and validate the return type (must be Vec<u8>)
     let ret_ty = match &input.sig.output {
         ReturnType::Default => {
-            return syn::Error::new_spanned(&input.sig, "#[handler] function must return Vec<u8>")
-                .to_compile_error();
+            return syn::Error::new_spanned(
+                &input.sig,
+                "#[handler] function must return `Vec<u8>`",
+            )
+            .to_compile_error();
         }
-        ReturnType::Type(_, ty) => ty.clone(),
+        ReturnType::Type(_, ty) => {
+            if !is_valid_return_type(ty) {
+                return syn::Error::new_spanned(ty, "#[handler] return type must be `Vec<u8>`")
+                    .to_compile_error();
+            }
+            ty.clone()
+        }
     };
 
     let vis = &input.vis;
@@ -57,14 +150,26 @@ pub fn handler_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let attrs = &input.attrs;
     let body = &input.block;
 
-    // Extract and rewrite the two parameters with 'a lifetime
-    let params: Vec<_> = input.sig.inputs.iter().collect();
-    let param0 = inject_lifetime(&params[0]);
-    let param1 = inject_lifetime(&params[1]);
+    // Preserve existing generics/where-clause and prepend the 'a lifetime
+    let mut generics = input.sig.generics.clone();
+    generics.params.insert(
+        0,
+        GenericParam::Lifetime(LifetimeParam {
+            attrs: vec![],
+            lifetime: Lifetime::new("'a", proc_macro2::Span::call_site()),
+            colon_token: None,
+            bounds: syn::punctuated::Punctuated::new(),
+        }),
+    );
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+
+    // Rewrite the two parameters with 'a lifetime
+    let param0 = inject_lifetime(params[0]);
+    let param1 = inject_lifetime(params[1]);
 
     let output = quote! {
         #(#attrs)*
-        #vis fn #fn_name<'a>(#param0, #param1) -> ::core::pin::Pin<::alloc::boxed::Box<dyn ::core::future::Future<Output = #ret_ty> + 'a>> {
+        #vis fn #fn_name #impl_generics (#param0, #param1) -> ::core::pin::Pin<::alloc::boxed::Box<dyn ::core::future::Future<Output = #ret_ty> + 'a>> #where_clause {
             ::alloc::boxed::Box::pin(async move #body)
         }
     };

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -3,10 +3,26 @@ use proc_macro_error2::proc_macro_error;
 use syn::{DeriveInput, parse_macro_input};
 
 mod derive_serializable;
+mod handler;
 
 #[proc_macro_derive(Serializable, attributes(maker, wrapped))]
 #[proc_macro_error]
 pub fn serializable(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_serializable::derive_serializable(input).into()
+}
+
+/// Attribute macro that transforms an `async fn` into a handler compatible
+/// with the Vanadium SDK's `App` framework.
+///
+/// # Example
+/// ```ignore
+/// #[sdk::handler]
+/// async fn process_message(app: &mut App, msg: &[u8]) -> Vec<u8> {
+///     // ...
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn handler(attr: TokenStream, item: TokenStream) -> TokenStream {
+    handler::handler_impl(attr.into(), item.into()).into()
 }


### PR DESCRIPTION
This adds an `executor` for futures/async functions in the app-sdk, and migrates the UX framework and the existing V-Apps to use an `async` approach by default.

The big win of this approach is that it becomes rather easy to create 'worker tasks' that perform useful computations while the device is idle. Thanks to the Rust's futures, the executor, and some syntactic sugar, this comes at very little added complexity when writing V-Apps.

Some use cases that might be useful in order to improve tha V-Apps UX and (perceived) performance:
- Preload code in hot paths when busy waiting for commands
- Perform precomputation related to transaction signing (or pre-signing checks) while the user is verifying the transaction details.