### PR TITLE
Label dummy/internal xpubs during wallet policy registration

### DIFF
--- a/app-sdk/src/curve.rs
+++ b/app-sdk/src/curve.rs
@@ -642,6 +642,15 @@ impl EcfpPublicKey<Secp256k1, 32> {
         Ok(Self::new(x, y))
     }
 
+    /// Encodes this public key as a 33-byte compressed SEC1 point.
+    pub fn to_compressed(&self) -> [u8; 33] {
+        let bytes = self.public_key.to_bytes();
+        let mut compressed = [0u8; 33];
+        compressed[0] = bytes[64] % 2 + 0x02;
+        compressed[1..33].copy_from_slice(&bytes[1..33]);
+        compressed
+    }
+
     pub fn ecdsa_verify_hash(
         &self,
         msg_hash: &[u8; 32],

--- a/app-sdk/src/curve.rs
+++ b/app-sdk/src/curve.rs
@@ -645,6 +645,9 @@ impl EcfpPublicKey<Secp256k1, 32> {
     /// Encodes this public key as a 33-byte compressed SEC1 point.
     pub fn to_compressed(&self) -> [u8; 33] {
         let bytes = self.public_key.to_bytes();
+        if bytes[0] != 0x04 {
+            panic!("Invalid public key");
+        }
         let mut compressed = [0u8; 33];
         compressed[0] = bytes[64] % 2 + 0x02;
         compressed[1..33].copy_from_slice(&bytes[1..33]);

--- a/app-sdk/src/ux.rs
+++ b/app-sdk/src/ux.rs
@@ -51,27 +51,30 @@ struct PageLayoutMetrics {
 fn get_page_layout_metrics() -> PageLayoutMetrics {
     match ecalls::get_device_property(DEVICE_PROPERTY_ID) {
         // Native target: not a real device, use Stax values as a sensible default.
+        // Stax
         0 | 0x2c970060 => PageLayoutMetrics {
-            tag_chars_per_line: 26,
+            tag_chars_per_line: 20,
             tag_line_height_px: 28,
-            value_chars_per_line: 23,
+            value_chars_per_line: 17,
             value_line_height_px: 36,
             pair_padding_px: 20,
             content_height_px: 488,
         },
+        // Flex
         0x2c970070 => PageLayoutMetrics {
-            tag_chars_per_line: 27, // (480-32)/(28*0.59), SMALL_FONT_HEIGHT=28
-            tag_line_height_px: 32, // SMALL_FONT_HEIGHT(28)+4
-            value_chars_per_line: 28,
+            tag_chars_per_line: 20,
+            tag_line_height_px: 32,
+            value_chars_per_line: 17,
             value_line_height_px: 36,
             pair_padding_px: 20,
             content_height_px: 416,
         },
+        // Apex_p
         0x2c970080 => PageLayoutMetrics {
-            tag_chars_per_line: 25,   // (300-32)/(18*0.59), SMALL_FONT_HEIGHT=18
-            tag_line_height_px: 22,   // SMALL_FONT_HEIGHT(18)+4
-            value_chars_per_line: 17, // (300-32)/(32*0.49), value font ~32px
-            value_line_height_px: 36,
+            tag_chars_per_line: 25,
+            tag_line_height_px: 18,
+            value_chars_per_line: 17,
+            value_line_height_px: 24,
             pair_padding_px: 16,
             content_height_px: 264,
         },

--- a/apps/bitcoin/app/src/constants.rs
+++ b/apps/bitcoin/app/src/constants.rs
@@ -7,3 +7,7 @@ pub const BIP32_TESTNET_PUBKEY_VERSION: u32 = 0x043587CFu32;
 // equal to THRESHOLD_WARN_HIGH_FEES_PERCENT. (E.g. 10 means 10%).
 pub const THRESHOLD_WARN_HIGH_FEES_PERCENT: u64 = 10; // 10%
 pub const THRESHOLD_WARN_HIGH_FEES_AMOUNT: u64 = 100_000;
+
+/// Compressed public key of the standard NUMS unspendable point from BIP-341
+pub const NUMS_COMPRESSED_PUBKEY: [u8; 33] =
+    hex_literal::hex!("0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0");

--- a/apps/bitcoin/app/src/handlers/register_account.rs
+++ b/apps/bitcoin/app/src/handlers/register_account.rs
@@ -6,7 +6,9 @@ use common::{
     message::{self, Response},
     por::{ProofOfRegistration, Registerable},
 };
-use sdk::curve::{EcfpPublicKey, Secp256k1};
+use sdk::curve::{Curve, EcfpPrivateKey, EcfpPublicKey, Secp256k1, ToPublicKey};
+
+use crate::constants::NUMS_COMPRESSED_PUBKEY;
 
 async fn display_wallet_policy(
     app: &mut sdk::App,
@@ -173,11 +175,41 @@ pub async fn handle_register_account(
         }
     }
 
-    // TODO: necessary sanity checks on the wallet policy
+    // Label keys as "dummy" or "our key" based on their properties.
+    let master_fpr = Secp256k1::get_master_fingerprint();
+    for (i, key_info) in wallet_policy.key_information.iter().enumerate() {
+        // Skip keys that already have a label from identity signature verification.
+        if key_auth_names[i].is_some() {
+            continue;
+        }
 
-    // TODO:
-    // distinguish internal keys (after checking the derivation is correct) and external ones
-    // We should also clearly mark any resident key among the internal keys
+        let xpub_bytes = key_info.pubkey.encode();
+        let compressed_pubkey = &xpub_bytes[45..78];
+
+        if compressed_pubkey == NUMS_COMPRESSED_PUBKEY {
+            key_auth_names[i] = Some(String::from("dummy"));
+            continue;
+        }
+
+        if let Some(ref origin) = key_info.origin_info {
+            if origin.fingerprint == master_fpr {
+                let path: Vec<u32> = origin
+                    .derivation_path
+                    .iter()
+                    .map(|step| u32::from(*step))
+                    .collect();
+                if let Ok(hd_node) = Secp256k1::derive_hd_node(&path) {
+                    let derived = EcfpPrivateKey::<Secp256k1, 32>::new(*hd_node.privkey)
+                        .to_public_key()
+                        .to_compressed();
+                    if compressed_pubkey == derived && xpub_bytes[13..45] == hd_node.chaincode {
+                        key_auth_names[i] = Some(String::from("our key"));
+                    }
+                }
+            }
+        }
+    }
+
     if !display_wallet_policy(app, name, &wallet_policy, &key_auth_names, show_cleartext).await {
         return Err(Error::UserRejected);
     }


### PR DESCRIPTION
This recognizes and clearly labels internal xpubs and also the ones that have the standard NUMS point as the pubkey during wallet policy registration.