### PR TITLE
Avoid dependencies on patched crates on vnd-bitcoin-client

### DIFF
--- a/apps/bitcoin/client/Cargo.toml
+++ b/apps/bitcoin/client/Cargo.toml
@@ -17,7 +17,7 @@ hashes   = { package = "bitcoin_hashes", version = "0.14", default-features = fa
 secp256k1 = { package = "secp256k1", version = "0.29", default-features = false }
 base58   = { package = "base58ck", version = "0.1", default-features = false }
 
-common = { package = "vnd-bitcoin-common", path = "../common"}
+common = { package = "vnd-bitcoin-common", path = "../common", default-features = false, features = ["target_native"]}
 hex = "0.4.3"
 hidapi = "2.6.3"
 sdk = { package = "vanadium-client-sdk", path = "../../../client-sdk" }
@@ -48,12 +48,3 @@ path = "src/main.rs"
 
 
 [workspace]
-
-[patch.crates-io.bitcoin_hashes]
-path = "../../../libs/bitcoin_hashes"
-[patch.crates-io.secp256k1]
-path = "../../../libs/secp256k1"
-[patch.crates-io.base58ck]
-path = "../../../libs/base58"
-[patch.crates-io.getrandom]
-path = "../../../libs/getrandom"

--- a/apps/bitcoin/common/Cargo.toml
+++ b/apps/bitcoin/common/Cargo.toml
@@ -7,15 +7,9 @@ edition = "2021"
 default = ["target_native"]
 target_native = [
     "sdk/target_native",
-    "hashes/target_native",
-    "secp256k1/target_native",
-    "base58/target_native"
 ]
 target_vanadium_ledger = [
     "sdk/target_vanadium_ledger",
-    "hashes/target_vanadium_ledger",
-    "secp256k1/target_vanadium_ledger",
-    "base58/target_vanadium_ledger"
 ]
 
 [dependencies]
@@ -39,12 +33,3 @@ opt-level = 3
 lto = true
 
 [workspace]
-
-[patch.crates-io.bitcoin_hashes]
-path = "../../../libs/bitcoin_hashes"
-[patch.crates-io.secp256k1]
-path = "../../../libs/secp256k1"
-[patch.crates-io.base58ck]
-path = "../../../libs/base58"
-[patch.crates-io.getrandom]
-path = "../../../libs/getrandom"


### PR DESCRIPTION
Patching the dependencies caused problems for any crate that imports `vnd-bitcoin-client`. Since that's in fact only needed when compiling `vnd-bitcoin`, we can avoid it by being more careful with dependency management.
