### PR TITLE
Standalone Vanadium client binary in `cargo-vnd`

### DIFF
--- a/.github/workflows/reusable_vapp_build.yaml
+++ b/.github/workflows/reusable_vapp_build.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install riscv64-unknown-elf-objcopy (cargo-vnd prerequisite)
         run: |
           sudo apt-get update && \
-          sudo apt-get install -y binutils-riscv64-unknown-elf
+          sudo apt-get install -y libudev-dev pkg-config binutils-riscv64-unknown-elf
       - name: Install cargo-vnd
         run: |
           cargo install --path ./cargo-vnd

--- a/apps/bitcoin/client/src/main.rs
+++ b/apps/bitcoin/client/src/main.rs
@@ -216,6 +216,10 @@ struct Args {
     /// Use the native interface
     #[arg(long, group = "interface")]
     native: bool,
+
+    /// Connect to a standalone vapp-server instance
+    #[arg(long, group = "interface")]
+    standalone: bool,
 }
 
 // a bit of a hack: we convert the prompt in a format that clap can parse
@@ -455,6 +459,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ClientType::Hid
     } else if args.native {
         ClientType::Native
+    } else if args.standalone {
+        ClientType::Standalone
     } else if args.sym {
         ClientType::Tcp
     } else {

--- a/cargo-vnd/Cargo.toml
+++ b/cargo-vnd/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive"] }
 common = { path = "../common", features = ["serde_json"] }
-client_sdk = { path = "../client-sdk", package="vanadium-client-sdk", features=["cargo_toml"], default-features = false }
+client_sdk = { path = "../client-sdk", package="vanadium-client-sdk", features=["cargo_toml", "transport", "target_all"], default-features = false }
 which = "7.0.3"
 cargo-generate = "0.23.7"
+tokio = { version = "1.38.1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"] }
+env_logger = "0.11"

--- a/cargo-vnd/src/main.rs
+++ b/cargo-vnd/src/main.rs
@@ -7,12 +7,15 @@ Usage:
 It can be called with no arguments if called from the folder containing the Cargo.toml file of th V-App.
 */
 
+mod serve;
+
 use anyhow::{Context, Result};
 use cargo_generate::{GenerateArgs, TemplatePath};
 use clap::{Parser, Subcommand};
 use client_sdk::elf::{VAppElfFile, get_vapp_metadata};
 use client_sdk::hash::Sha256;
 use client_sdk::memory::MemorySegment;
+use client_sdk::vanadium_client::client_utils::ClientType;
 use common::constants;
 use common::manifest::Manifest;
 use std::path::PathBuf;
@@ -53,6 +56,31 @@ enum Commands {
         /// Path to a local template directory (optional, defaults to fetching from GitHub)
         #[arg(long, value_name = "PATH")]
         template_path: Option<PathBuf>,
+    },
+    /// Run a V-App and expose it over a simple TCP interface
+    Serve {
+        /// Path to the V-App ELF binary
+        elf_path: String,
+
+        /// TCP port to listen on for client connections
+        #[arg(long, default_value = "12167")]
+        port: u16,
+
+        /// Connect to a real device via HID
+        #[arg(long, group = "device")]
+        hid: bool,
+
+        /// Connect to Speculos emulator instead of a real device
+        #[arg(long, group = "device")]
+        speculos: bool,
+
+        /// Connect to a natively-compiled V-App (the ELF binary is already running)
+        #[arg(long, group = "device")]
+        native: bool,
+
+        /// Disable HMAC-based proofs for code loading (HMACs are used by default)
+        #[arg(long)]
+        no_hmacs: bool,
     },
 }
 
@@ -153,6 +181,25 @@ fn main() -> Result<()> {
                 ..Default::default()
             };
             cargo_generate::generate(args)?;
+        }
+        Commands::Serve {
+            elf_path,
+            port,
+            hid,
+            speculos,
+            native,
+            no_hmacs,
+        } => {
+            let client_type = if hid {
+                ClientType::Hid
+            } else if speculos {
+                ClientType::Tcp
+            } else if native {
+                ClientType::Native
+            } else {
+                ClientType::Any
+            };
+            serve::run(elf_path, port, client_type, !no_hmacs)?;
         }
     }
     Ok(())

--- a/cargo-vnd/src/serve.rs
+++ b/cargo-vnd/src/serve.rs
@@ -1,0 +1,155 @@
+use client_sdk::linewriter::FileLineWriter;
+use client_sdk::vanadium_client::client_utils::{
+    ClientType, ClientUtilsError, create_hid_client, create_native_client, create_tcp_client,
+};
+use client_sdk::vanadium_client::{VAppExecutionError, VAppTransport};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Read a length-prefixed message from the TCP stream.
+/// Returns `None` if the connection was closed.
+async fn read_message(
+    stream: &mut tokio::net::TcpStream,
+) -> Result<Option<Vec<u8>>, std::io::Error> {
+    let mut len_buf = [0u8; 4];
+    match stream.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e)
+            if e.kind() == std::io::ErrorKind::UnexpectedEof
+                || e.kind() == std::io::ErrorKind::ConnectionReset =>
+        {
+            return Ok(None);
+        }
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf).await?;
+    Ok(Some(buf))
+}
+
+/// Write a length-prefixed message to the TCP stream.
+async fn write_message(
+    stream: &mut tokio::net::TcpStream,
+    data: &[u8],
+) -> Result<(), std::io::Error> {
+    let len = data.len() as u32;
+    stream.write_all(&len.to_be_bytes()).await?;
+    stream.write_all(data).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+async fn create_vapp_client(
+    elf_path: &str,
+    client_type: ClientType,
+    use_hmacs: bool,
+) -> Result<Box<dyn VAppTransport + Send>, ClientUtilsError> {
+    let make_print_writer = || -> Option<Box<dyn std::io::Write + Send + Sync>> {
+        Some(Box::new(FileLineWriter::new("print.log", true, true)))
+    };
+
+    match client_type {
+        ClientType::Native => create_native_client(None, make_print_writer()).await,
+        ClientType::Tcp => create_tcp_client(elf_path, make_print_writer(), use_hmacs).await,
+        ClientType::Hid => create_hid_client(elf_path, make_print_writer(), use_hmacs).await,
+        ClientType::Any => {
+            // No flag specified: try HID, then Speculos, then native
+            eprintln!("No device flag specified, trying HID...");
+            match create_hid_client(elf_path, make_print_writer(), use_hmacs).await {
+                Ok(client) => {
+                    eprintln!("Connected via HID.");
+                    Ok(client)
+                }
+                Err(e) => {
+                    eprintln!("HID failed ({e}), trying Speculos...");
+                    match create_tcp_client(elf_path, make_print_writer(), use_hmacs).await {
+                        Ok(client) => {
+                            eprintln!("Connected via Speculos.");
+                            Ok(client)
+                        }
+                        Err(e) => {
+                            eprintln!("Speculos failed ({e}), trying native...");
+                            create_native_client(None, make_print_writer()).await
+                        }
+                    }
+                }
+            }
+        }
+        ClientType::Standalone => {
+            panic!(
+                "Standalone client is only supported in the client-sdk to connect to this server!"
+            )
+        }
+    }
+}
+
+async fn handle_client(
+    vapp: &mut Box<dyn VAppTransport + Send>,
+    stream: &mut tokio::net::TcpStream,
+) {
+    loop {
+        let msg = match read_message(stream).await {
+            Ok(Some(msg)) => msg,
+            Ok(None) => {
+                eprintln!("Client disconnected.");
+                return;
+            }
+            Err(e) => {
+                eprintln!("Error reading from client: {e}");
+                return;
+            }
+        };
+
+        match vapp.send_message(&msg).await {
+            Ok(resp) => {
+                if let Err(e) = write_message(stream, &resp).await {
+                    eprintln!("Error writing to client: {e}");
+                    return;
+                }
+            }
+            Err(VAppExecutionError::AppExited(code)) => {
+                eprintln!("V-App exited with status {code}");
+                return;
+            }
+            Err(VAppExecutionError::AppPanicked(msg)) => {
+                eprintln!("V-App panicked: {msg}");
+                return;
+            }
+            Err(e) => {
+                eprintln!("V-App error: {e}");
+                return;
+            }
+        }
+    }
+}
+
+pub fn run(
+    elf_path: String,
+    port: u16,
+    client_type: ClientType,
+    use_hmacs: bool,
+) -> anyhow::Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async move {
+            eprintln!("Connecting to V-App...");
+            let mut vapp = create_vapp_client(&elf_path, client_type, use_hmacs)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to create V-App client: {e}"))?;
+
+            let listener = TcpListener::bind(format!("127.0.0.1:{}", port)).await?;
+            eprintln!("Listening on 127.0.0.1:{}", port);
+
+            // Accept one connection at a time (V-App is single-threaded)
+            loop {
+                let (mut stream, addr) = listener.accept().await?;
+                eprintln!("Client connected from {addr}");
+                handle_client(&mut vapp, &mut stream).await;
+                eprintln!("Ready for new connection.");
+            }
+        })
+}

--- a/client-sdk/src/vanadium_client.rs
+++ b/client-sdk/src/vanadium_client.rs
@@ -1908,6 +1908,65 @@ impl VAppTransport for NativeAppClient {
     }
 }
 
+/// Client that connects to a standalone V-App server over a simple length-prefixed TCP stream.
+///
+/// Unlike [`NativeAppClient`] which speaks the native V-App protocol (with `BufferType` tags),
+/// this client uses a minimal protocol: each message is a 4-byte big-endian length followed by
+/// the payload, in both directions. Print and panic handling is done server-side.
+///
+/// This is intended for use with a standalone server binary (e.g., `cargo-vnd serve`) that manages
+/// the full Vanadium client stack and exposes this simple TCP interface.
+pub struct StandaloneAppClient {
+    stream: TcpStream,
+}
+
+impl StandaloneAppClient {
+    /// Connect to a standalone V-App server at the given address (e.g., `"127.0.0.1:12167"`).
+    pub async fn new(addr: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let stream = TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(Self { stream })
+    }
+
+    fn map_err(e: std::io::Error) -> VAppExecutionError {
+        use std::io::ErrorKind::*;
+        match e.kind() {
+            UnexpectedEof | ConnectionReset | BrokenPipe => VAppExecutionError::AppExited(-1),
+            _ => VAppExecutionError::Other(Box::new(e)),
+        }
+    }
+}
+
+#[async_trait]
+impl VAppTransport for StandaloneAppClient {
+    async fn send_message(&mut self, msg: &[u8]) -> Result<Vec<u8>, VAppExecutionError> {
+        // ---------- WRITE: 4-byte BE length + payload ----------
+        let len = msg.len() as u32;
+        self.stream
+            .write_all(&len.to_be_bytes())
+            .await
+            .map_err(Self::map_err)?;
+        self.stream.write_all(msg).await.map_err(Self::map_err)?;
+        self.stream.flush().await.map_err(Self::map_err)?;
+
+        // ---------- READ: 4-byte BE length + payload ----------
+        let mut len_buf = [0u8; 4];
+        self.stream
+            .read_exact(&mut len_buf)
+            .await
+            .map_err(Self::map_err)?;
+        let resp_len = u32::from_be_bytes(len_buf) as usize;
+
+        let mut resp = vec![0u8; resp_len];
+        self.stream
+            .read_exact(&mut resp)
+            .await
+            .map_err(Self::map_err)?;
+
+        Ok(resp)
+    }
+}
+
 /// Utility functions to simplify client creation
 ///
 /// This module provides convenient functions to create different types of VApp clients
@@ -1944,11 +2003,14 @@ pub mod client_utils {
         TcpTransportFailed(String),
         /// Failed to create HID transport
         HidTransportFailed(String),
-        /// Hid, Tcp and Native interfaces all failed
+        /// Failed to connect to standalone server
+        StandaloneConnectionFailed(String),
+        /// Hid, Tcp, Native and Standalone interfaces all failed
         AllInterfacesFailed {
             hid_error: Box<ClientUtilsError>,
             tcp_error: Box<ClientUtilsError>,
             native_error: Box<ClientUtilsError>,
+            standalone_error: Box<ClientUtilsError>,
         },
         /// Failed to create Vanadium app client
         VanadiumClientFailed(String),
@@ -1966,17 +2028,22 @@ pub mod client_utils {
                 ClientUtilsError::HidTransportFailed(msg) => {
                     write!(f, "HID transport failed: {}", msg)
                 }
+                ClientUtilsError::StandaloneConnectionFailed(msg) => {
+                    write!(f, "Standalone server connection failed: {}", msg)
+                }
                 ClientUtilsError::AllInterfacesFailed {
                     hid_error,
                     tcp_error,
                     native_error,
+                    standalone_error,
                 } => write!(
                     f,
                     "Failed to connect to a device or speculos running vanadium, or the native app.\n\
                     HID error: {}\n\
                     TCP error: {}\n\
-                    Native error: {}",
-                    hid_error, tcp_error, native_error
+                    Native error: {}\n\
+                    Standalone error: {}",
+                    hid_error, tcp_error, native_error, standalone_error
                 ),
                 ClientUtilsError::VanadiumClientFailed(msg) => {
                     write!(f, "Vanadium client failed: {}", msg)
@@ -1999,6 +2066,20 @@ pub mod client_utils {
         let client = NativeAppClient::new(addr, print_writer)
             .await
             .map_err(|e| ClientUtilsError::NativeConnectionFailed(e.to_string()))?;
+        Ok(Box::new(client))
+    }
+
+    /// Creates a client that connects to a standalone V-App server (e.g., `vapp-server`).
+    ///
+    /// The server is expected to be already running and listening on the given TCP address.
+    /// Uses a simple length-prefixed protocol without `BufferType` tags.
+    pub async fn create_standalone_client(
+        tcp_addr: Option<&str>,
+    ) -> Result<Box<dyn VAppTransport + Send>, ClientUtilsError> {
+        let addr = tcp_addr.unwrap_or("127.0.0.1:12167");
+        let client = StandaloneAppClient::new(addr)
+            .await
+            .map_err(|e| ClientUtilsError::StandaloneConnectionFailed(e.to_string()))?;
         Ok(Box::new(client))
     }
 
@@ -2054,10 +2135,12 @@ pub mod client_utils {
     }
 
     pub enum ClientType {
-        /// Try in sequence Hid, Tcp (Speculos), then native
+        /// Try in sequence Standalone, Hid, Tcp (Speculos), then Native
         Any,
         /// Native client using TCP transport
         Native,
+        /// Standalone client connecting to a vapp-server via TCP
+        Standalone,
         /// Vanadium client using TCP transport (for Speculos)
         Tcp,
         /// Vanadium client using HID transport (for real device)
@@ -2088,6 +2171,8 @@ pub mod client_utils {
         );
 
         let tcp_addr = std::env::var("VAPP_ADDRESS").unwrap_or_else(|_| "127.0.0.1:2323".into());
+        let standalone_addr =
+            std::env::var("VANADIUM_SERVER_ADDRESS").unwrap_or_else(|_| "127.0.0.1:12167".into());
 
         let shared_writer = print_writer.map(|w| std::sync::Arc::new(std::sync::Mutex::new(w)));
 
@@ -2099,25 +2184,50 @@ pub mod client_utils {
 
         match client_type {
             ClientType::Any => {
+                // Try standalone first: it's a lightweight TCP connect (no ELF upload),
+                // so it fails fast if no server is running. This avoids accidentally
+                // connecting to Speculos when a standalone vapp-server is intended.
+                let standalone_error = match create_standalone_client(Some(&standalone_addr)).await
+                {
+                    Ok(client) => {
+                        eprintln!(
+                            "Connected via TCP to the standalone server ({})",
+                            standalone_addr
+                        );
+                        return Ok(client);
+                    }
+                    Err(e) => e,
+                };
                 let hid_error = match create_hid_client(&vapp_path, get_writer(), use_hmacs).await {
-                    Ok(client) => return Ok(client),
+                    Ok(client) => {
+                        eprintln!("Connected via HID (real device)");
+                        return Ok(client);
+                    }
                     Err(e) => e,
                 };
                 let tcp_error = match create_tcp_client(&vapp_path, get_writer(), use_hmacs).await {
-                    Ok(client) => return Ok(client),
+                    Ok(client) => {
+                        eprintln!("Connected via TCP (Speculos)");
+                        return Ok(client);
+                    }
                     Err(e) => e,
                 };
                 let native_error = match create_native_client(Some(&tcp_addr), get_writer()).await {
-                    Ok(client) => return Ok(client),
+                    Ok(client) => {
+                        eprintln!("Connected via TCP to the native app ({})", tcp_addr);
+                        return Ok(client);
+                    }
                     Err(e) => e,
                 };
                 Err(ClientUtilsError::AllInterfacesFailed {
                     hid_error: Box::new(hid_error),
                     tcp_error: Box::new(tcp_error),
                     native_error: Box::new(native_error),
+                    standalone_error: Box::new(standalone_error),
                 })
             }
             ClientType::Native => create_native_client(Some(&tcp_addr), get_writer()).await,
+            ClientType::Standalone => create_standalone_client(Some(&standalone_addr)).await,
             ClientType::Tcp => create_tcp_client(&vapp_path, get_writer(), use_hmacs).await,
             ClientType::Hid => create_hid_client(&vapp_path, get_writer(), use_hmacs).await,
         }


### PR DESCRIPTION
Added a basic 'served instance' version of Vanadium to `cargo-vnd`

Clients using the normal Vanadium clients have to manage the lifetime of the Vanadium client, and keep the connection alive for the entire lifetime of the V-App. This can be rather complex.

This introduces a rudimentary server that manages the V-App's lifetime, and can be connected to as a `VAppTransport` by other processes via a simple TCP connection, simplifying external integrations.

Added support for it in `vnd-bitcoin`.