### PR TITLE
Musig2 support in bip388 and cleartext module

### DIFF
--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -697,7 +697,11 @@ fn sign_all_inputs(
         let PsbtAccount::WalletPolicy(wallet_policy) = &summary.accounts[account_id as usize];
 
         for (kp, tapleaf_desc) in wallet_policy.descriptor_template.placeholders() {
-            let key_info = &wallet_policy.key_information[kp.key_index as usize];
+            let key_index = match kp.plain_key_index() {
+                Some(idx) => idx,
+                None => continue, // musig key expressions not yet supported for signing
+            };
+            let key_info = &wallet_policy.key_information[key_index as usize];
 
             // Determine the key source: either the master seed (fingerprint match)
             // or the resident key (compressed pubkey + synthetic chaincode match).

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -151,7 +151,7 @@ fn resolve_private_key(
 fn sign_input_ecdsa(
     psbt: &fastpsbt::Psbt,
     input_index: usize,
-    sighash_cache: &mut SighashCache<Transaction>,
+    sighash_cache: &mut SighashCache<&Transaction>,
     key_source: &KeySource,
 ) -> Result<PartialSignature, Error> {
     let (sighash, sighash_type) = psbt
@@ -181,7 +181,7 @@ fn sign_input_ecdsa(
 
 fn sign_input_schnorr(
     input_index: usize,
-    sighash_cache: &mut SighashCache<Transaction>,
+    sighash_cache: &mut SighashCache<&Transaction>,
     prevouts: &[TxOut],
     key_source: &KeySource,
     taptree_hash: Option<[u8; 32]>,
@@ -681,7 +681,7 @@ fn sign_all_inputs(
     let unsigned_tx = psbt
         .unsigned_tx()
         .map_err(|_| Error::FailedUnsignedTransaction)?;
-    let mut sighash_cache = SighashCache::new(unsigned_tx.clone());
+    let mut sighash_cache = SighashCache::new(unsigned_tx);
 
     let mut prevouts: Option<Vec<TxOut>> = None;
     let master_fingerprint = sdk::curve::Secp256k1::get_master_fingerprint();
@@ -697,7 +697,7 @@ fn sign_all_inputs(
         let PsbtAccount::WalletPolicy(wallet_policy) = &summary.accounts[account_id as usize];
 
         for (kp, tapleaf_desc) in wallet_policy.descriptor_template.placeholders() {
-            let key_info = wallet_policy.key_information[kp.key_index as usize].clone();
+            let key_info = &wallet_policy.key_information[kp.key_index as usize];
 
             // Determine the key source: either the master seed (fingerprint match)
             // or the resident key (compressed pubkey + synthetic chaincode match).

--- a/apps/bitcoin/client/src/main.rs
+++ b/apps/bitcoin/client/src/main.rs
@@ -62,7 +62,7 @@ enum CliCommand {
         #[clap(long)]
         keys_info: String,
         /// If set, show a human-readable cleartext description of the descriptor
-        /// template on screen (when its complexity score is at most MAX_CONFUSION_SCORE).
+        /// template on screen (when its confusion score is at most MAX_CONFUSION_SCORE).
         #[clap(long, default_missing_value = "true", num_args = 0..=1)]
         show_cleartext: bool,
     },

--- a/apps/bitcoin/common/src/account.rs
+++ b/apps/bitcoin/common/src/account.rs
@@ -9,7 +9,8 @@ use sdk::hash::{Hasher, Sha256};
 pub use crate::message::WalletPolicyCoordinates;
 
 pub use crate::bip388::{
-    DescriptorTemplate, KeyInformation, KeyPlaceholder, TapTree, WalletPolicy,
+    DescriptorTemplate, KeyExpression, KeyExpressionType, KeyInformation, KeyPlaceholder, TapTree,
+    WalletPolicy,
 };
 use crate::por::{Registerable, RegistrationId};
 use bitcoin::{params::Params, Address};

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -392,11 +392,11 @@ impl TapleafClass {
             (
                 TC::SingleSig { key: k1 },
                 TC::SingleSig { key: k2 },
-            ) => k1.key_index.cmp(&k2.key_index),
+            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)),
             (
                 TC::BothMustSign { key1: a1, key2: b1 },
                 TC::BothMustSign { key1: a2, key2: b2 },
-            ) => a1.key_index.cmp(&a2.key_index).then(b1.key_index.cmp(&b2.key_index)),
+            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))),
             (
                 TC::SortedMultisig { threshold: t1, keys: k1 },
                 TC::SortedMultisig { threshold: t2, keys: k2 },
@@ -408,11 +408,11 @@ impl TapleafClass {
             (
                 TC::RelativeHeightlockSingleSig { key: k1, blocks: b1 },
                 TC::RelativeHeightlockSingleSig { key: k2, blocks: b2 },
-            ) => k1.key_index.cmp(&k2.key_index).then(b1.cmp(b2)),
+            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(b1.cmp(b2)),
             (
                 TC::RelativeHeightlockBothMustSign { key1: a1, key2: b1, blocks: bl1 },
                 TC::RelativeHeightlockBothMustSign { key1: a2, key2: b2, blocks: bl2 },
-            ) => a1.key_index.cmp(&a2.key_index).then(b1.key_index.cmp(&b2.key_index)).then(bl1.cmp(bl2)),
+            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(bl1.cmp(bl2)),
             (
                 TC::RelativeHeightlockMultiSig { threshold: t1, keys: k1, blocks: b1 },
                 TC::RelativeHeightlockMultiSig { threshold: t2, keys: k2, blocks: b2 },
@@ -420,11 +420,11 @@ impl TapleafClass {
             (
                 TC::RelativeTimelockSingleSig { key: k1, time: t1 },
                 TC::RelativeTimelockSingleSig { key: k2, time: t2 },
-            ) => k1.key_index.cmp(&k2.key_index).then(t1.cmp(t2)),
+            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(t1.cmp(t2)),
             (
                 TC::RelativeTimelockBothMustSign { key1: a1, key2: b1, time: t1 },
                 TC::RelativeTimelockBothMustSign { key1: a2, key2: b2, time: t2 },
-            ) => a1.key_index.cmp(&a2.key_index).then(b1.key_index.cmp(&b2.key_index)).then(t1.cmp(t2)),
+            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(t1.cmp(t2)),
             (
                 TC::RelativeTimelockMultiSig { threshold: t1, keys: k1, time: tm1 },
                 TC::RelativeTimelockMultiSig { threshold: t2, keys: k2, time: tm2 },
@@ -432,11 +432,11 @@ impl TapleafClass {
             (
                 TC::AbsoluteHeightlockSingleSig { key: k1, block_height: h1 },
                 TC::AbsoluteHeightlockSingleSig { key: k2, block_height: h2 },
-            ) => k1.key_index.cmp(&k2.key_index).then(h1.cmp(h2)),
+            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(h1.cmp(h2)),
             (
                 TC::AbsoluteHeightlockBothMustSign { key1: a1, key2: b1, block_height: h1 },
                 TC::AbsoluteHeightlockBothMustSign { key1: a2, key2: b2, block_height: h2 },
-            ) => a1.key_index.cmp(&a2.key_index).then(b1.key_index.cmp(&b2.key_index)).then(h1.cmp(&h2)),
+            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(h1.cmp(&h2)),
             (
                 TC::AbsoluteHeightlockMultiSig { threshold: t1, keys: k1, block_height: h1 },
                 TC::AbsoluteHeightlockMultiSig { threshold: t2, keys: k2, block_height: h2 },
@@ -444,11 +444,11 @@ impl TapleafClass {
             (
                 TC::AbsoluteTimelockSingleSig { key: k1, timestamp: ts1 },
                 TC::AbsoluteTimelockSingleSig { key: k2, timestamp: ts2 },
-            ) => k1.key_index.cmp(&k2.key_index).then(ts1.cmp(&ts2)),
+            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(ts1.cmp(&ts2)),
             (
                 TC::AbsoluteTimelockBothMustSign { key1: a1, key2: b1, timestamp: ts1 },
                 TC::AbsoluteTimelockBothMustSign { key1: a2, key2: b2, timestamp: ts2 },
-            ) => a1.key_index.cmp(&a2.key_index).then(b1.key_index.cmp(&b2.key_index)).then(ts1.cmp(&ts2)),
+            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(ts1.cmp(&ts2)),
             (
                 TC::AbsoluteTimelockMultiSig { threshold: t1, keys: k1, timestamp: ts1 },
                 TC::AbsoluteTimelockMultiSig { threshold: t2, keys: k2, timestamp: ts2 },
@@ -464,22 +464,22 @@ impl DescriptorTemplate {
     fn classify(&self) -> DescriptorClass {
         descriptor_match!(self, {
             pkh(_key_index) => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 DescriptorClass::LegacySingleSig { key }
             },
             // normal or wrapped
             wpkh(_key_index) | sh(wpkh(_key_index)) => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 DescriptorClass::SegwitSingleSig { key }
             },
             // 4 combinations: multi/sortedmulti; normal/wrapped
             wsh(multi(threshold, _key_indices)) | wsh(sortedmulti(threshold, _key_indices)) | sh(wsh(multi(threshold, _key_indices))) | sh(wsh(sortedmulti(threshold, _key_indices))) => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 DescriptorClass::SegwitMultisig { threshold, keys }
             },
             tr(internal_key, tree) => {
                 DescriptorClass::Taproot {
-                    internal_key: *internal_key,
+                    internal_key: internal_key.clone(),
                     leaves: tree
                         .as_ref()
                         .map(|t| t.tapleaves().map(|l| l.classify_as_tapleaf()).collect())
@@ -493,75 +493,75 @@ impl DescriptorTemplate {
     fn classify_as_tapleaf(&self) -> TapleafClass {
         descriptor_match!(self, {
             sortedmulti_a(threshold, _key_indices) => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 TapleafClass::SortedMultisig { threshold, keys }
             },
             pk(_key_index) | pkh(_key_index) => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 TapleafClass::SingleSig { key }
             },
             multi_a(threshold, _key_indices) => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 TapleafClass::Multisig { threshold, keys }
             },
             and_v(v:pk(_key_index), older(blocks)) if blocks >= 1 && blocks < 65536 => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 TapleafClass::RelativeHeightlockSingleSig { key, blocks }
             },
             and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), older(blocks)) if blocks >= 1 && blocks < 65536 => {
-                let mut phs = self.placeholders().map(|(kp, _)| *kp);
+                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
                 let key1 = phs.next().unwrap();
                 let key2 = phs.next().unwrap();
                 TapleafClass::RelativeHeightlockBothMustSign { key1, key2, blocks }
             },
             and_v(v:multi_a(threshold, _key_indices), older(blocks)) if blocks >= 1 && blocks < 65536 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 TapleafClass::RelativeHeightlockMultiSig { threshold, keys, blocks }
             },
             and_v(v:pk(_key_index), older(time)) if time >= 4194305 && time < 4259840 => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 TapleafClass::RelativeTimelockSingleSig { key, time }
             },
             and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), older(time)) if time >= 4194305 && time < 4259840 => {
-                let mut phs = self.placeholders().map(|(kp, _)| *kp);
+                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
                 let key1 = phs.next().unwrap();
                 let key2 = phs.next().unwrap();
                 TapleafClass::RelativeTimelockBothMustSign { key1, key2, time }
             },
             and_v(v:multi_a(threshold, _key_indices), older(time)) if time >= 4194305 && time < 4259840 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 TapleafClass::RelativeTimelockMultiSig { threshold, keys, time }
             },
             and_v(v:pk(_key_index), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 TapleafClass::AbsoluteHeightlockSingleSig { key, block_height }
             },
             and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
-                let mut phs = self.placeholders().map(|(kp, _)| *kp);
+                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
                 let key1 = phs.next().unwrap();
                 let key2 = phs.next().unwrap();
                 TapleafClass::AbsoluteHeightlockBothMustSign { key1, key2, block_height }
             },
             and_v(v:multi_a(threshold, _key_indices), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 TapleafClass::AbsoluteHeightlockMultiSig { threshold, keys, block_height }
             },
             and_v(v:pk(_key_index), after(timestamp)) if timestamp >= 500000000 => {
-                let key = self.placeholders().next().map(|(kp, _)| *kp).unwrap();
+                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
                 TapleafClass::AbsoluteTimelockSingleSig { key, timestamp }
             },
             and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), after(timestamp)) if timestamp >= 500000000 => {
-                let mut phs = self.placeholders().map(|(kp, _)| *kp);
+                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
                 let key1 = phs.next().unwrap();
                 let key2 = phs.next().unwrap();
                 TapleafClass::AbsoluteTimelockBothMustSign { key1, key2, timestamp }
             },
             and_v(v:multi_a(threshold, _key_indices), after(timestamp)) if timestamp >= 500000000 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| *kp).collect();
+                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
                 TapleafClass::AbsoluteTimelockMultiSig { threshold, keys, timestamp }
             },
             and_v(v:pk(_key_index1), pk(_key_index2)) => {
-                let mut phs = self.placeholders().map(|(kp, _)| *kp);
+                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
                 let key1 = phs.next().unwrap();
                 let key2 = phs.next().unwrap();
                 TapleafClass::BothMustSign { key1, key2 }
@@ -571,21 +571,36 @@ impl DescriptorTemplate {
     }
 }
 
-fn format_key(kp: KeyPlaceholder, canonical: bool) -> String {
+fn format_key(kp: &KeyPlaceholder, canonical: bool) -> String {
     if canonical {
-        format!("@{}", kp.key_index)
+        match &kp.key_type {
+            super::KeyExpressionType::PlainKey(key_index) => format!("@{}", key_index),
+            super::KeyExpressionType::Musig(key_indices) => {
+                let inner: Vec<String> = key_indices.iter().map(|idx| format!("@{}", idx)).collect();
+                format!("musig({})", inner.join(","))
+            }
+        }
     } else {
-        format!("@{}/<{};{}>/*", kp.key_index, kp.num1, kp.num2)
+        // Always use explicit derivation form for non-canonical display
+        match &kp.key_type {
+            super::KeyExpressionType::PlainKey(key_index) => {
+                format!("@{}/<{};{}>/*", key_index, kp.num1, kp.num2)
+            }
+            super::KeyExpressionType::Musig(key_indices) => {
+                let inner: Vec<String> = key_indices.iter().map(|idx| format!("@{}", idx)).collect();
+                format!("musig({})/<{};{}>/*", inner.join(","), kp.num1, kp.num2)
+            }
+        }
     }
 }
 
 fn format_key_indices(keys: &[KeyPlaceholder], canonical: bool) -> String {
     match keys {
         [] => String::new(),
-        [single] => format_key(*single, canonical),
+        [single] => format_key(single, canonical),
         [init @ .., last] => {
-            let parts: Vec<String> = init.iter().map(|k| format_key(*k, canonical)).collect();
-            format!("{} and {}", parts.join(", "), format_key(*last, canonical))
+            let parts: Vec<String> = init.iter().map(|k| format_key(k, canonical)).collect();
+            format!("{} and {}", parts.join(", "), format_key(last, canonical))
         }
     }
 }
@@ -613,7 +628,7 @@ fn format_cleartext_value(
         (CleartextPart::Threshold, CleartextValue::Threshold(threshold)) => {
             Some(threshold.to_string())
         }
-        (CleartextPart::KeyIndex, CleartextValue::KeyIndex(kp)) => Some(format_key(*kp, canonical)),
+        (CleartextPart::KeyIndex, CleartextValue::KeyIndex(kp)) => Some(format_key(kp, canonical)),
         (CleartextPart::KeyIndices, CleartextValue::KeyIndices(keys)) => {
             Some(format_key_indices(keys, canonical))
         }
@@ -660,11 +675,11 @@ impl DescriptorClass {
         match self {
             DescriptorClass::LegacySingleSig { key } => Some((
                 TopLevelPattern::LegacySingleSig,
-                vec![CleartextValue::KeyIndex(*key)],
+                vec![CleartextValue::KeyIndex(key.clone())],
             )),
             DescriptorClass::SegwitSingleSig { key } => Some((
                 TopLevelPattern::SegwitSingleSig,
-                vec![CleartextValue::KeyIndex(*key)],
+                vec![CleartextValue::KeyIndex(key.clone())],
             )),
             DescriptorClass::SegwitMultisig { threshold, keys } => Some((
                 TopLevelPattern::SegwitMultisig,
@@ -675,7 +690,7 @@ impl DescriptorClass {
             )),
             DescriptorClass::Taproot { internal_key, .. } => Some((
                 TopLevelPattern::Taproot,
-                vec![CleartextValue::KeyIndex(*internal_key)],
+                vec![CleartextValue::KeyIndex(internal_key.clone())],
             )),
             DescriptorClass::Other => None,
         }
@@ -696,7 +711,7 @@ impl TapleafClass {
         match self {
             TapleafClass::SingleSig { key } => Some((
                 TapleafPattern::SingleSig,
-                vec![CleartextValue::KeyIndex(*key)],
+                vec![CleartextValue::KeyIndex(key.clone())],
             )),
             TapleafClass::SortedMultisig { threshold, keys } => Some((
                 TapleafPattern::SortedMultisig,
@@ -708,8 +723,8 @@ impl TapleafClass {
             TapleafClass::BothMustSign { key1, key2 } => Some((
                 TapleafPattern::BothMustSign,
                 vec![
-                    CleartextValue::KeyIndex(*key1),
-                    CleartextValue::KeyIndex(*key2),
+                    CleartextValue::KeyIndex(key1.clone()),
+                    CleartextValue::KeyIndex(key2.clone()),
                 ],
             )),
             TapleafClass::Multisig { threshold, keys } => Some((
@@ -722,15 +737,15 @@ impl TapleafClass {
             TapleafClass::RelativeHeightlockSingleSig { key, blocks } => Some((
                 TapleafPattern::RelativeHeightlockSingleSig,
                 vec![
-                    CleartextValue::KeyIndex(*key),
+                    CleartextValue::KeyIndex(key.clone()),
                     CleartextValue::Blocks(*blocks),
                 ],
             )),
             TapleafClass::RelativeHeightlockBothMustSign { key1, key2, blocks } => Some((
                 TapleafPattern::RelativeHeightlockBothMustSign,
                 vec![
-                    CleartextValue::KeyIndex(*key1),
-                    CleartextValue::KeyIndex(*key2),
+                    CleartextValue::KeyIndex(key1.clone()),
+                    CleartextValue::KeyIndex(key2.clone()),
                     CleartextValue::Blocks(*blocks),
                 ],
             )),
@@ -749,15 +764,15 @@ impl TapleafClass {
             TapleafClass::RelativeTimelockSingleSig { key, time } => Some((
                 TapleafPattern::RelativeTimelockSingleSig,
                 vec![
-                    CleartextValue::KeyIndex(*key),
+                    CleartextValue::KeyIndex(key.clone()),
                     CleartextValue::RelativeTime(*time),
                 ],
             )),
             TapleafClass::RelativeTimelockBothMustSign { key1, key2, time } => Some((
                 TapleafPattern::RelativeTimelockBothMustSign,
                 vec![
-                    CleartextValue::KeyIndex(*key1),
-                    CleartextValue::KeyIndex(*key2),
+                    CleartextValue::KeyIndex(key1.clone()),
+                    CleartextValue::KeyIndex(key2.clone()),
                     CleartextValue::RelativeTime(*time),
                 ],
             )),
@@ -776,7 +791,7 @@ impl TapleafClass {
             TapleafClass::AbsoluteHeightlockSingleSig { key, block_height } => Some((
                 TapleafPattern::AbsoluteHeightlockSingleSig,
                 vec![
-                    CleartextValue::KeyIndex(*key),
+                    CleartextValue::KeyIndex(key.clone()),
                     CleartextValue::BlockHeight(*block_height),
                 ],
             )),
@@ -787,8 +802,8 @@ impl TapleafClass {
             } => Some((
                 TapleafPattern::AbsoluteHeightlockBothMustSign,
                 vec![
-                    CleartextValue::KeyIndex(*key1),
-                    CleartextValue::KeyIndex(*key2),
+                    CleartextValue::KeyIndex(key1.clone()),
+                    CleartextValue::KeyIndex(key2.clone()),
                     CleartextValue::BlockHeight(*block_height),
                 ],
             )),
@@ -807,7 +822,7 @@ impl TapleafClass {
             TapleafClass::AbsoluteTimelockSingleSig { key, timestamp } => Some((
                 TapleafPattern::AbsoluteTimelockSingleSig,
                 vec![
-                    CleartextValue::KeyIndex(*key),
+                    CleartextValue::KeyIndex(key.clone()),
                     CleartextValue::Timestamp(*timestamp),
                 ],
             )),
@@ -818,8 +833,8 @@ impl TapleafClass {
             } => Some((
                 TapleafPattern::AbsoluteTimelockBothMustSign,
                 vec![
-                    CleartextValue::KeyIndex(*key1),
-                    CleartextValue::KeyIndex(*key2),
+                    CleartextValue::KeyIndex(key1.clone()),
+                    CleartextValue::KeyIndex(key2.clone()),
                     CleartextValue::Timestamp(*timestamp),
                 ],
             )),
@@ -882,7 +897,7 @@ impl DescriptorTemplate {
             alloc::collections::BTreeMap::new();
 
         for (kp, _) in self.placeholders() {
-            let next_num1 = next_num1_per_key.entry(kp.key_index).or_insert(0);
+            let next_num1 = next_num1_per_key.entry(kp.plain_key_index().unwrap_or(0)).or_insert(0);
             if kp.num1 as u64 != *next_num1 || kp.num2 as u64 != *next_num1 + 1 {
                 return false;
             }
@@ -1001,11 +1016,7 @@ fn parse_key_index(s: &str) -> Option<KeyPlaceholder> {
     let rest = s.strip_prefix('@')?;
     if let Ok(idx) = rest.parse::<u32>() {
         // "@N" canonical format
-        Some(KeyPlaceholder {
-            key_index: idx,
-            num1: 0,
-            num2: 1,
-        })
+        Some(KeyPlaceholder::plain(idx, 0, 1))
     } else if let Some((idx_str, deriv)) = rest.split_once('/') {
         // "@N/<M;K>/*" explicit derivation format
         let key_index = idx_str.parse().ok()?;
@@ -1013,11 +1024,7 @@ fn parse_key_index(s: &str) -> Option<KeyPlaceholder> {
         let (m, k) = deriv.split_once(';')?;
         let num1 = m.parse().ok()?;
         let num2 = k.parse().ok()?;
-        Some(KeyPlaceholder {
-            key_index,
-            num1,
-            num2,
-        })
+        Some(KeyPlaceholder::plain(key_index, num1, num2))
     } else {
         None
     }
@@ -1431,7 +1438,7 @@ fn parse_top_level_candidates(
                     push_unique(
                         &mut classes,
                         DescriptorClass::Taproot {
-                            internal_key,
+                            internal_key: internal_key.clone(),
                             leaves: leaves.clone(),
                         },
                     );
@@ -1454,12 +1461,12 @@ fn parse_top_level_candidates(
 #[cfg(any(test, feature = "cleartext-decode"))]
 fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>, CleartextError> {
     match leaf {
-        TapleafClass::SingleSig { key } => Ok(vec![DescriptorTemplate::Pk(*key)]),
+        TapleafClass::SingleSig { key } => Ok(vec![DescriptorTemplate::Pk(key.clone())]),
         TapleafClass::BothMustSign { key1, key2 } => Ok(vec![DescriptorTemplate::And_v(
             Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                *key1,
+                key1.clone(),
             )))),
-            Box::new(DescriptorTemplate::Pk(*key2)),
+            Box::new(DescriptorTemplate::Pk(key2.clone())),
         )]),
         TapleafClass::SortedMultisig { threshold, keys } => {
             Ok(vec![DescriptorTemplate::Sortedmulti_a(
@@ -1473,7 +1480,7 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         TapleafClass::RelativeHeightlockSingleSig { key, blocks } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                    *key,
+                    key.clone(),
                 )))),
                 Box::new(DescriptorTemplate::Older(*blocks)),
             )])
@@ -1482,9 +1489,9 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::And_v(
                     Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                        *key1,
+                        key1.clone(),
                     )))),
-                    Box::new(DescriptorTemplate::Pk(*key2)),
+                    Box::new(DescriptorTemplate::Pk(key2.clone())),
                 )))),
                 Box::new(DescriptorTemplate::Older(*blocks)),
             )])
@@ -1502,7 +1509,7 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         TapleafClass::RelativeTimelockSingleSig { key, time } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                    *key,
+                    key.clone(),
                 )))),
                 Box::new(DescriptorTemplate::Older(*time)),
             )])
@@ -1511,9 +1518,9 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::And_v(
                     Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                        *key1,
+                        key1.clone(),
                     )))),
-                    Box::new(DescriptorTemplate::Pk(*key2)),
+                    Box::new(DescriptorTemplate::Pk(key2.clone())),
                 )))),
                 Box::new(DescriptorTemplate::Older(*time)),
             )])
@@ -1531,7 +1538,7 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         TapleafClass::AbsoluteHeightlockSingleSig { key, block_height } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                    *key,
+                    key.clone(),
                 )))),
                 Box::new(DescriptorTemplate::After(*block_height)),
             )])
@@ -1543,9 +1550,9 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         } => Ok(vec![DescriptorTemplate::And_v(
             Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                    *key1,
+                    key1.clone(),
                 )))),
-                Box::new(DescriptorTemplate::Pk(*key2)),
+                Box::new(DescriptorTemplate::Pk(key2.clone())),
             )))),
             Box::new(DescriptorTemplate::After(*block_height)),
         )]),
@@ -1562,7 +1569,7 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         TapleafClass::AbsoluteTimelockSingleSig { key, timestamp } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                    *key,
+                    key.clone(),
                 )))),
                 Box::new(DescriptorTemplate::After(*timestamp)),
             )])
@@ -1574,9 +1581,9 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         } => Ok(vec![DescriptorTemplate::And_v(
             Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
-                    *key1,
+                    key1.clone(),
                 )))),
-                Box::new(DescriptorTemplate::Pk(*key2)),
+                Box::new(DescriptorTemplate::Pk(key2.clone())),
             )))),
             Box::new(DescriptorTemplate::After(*timestamp)),
         )]),
@@ -1688,7 +1695,7 @@ fn top_level_variants(
         }
         DescriptorClass::SegwitSingleSig { key } => Ok(Box::new(
             vec![
-                DescriptorTemplate::Wpkh(key),
+                DescriptorTemplate::Wpkh(key.clone()),
                 DescriptorTemplate::Sh(Box::new(DescriptorTemplate::Wpkh(key))),
             ]
             .into_iter(),
@@ -1728,11 +1735,11 @@ fn top_level_variants(
             }
             let trees = enumerate_taptrees(per_leaf_variants);
             Ok(Box::new(trees.map(move |t| {
-                let mut dt = DescriptorTemplate::Tr(internal_key, Some(t));
+                let mut dt = DescriptorTemplate::Tr(internal_key.clone(), Some(t));
                 let mut next_per_key: alloc::collections::BTreeMap<u32, u32> =
                     alloc::collections::BTreeMap::new();
                 for kp in dt.placeholders_mut() {
-                    let next = next_per_key.entry(kp.key_index).or_insert(0);
+                    let next = next_per_key.entry(kp.plain_key_index().unwrap_or(0)).or_insert(0);
                     kp.num1 = *next;
                     kp.num2 = *next + 1;
                     *next += 2;

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -956,28 +956,61 @@ pub trait ClearText {
 }
 
 impl DescriptorTemplate {
-    // Verify that for each key index that appears multiple times in placeholders, the derivations are <0;1>/*,
-    // then <2;3>/*, etc. This guarantees that no information on the derivations is lost when omitting this part
-    // in the cleartext representation.
+    // Verify that, for each distinct key expression in placeholders, its k occurrences carry derivations
+    // (in some order) equal to <0;1>/*, <2;3>/*, ..., <2k-2;2k-1>/*. That is, after sorting the (num1, num2)
+    // pairs for each key, they must be exactly (0,1), (2,3), .... This guarantees that no information on
+    // the derivations is lost when omitting this part in the cleartext representation, up to the
+    // permutation of pair assignments to occurrences (which is accounted for in the confusion score).
     fn are_key_derivations_canonical(&self) -> bool {
-        let mut next_num1_per_key: alloc::collections::BTreeMap<super::KeyExpressionType, u64> =
-            alloc::collections::BTreeMap::new();
+        let mut pairs_per_key: alloc::collections::BTreeMap<
+            super::KeyExpressionType,
+            Vec<(u32, u32)>,
+        > = alloc::collections::BTreeMap::new();
 
         for (kp, _) in self.placeholders() {
-            let next_num1 = next_num1_per_key.entry(kp.key_type.clone()).or_insert(0);
-            if kp.num1 as u64 != *next_num1 || kp.num2 as u64 != *next_num1 + 1 {
-                return false;
+            pairs_per_key
+                .entry(kp.key_type.clone())
+                .or_default()
+                .push((kp.num1, kp.num2));
+        }
+
+        for pairs in pairs_per_key.values_mut() {
+            pairs.sort();
+            for (i, &(n1, n2)) in pairs.iter().enumerate() {
+                let expected = (2 * i as u32, 2 * i as u32 + 1);
+                if (n1, n2) != expected {
+                    return false;
+                }
             }
-            *next_num1 += 2;
         }
 
         true
+    }
+
+    // For each distinct key expression that appears k times in the placeholders, returns the product of
+    // k! across all keys. This is the number of distinct ways the canonical derivation pairs
+    // (0,1), (2,3), ... can be permuted across the k occurrences.
+    fn key_derivation_orderings_count(&self) -> u64 {
+        let mut counts: alloc::collections::BTreeMap<super::KeyExpressionType, u32> =
+            alloc::collections::BTreeMap::new();
+        for (kp, _) in self.placeholders() {
+            *counts.entry(kp.key_type.clone()).or_insert(0) += 1;
+        }
+        let mut product = 1u64;
+        for &k in counts.values() {
+            let mut f = 1u64;
+            for i in 1..=k as u64 {
+                f = f.saturating_mul(i);
+            }
+            product = product.saturating_mul(f);
+        }
+        product
     }
 }
 
 impl ClearText for DescriptorTemplate {
     fn confusion_score(&self) -> u64 {
-        match self.classify() {
+        let base = match self.classify() {
             DescriptorClass::LegacySingleSig { .. } => 1,
             DescriptorClass::SegwitSingleSig { .. } => 2, // wpkh and sh(wpkh)
             DescriptorClass::SegwitMultisig { .. } => 4, // multi or sortedmulti / normal or wrapped
@@ -1059,25 +1092,27 @@ impl ClearText for DescriptorTemplate {
                 score
             }
             DescriptorClass::Other => 1,
-        }
+        };
+        // For each key expression that appears k times in the descriptor template, multiply by k!
+        // to account for the possible re-orderings of the canonical derivation pairs across its
+        // occurrences. This is only applied at the root level (not when recurring).
+        base.saturating_mul(self.key_derivation_orderings_count())
     }
 
     fn to_cleartext(&self) -> (Vec<String>, bool) {
-        let canonical = self.are_key_derivations_canonical();
+        if !self.are_key_derivations_canonical() {
+            return (vec![self.to_string()], false);
+        }
         match self.classify() {
             class @ DescriptorClass::LegacySingleSig { .. }
             | class @ DescriptorClass::SegwitSingleSig { .. }
             | class @ DescriptorClass::SegwitMultisig { .. } => (
-                vec![class
-                    .to_cleartext_string(canonical)
-                    .expect("missing cleartext")],
-                canonical,
+                vec![class.to_cleartext_string(true).expect("missing cleartext")],
+                true,
             ),
             class @ DescriptorClass::Taproot { .. }
             | class @ DescriptorClass::TaprootMusig { .. } => {
-                let primary_path = class
-                    .to_cleartext_string(canonical)
-                    .expect("missing cleartext");
+                let primary_path = class.to_cleartext_string(true).expect("missing cleartext");
                 let mut leaves = match class {
                     DescriptorClass::Taproot { leaves, .. } => leaves,
                     DescriptorClass::TaprootMusig { leaves, .. } => leaves,
@@ -1085,9 +1120,9 @@ impl ClearText for DescriptorTemplate {
                 };
                 leaves.sort_by(|a, b| a.display_cmp(b));
                 let mut descriptions = vec![primary_path];
-                let mut all_leaves_have_cleartext = canonical;
+                let mut all_leaves_have_cleartext = true;
                 for leaf in leaves {
-                    if let Some(description) = leaf.to_cleartext_string(canonical) {
+                    if let Some(description) = leaf.to_cleartext_string(true) {
                         descriptions.push(description);
                     } else {
                         let TapleafClass::Other(raw) = leaf else {
@@ -1110,7 +1145,9 @@ impl ClearText for DescriptorTemplate {
         let mut variants = Vec::new();
         for class in parse_top_level_candidates(descriptions)? {
             for variant in top_level_variants(class)? {
-                push_unique(&mut variants, variant);
+                for permuted in expand_derivation_orderings(variant) {
+                    push_unique(&mut variants, permuted);
+                }
             }
         }
         Ok(Box::new(variants.into_iter()))
@@ -1479,6 +1516,103 @@ fn parse_spec_parts(
 fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
     if !items.iter().any(|existing| existing == &item) {
         items.push(item);
+    }
+}
+
+#[cfg(any(test, feature = "cleartext-decode"))]
+fn permutations(n: usize) -> Vec<Vec<usize>> {
+    let mut result = Vec::new();
+    let mut current: Vec<usize> = (0..n).collect();
+    permute_helper(&mut current, 0, &mut result);
+    result
+}
+
+#[cfg(any(test, feature = "cleartext-decode"))]
+fn permute_helper(arr: &mut Vec<usize>, start: usize, out: &mut Vec<Vec<usize>>) {
+    if start == arr.len() {
+        out.push(arr.clone());
+        return;
+    }
+    for i in start..arr.len() {
+        arr.swap(start, i);
+        permute_helper(arr, start + 1, out);
+        arr.swap(start, i);
+    }
+}
+
+/// Given a base descriptor template (with canonical derivation pairs (0,1), (2,3), ...
+/// assigned to placeholder occurrences in source order, per key expression), return the
+/// list of all variants obtained by permuting the assignment of those canonical pairs
+/// across the occurrences of each key expression.
+#[cfg(any(test, feature = "cleartext-decode"))]
+fn expand_derivation_orderings(base: DescriptorTemplate) -> Vec<DescriptorTemplate> {
+    use alloc::collections::BTreeMap;
+
+    // Collect the source-order positions of placeholders, grouped by key expression.
+    let mut groups: BTreeMap<super::KeyExpressionType, Vec<usize>> = BTreeMap::new();
+    for (i, (kp, _)) in base.placeholders().enumerate() {
+        groups.entry(kp.key_type.clone()).or_default().push(i);
+    }
+
+    let positions_per_group: Vec<Vec<usize>> = groups.into_values().collect();
+    let perms_per_group: Vec<Vec<Vec<usize>>> = positions_per_group
+        .iter()
+        .map(|positions| permutations(positions.len()))
+        .collect();
+
+    let mut results = Vec::new();
+    let mut chosen: Vec<&Vec<usize>> = Vec::with_capacity(perms_per_group.len());
+    expand_derivation_orderings_rec(
+        &positions_per_group,
+        &perms_per_group,
+        &mut chosen,
+        &base,
+        &mut results,
+    );
+    results
+}
+
+#[cfg(any(test, feature = "cleartext-decode"))]
+fn expand_derivation_orderings_rec<'a>(
+    positions_per_group: &[Vec<usize>],
+    perms_per_group: &'a [Vec<Vec<usize>>],
+    chosen: &mut Vec<&'a Vec<usize>>,
+    base: &DescriptorTemplate,
+    results: &mut Vec<DescriptorTemplate>,
+) {
+    if chosen.len() == perms_per_group.len() {
+        // Build mapping: source-position -> (num1, num2)
+        let mut mapping: alloc::collections::BTreeMap<usize, (u32, u32)> =
+            alloc::collections::BTreeMap::new();
+        for (g, perm) in chosen.iter().enumerate() {
+            let positions = &positions_per_group[g];
+            for (slot, &src_pos) in positions.iter().enumerate() {
+                let p = perm[slot];
+                mapping.insert(src_pos, (2 * p as u32, 2 * p as u32 + 1));
+            }
+        }
+        let mut new_dt = base.clone();
+        let mut idx = 0;
+        for kp in new_dt.placeholders_mut() {
+            let (n1, n2) = mapping[&idx];
+            kp.num1 = n1;
+            kp.num2 = n2;
+            idx += 1;
+        }
+        results.push(new_dt);
+        return;
+    }
+    let g = chosen.len();
+    for p in &perms_per_group[g] {
+        chosen.push(p);
+        expand_derivation_orderings_rec(
+            positions_per_group,
+            perms_per_group,
+            chosen,
+            base,
+            results,
+        );
+        chosen.pop();
     }
 }
 
@@ -2076,6 +2210,16 @@ mod tests {
                 "tr(@0/**,{multi_a(2,@1/**,@2/**,@3/**),pk(musig(@4,@5)/**)})",
                 2,
             ),
+            (
+                // leaves are unambiguous, but keys @1 and @2 appear twice each, so the result is multiplied by 2! * 2!
+                "tr(@0/<0;1>/*,{and_v(v:multi_a(2,@1/<0;1>/*,@2/<0;1>/*,@3/<0;1>/*),older(144)),and_v(v:pk(@1/<2;3>/*),pk(@2/<2;3>/*))})", 
+                4
+            ),
+            (
+                // leaves are unambiguous, but keys @1 and @2 appear twice each, so the result is multiplied by 2! * 2!
+                "tr(@0/<0;1>/*,{and_v(v:multi_a(2,@1/<0;1>/*,@2/<0;1>/*,@3/<0;1>/*),older(144)),and_v(v:pk(@1/<2;3>/*),pk(@2/<2;3>/*))})", 
+                4
+            ),
         ];
 
         for &(desc_str, expected) in cases {
@@ -2130,6 +2274,12 @@ mod tests {
             "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(4194484)))",
             "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(840000)))",
             "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(1700000000)))",
+            // Key derivation ordering tests (keys appear multiple times with canonical derivations)
+            "tr(@0/<0;1>/*,pk(@0/<2;3>/*))",
+            "tr(@0/<0;1>/*,{pk(@0/<2;3>/*),pk(@0/<4;5>/*)})",
+            "tr(@0/**,{pk(@1/<0;1>/*),pk(@1/<2;3>/*)})",
+            "tr(@0/**,{and_v(v:pk(@1/<0;1>/*),older(4383)),pk(@1/<2;3>/*)})",
+            "tr(@0/<0;1>/*,{pk(@0/<2;3>/*),and_v(v:pk(@1/<0;1>/*),pk(@1/<2;3>/*))})",
         ];
         for &desc_str in cases {
             assert!(
@@ -2452,47 +2602,30 @@ mod tests {
                 true,
             ),
             // --------------------------------------------------------------------------------------
-            // Non-canonical key derivations: cleartext must includes <num1;num2> for all derivations
+            // Non-canonical key derivations: no cleartext representation; raw to_string() is returned.
             // --------------------------------------------------------------------------------------
             // Legacy single-sig: num1 is not 0 for the first (and only) occurrence
             (
                 "pkh(@0/<2;3>/*)",
-                &["Legacy single-signature (@0/<2;3>/*)"],
+                &["pkh(@0/<2;3>/*)"],
                 false,
             ),
             // Segwit single-sig: num2 is not num1+1
             (
                 "wpkh(@0/<0;2>/*)",
-                &["Segwit single-signature (@0/<0;2>/*)"],
-                false,
-            ),
-            // 2-of-2 sortedmulti: first key has wrong num1
-            (
-                "wsh(sortedmulti(2,@0/<2;3>/*,@1/**))",
-                &["2 of @0/<2;3>/* and @1/<0;1>/* (SegWit)"],
+                &["wpkh(@0/<0;2>/*)"],
                 false,
             ),
             // Taproot, key-path only: internal key has non-canonical derivation
             (
                 "tr(@0/<4;5>/*)",
-                &["Primary path: @0/<4;5>/*"],
+                &["tr(@0/<4;5>/*)"],
                 false,
             ),
             // Taproot single leaf: internal key canonical, leaf key non-canonical
             (
                 "tr(@0/**,pk(@1/<2;3>/*))",
-                &["Primary path: @0/<0;1>/*", "Single-signature (@1/<2;3>/*)"],
-                false,
-            ),
-            // Taproot two leaves: same key index appears twice, derivations reversed
-            // (first occurrence has <2;3>, second has <0;1> — both must be shown verbatim)
-            (
-                "tr(@0/**,{pk(@1/<2;3>/*),pk(@1/<0;1>/*)})",
-                &[
-                    "Primary path: @0/<0;1>/*",
-                    "Single-signature (@1/<2;3>/*)",
-                    "Single-signature (@1/<0;1>/*)",
-                ],
+                &["tr(@0/**,pk(@1/<2;3>/*))"],
                 false,
             ),
         ];
@@ -2573,6 +2706,13 @@ mod tests {
             "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(4194484)))",
             "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(840000)))",
             "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(1700000000)))",
+            // Key derivation ordering roundtrip tests
+            "tr(@0/<0;1>/*,pk(@0/<2;3>/*))",
+            "tr(@0/<0;1>/*,{pk(@0/<2;3>/*),pk(@0/<4;5>/*)})",
+            "tr(@0/**,{pk(@1/<0;1>/*),pk(@1/<2;3>/*)})",
+            "tr(@0/**,{and_v(v:pk(@1/<0;1>/*),older(4383)),pk(@1/<2;3>/*)})",
+            // @0 appears twice, @1 appears twice
+            "tr(@0/<0;1>/*,{pk(@0/<2;3>/*),and_v(v:pk(@1/<0;1>/*),pk(@1/<2;3>/*))})",
         ];
 
         for &desc_str in cases {

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -48,10 +48,19 @@ pub const MAX_CONFUSION_SCORE: u64 = 3600;
 const SEQUENCE_LOCKTIME_TYPE_FLAG: u32 = 1 << 22;
 
 /// Error type for `from_cleartext`.
+#[cfg(any(test, feature = "cleartext-decode"))]
 #[derive(Debug)]
-pub enum CleartextError {
-    /// The cleartext string could not be parsed.
-    ParseError(String),
+pub enum CleartextDecodeError {
+    /// The input descriptions slice was empty.
+    EmptyInput,
+    /// The cleartext string could not be matched to any known pattern.
+    UnrecognizedPattern,
+    /// A descriptor template string embedded in the cleartext could not be parsed.
+    InvalidDescriptor(String),
+    /// A key placeholder was expected to be a plain key but was not.
+    ExpectedPlainKey,
+    /// Internal inconsistency in spec/pattern matching (should not happen).
+    InternalError(&'static str),
 }
 
 // Private intermediate representations for the DescriptorTemplate variants for the root descriptor template that have
@@ -950,7 +959,7 @@ pub trait ClearText {
     #[cfg(any(test, feature = "cleartext-decode"))]
     fn from_cleartext(
         descriptions: &[&str],
-    ) -> Result<Box<dyn Iterator<Item = Self>>, CleartextError>
+    ) -> Result<Box<dyn Iterator<Item = Self>>, CleartextDecodeError>
     where
         Self: Sized;
 }
@@ -1141,7 +1150,7 @@ impl ClearText for DescriptorTemplate {
     #[cfg(any(test, feature = "cleartext-decode"))]
     fn from_cleartext(
         descriptions: &[&str],
-    ) -> Result<Box<dyn Iterator<Item = Self>>, CleartextError> {
+    ) -> Result<Box<dyn Iterator<Item = Self>>, CleartextDecodeError> {
         let mut variants = Vec::new();
         for class in parse_top_level_candidates(descriptions)? {
             for variant in top_level_variants(class)? {
@@ -1617,13 +1626,14 @@ fn expand_derivation_orderings_rec<'a>(
 }
 
 #[cfg(any(test, feature = "cleartext-decode"))]
-fn parse_leaf_candidates(s: &str) -> Result<Vec<TapleafClass>, CleartextError> {
+fn parse_leaf_candidates(s: &str) -> Result<Vec<TapleafClass>, CleartextDecodeError> {
     let mut leaves = Vec::new();
     for (kind, values) in parse_with_specs(TAPLEAF_SPECS, s) {
         push_unique(
             &mut leaves,
-            TapleafClass::from_cleartext_pattern(kind, values)
-                .expect("spec/from_cleartext_pattern mismatch: this is a bug"),
+            TapleafClass::from_cleartext_pattern(kind, values).ok_or(
+                CleartextDecodeError::InternalError("spec/from_cleartext_pattern mismatch"),
+            )?,
         );
     }
     if leaves.is_empty() {
@@ -1653,17 +1663,18 @@ fn collect_tapleaf_combinations(
 #[cfg(any(test, feature = "cleartext-decode"))]
 fn parse_top_level_candidates(
     descriptions: &[&str],
-) -> Result<Vec<DescriptorClass>, CleartextError> {
-    let err = || CleartextError::ParseError("unrecognized cleartext".into());
+) -> Result<Vec<DescriptorClass>, CleartextDecodeError> {
+    let err = || CleartextDecodeError::UnrecognizedPattern;
     match descriptions {
-        [] => Err(CleartextError::ParseError("empty descriptions".into())),
+        [] => Err(CleartextDecodeError::EmptyInput),
         [single] => {
             let mut classes = Vec::new();
             for (kind, values) in parse_with_specs(TOP_LEVEL_SPECS, single) {
                 push_unique(
                     &mut classes,
-                    DescriptorClass::from_cleartext_pattern(kind, values)
-                        .expect("spec/from_cleartext_pattern mismatch: this is a bug"),
+                    DescriptorClass::from_cleartext_pattern(kind, values).ok_or(
+                        CleartextDecodeError::InternalError("spec/from_cleartext_pattern mismatch"),
+                    )?,
                 );
             }
             if classes.is_empty() {
@@ -1686,8 +1697,9 @@ fn parse_top_level_candidates(
             );
 
             for (kind, values) in parse_with_specs(TOP_LEVEL_SPECS, first) {
-                let base_class = DescriptorClass::from_cleartext_pattern(kind, values)
-                    .expect("spec/from_cleartext_pattern mismatch: this is a bug");
+                let base_class = DescriptorClass::from_cleartext_pattern(kind, values).ok_or(
+                    CleartextDecodeError::InternalError("spec/from_cleartext_pattern mismatch"),
+                )?;
                 match base_class {
                     DescriptorClass::Taproot { internal_key, .. } => {
                         for leaves in &leaf_combinations {
@@ -1729,7 +1741,9 @@ fn parse_top_level_candidates(
 // ---------------------------------------------------------------------------
 
 #[cfg(any(test, feature = "cleartext-decode"))]
-fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>, CleartextError> {
+fn tapleaf_to_descriptors(
+    leaf: &TapleafClass,
+) -> Result<Vec<DescriptorTemplate>, CleartextDecodeError> {
     match leaf {
         TapleafClass::SingleSig { key } => Ok(vec![DescriptorTemplate::Pk(key.clone())]),
         TapleafClass::BothMustSign { key1, key2 } => Ok(vec![DescriptorTemplate::And_v(
@@ -1748,7 +1762,12 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             let mut variants = vec![DescriptorTemplate::Multi_a(*threshold, keys.clone())];
             if *threshold as usize == keys.len() {
                 variants.push(DescriptorTemplate::Pk(KeyPlaceholder::musig(
-                    keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                    keys.iter()
+                        .map(|k| {
+                            k.plain_key_index()
+                                .ok_or(CleartextDecodeError::ExpectedPlainKey)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
                     0,
                     1,
                 )));
@@ -1789,7 +1808,12 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
                 variants.push(DescriptorTemplate::And_v(
                     Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
                         KeyPlaceholder::musig(
-                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            keys.iter()
+                                .map(|k| {
+                                    k.plain_key_index()
+                                        .ok_or(CleartextDecodeError::ExpectedPlainKey)
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
                             0,
                             1,
                         ),
@@ -1833,7 +1857,12 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
                 variants.push(DescriptorTemplate::And_v(
                     Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
                         KeyPlaceholder::musig(
-                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            keys.iter()
+                                .map(|k| {
+                                    k.plain_key_index()
+                                        .ok_or(CleartextDecodeError::ExpectedPlainKey)
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
                             0,
                             1,
                         ),
@@ -1879,7 +1908,12 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
                 variants.push(DescriptorTemplate::And_v(
                     Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
                         KeyPlaceholder::musig(
-                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            keys.iter()
+                                .map(|k| {
+                                    k.plain_key_index()
+                                        .ok_or(CleartextDecodeError::ExpectedPlainKey)
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
                             0,
                             1,
                         ),
@@ -1925,7 +1959,12 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
                 variants.push(DescriptorTemplate::And_v(
                     Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
                         KeyPlaceholder::musig(
-                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            keys.iter()
+                                .map(|k| {
+                                    k.plain_key_index()
+                                        .ok_or(CleartextDecodeError::ExpectedPlainKey)
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
                             0,
                             1,
                         ),
@@ -1937,7 +1976,7 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
         }
         TapleafClass::Other(s) => {
             let dt = DescriptorTemplate::from_str(s)
-                .map_err(|e| CleartextError::ParseError(format!("{:?}", e)))?;
+                .map_err(|e| CleartextDecodeError::InvalidDescriptor(format!("{:?}", e)))?;
             Ok(vec![dt])
         }
     }
@@ -2026,7 +2065,7 @@ fn enumerate_taptrees_indices(
 #[cfg(any(test, feature = "cleartext-decode"))]
 fn top_level_variants(
     class: DescriptorClass,
-) -> Result<Box<dyn Iterator<Item = DescriptorTemplate>>, CleartextError> {
+) -> Result<Box<dyn Iterator<Item = DescriptorTemplate>>, CleartextDecodeError> {
     match class {
         DescriptorClass::LegacySingleSig { key } => {
             Ok(Box::new(core::iter::once(DescriptorTemplate::Pkh(key))))
@@ -2113,9 +2152,7 @@ fn top_level_variants(
                 dt
             })))
         }
-        DescriptorClass::Other => Err(CleartextError::ParseError(
-            "cannot enumerate variants for unrecognized descriptor class".into(),
-        )),
+        DescriptorClass::Other => Err(CleartextDecodeError::UnrecognizedPattern),
     }
 }
 
@@ -2209,11 +2246,6 @@ mod tests {
             (
                 "tr(@0/**,{multi_a(2,@1/**,@2/**,@3/**),pk(musig(@4,@5)/**)})",
                 2,
-            ),
-            (
-                // leaves are unambiguous, but keys @1 and @2 appear twice each, so the result is multiplied by 2! * 2!
-                "tr(@0/<0;1>/*,{and_v(v:multi_a(2,@1/<0;1>/*,@2/<0;1>/*,@3/<0;1>/*),older(144)),and_v(v:pk(@1/<2;3>/*),pk(@2/<2;3>/*))})", 
-                4
             ),
             (
                 // leaves are unambiguous, but keys @1 and @2 appear twice each, so the result is multiplied by 2! * 2!

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -344,6 +344,24 @@ mod specs {
 }
 use specs::{TAPLEAF_SPECS, TOP_LEVEL_SPECS};
 
+/// Compares two key placeholders for canonical display ordering:
+/// - plain key vs plain key: ordered by key index
+/// - plain key vs musig: plain key comes first
+/// - musig vs musig: ordered by number of keys, then left-to-right by key index
+fn cmp_key(a: &KeyPlaceholder, b: &KeyPlaceholder) -> core::cmp::Ordering {
+    use super::KeyExpressionType;
+    match (&a.key_type, &b.key_type) {
+        (KeyExpressionType::PlainKey(i1), KeyExpressionType::PlainKey(i2)) => i1.cmp(i2),
+        (KeyExpressionType::PlainKey(_), KeyExpressionType::Musig(_)) => core::cmp::Ordering::Less,
+        (KeyExpressionType::Musig(_), KeyExpressionType::PlainKey(_)) => {
+            core::cmp::Ordering::Greater
+        }
+        (KeyExpressionType::Musig(i1), KeyExpressionType::Musig(i2)) => {
+            i1.len().cmp(&i2.len()).then_with(|| i1.cmp(i2))
+        }
+    }
+}
+
 impl TapleafClass {
     /// Returns a numeric key that defines the canonical visualization order for
     /// taptree leaves:
@@ -392,11 +410,11 @@ impl TapleafClass {
             (
                 TC::SingleSig { key: k1 },
                 TC::SingleSig { key: k2 },
-            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)),
+            ) => cmp_key(k1, k2),
             (
                 TC::BothMustSign { key1: a1, key2: b1 },
                 TC::BothMustSign { key1: a2, key2: b2 },
-            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))),
+            ) => cmp_key(a1, a2).then(cmp_key(b1, b2)),
             (
                 TC::SortedMultisig { threshold: t1, keys: k1 },
                 TC::SortedMultisig { threshold: t2, keys: k2 },
@@ -408,11 +426,11 @@ impl TapleafClass {
             (
                 TC::RelativeHeightlockSingleSig { key: k1, blocks: b1 },
                 TC::RelativeHeightlockSingleSig { key: k2, blocks: b2 },
-            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(b1.cmp(b2)),
+            ) => cmp_key(k1, k2).then(b1.cmp(b2)),
             (
                 TC::RelativeHeightlockBothMustSign { key1: a1, key2: b1, blocks: bl1 },
                 TC::RelativeHeightlockBothMustSign { key1: a2, key2: b2, blocks: bl2 },
-            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(bl1.cmp(bl2)),
+            ) => cmp_key(a1, a2).then(cmp_key(b1, b2)).then(bl1.cmp(bl2)),
             (
                 TC::RelativeHeightlockMultiSig { threshold: t1, keys: k1, blocks: b1 },
                 TC::RelativeHeightlockMultiSig { threshold: t2, keys: k2, blocks: b2 },
@@ -420,11 +438,11 @@ impl TapleafClass {
             (
                 TC::RelativeTimelockSingleSig { key: k1, time: t1 },
                 TC::RelativeTimelockSingleSig { key: k2, time: t2 },
-            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(t1.cmp(t2)),
+            ) => cmp_key(k1, k2).then(t1.cmp(t2)),
             (
                 TC::RelativeTimelockBothMustSign { key1: a1, key2: b1, time: t1 },
                 TC::RelativeTimelockBothMustSign { key1: a2, key2: b2, time: t2 },
-            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(t1.cmp(t2)),
+            ) => cmp_key(a1, a2).then(cmp_key(b1, b2)).then(t1.cmp(t2)),
             (
                 TC::RelativeTimelockMultiSig { threshold: t1, keys: k1, time: tm1 },
                 TC::RelativeTimelockMultiSig { threshold: t2, keys: k2, time: tm2 },
@@ -432,27 +450,27 @@ impl TapleafClass {
             (
                 TC::AbsoluteHeightlockSingleSig { key: k1, block_height: h1 },
                 TC::AbsoluteHeightlockSingleSig { key: k2, block_height: h2 },
-            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(h1.cmp(h2)),
+            ) => cmp_key(k1, k2).then(h1.cmp(h2)),
             (
                 TC::AbsoluteHeightlockBothMustSign { key1: a1, key2: b1, block_height: h1 },
                 TC::AbsoluteHeightlockBothMustSign { key1: a2, key2: b2, block_height: h2 },
-            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(h1.cmp(&h2)),
+            ) => cmp_key(a1, a2).then(cmp_key(b1, b2)).then(h1.cmp(h2)),
             (
                 TC::AbsoluteHeightlockMultiSig { threshold: t1, keys: k1, block_height: h1 },
                 TC::AbsoluteHeightlockMultiSig { threshold: t2, keys: k2, block_height: h2 },
-            ) => k1.len().cmp(&k2.len()).then(t1.cmp(t2)).then(h1.cmp(&h2)),
+            ) => k1.len().cmp(&k2.len()).then(t1.cmp(t2)).then(h1.cmp(h2)),
             (
                 TC::AbsoluteTimelockSingleSig { key: k1, timestamp: ts1 },
                 TC::AbsoluteTimelockSingleSig { key: k2, timestamp: ts2 },
-            ) => k1.plain_key_index().unwrap_or(0).cmp(&k2.plain_key_index().unwrap_or(0)).then(ts1.cmp(&ts2)),
+            ) => cmp_key(k1, k2).then(ts1.cmp(ts2)),
             (
                 TC::AbsoluteTimelockBothMustSign { key1: a1, key2: b1, timestamp: ts1 },
                 TC::AbsoluteTimelockBothMustSign { key1: a2, key2: b2, timestamp: ts2 },
-            ) => a1.plain_key_index().unwrap_or(0).cmp(&a2.plain_key_index().unwrap_or(0)).then(b1.plain_key_index().unwrap_or(0).cmp(&b2.plain_key_index().unwrap_or(0))).then(ts1.cmp(&ts2)),
+            ) => cmp_key(a1, a2).then(cmp_key(b1, b2)).then(ts1.cmp(ts2)),
             (
                 TC::AbsoluteTimelockMultiSig { threshold: t1, keys: k1, timestamp: ts1 },
                 TC::AbsoluteTimelockMultiSig { threshold: t2, keys: k2, timestamp: ts2 },
-            ) => k1.len().cmp(&k2.len()).then(t1.cmp(t2)).then(ts1.cmp(&ts2)),
+            ) => k1.len().cmp(&k2.len()).then(t1.cmp(t2)).then(ts1.cmp(ts2)),
             (TC::Other(s1), TC::Other(s2)) => s1.cmp(s2),
             // Same order() value implies same variant; this arm is unreachable.
             _ => Ordering::Equal,
@@ -866,13 +884,11 @@ impl DescriptorTemplate {
     // then <2;3>/*, etc. This guarantees that no information on the derivations is lost when omitting this part
     // in the cleartext representation.
     fn are_key_derivations_canonical(&self) -> bool {
-        let mut next_num1_per_key: alloc::collections::BTreeMap<u32, u64> =
+        let mut next_num1_per_key: alloc::collections::BTreeMap<super::KeyExpressionType, u64> =
             alloc::collections::BTreeMap::new();
 
         for (kp, _) in self.placeholders() {
-            let next_num1 = next_num1_per_key
-                .entry(kp.plain_key_index().unwrap_or(0))
-                .or_insert(0);
+            let next_num1 = next_num1_per_key.entry(kp.key_type.clone()).or_insert(0);
             if kp.num1 as u64 != *next_num1 || kp.num2 as u64 != *next_num1 + 1 {
                 return false;
             }
@@ -1711,12 +1727,10 @@ fn top_level_variants(
             let trees = enumerate_taptrees(per_leaf_variants);
             Ok(Box::new(trees.map(move |t| {
                 let mut dt = DescriptorTemplate::Tr(internal_key.clone(), Some(t));
-                let mut next_per_key: alloc::collections::BTreeMap<u32, u32> =
+                let mut next_per_key: alloc::collections::BTreeMap<super::KeyExpressionType, u32> =
                     alloc::collections::BTreeMap::new();
                 for kp in dt.placeholders_mut() {
-                    let next = next_per_key
-                        .entry(kp.plain_key_index().unwrap_or(0))
-                        .or_insert(0);
+                    let next = next_per_key.entry(kp.key_type.clone()).or_insert(0);
                     kp.num1 = *next;
                     kp.num2 = *next + 1;
                     *next += 2;

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -38,7 +38,7 @@ use super::time::{parse_relative_time_to_seconds, parse_utc_date_to_timestamp};
 #[cfg(any(test, feature = "cleartext-decode"))]
 use super::TapTree;
 #[cfg(any(test, feature = "cleartext-decode"))]
-use alloc::rc::Rc;
+use alloc::{boxed::Box, rc::Rc};
 #[cfg(any(test, feature = "cleartext-decode"))]
 use core::str::FromStr;
 
@@ -70,7 +70,13 @@ enum DescriptorClass {
         keys: Vec<KeyPlaceholder>,
     },
     Taproot {
+        // taproot descriptor templates where the internal key is a plain key
         internal_key: KeyPlaceholder,
+        leaves: Vec<TapleafClass>,
+    },
+    TaprootMusig {
+        // taproot descriptor templates where the internal key is a musig expression
+        keys: Vec<KeyPlaceholder>,
         leaves: Vec<TapleafClass>,
     },
     Other,
@@ -207,6 +213,7 @@ enum TopLevelPattern {
     SegwitSingleSig,
     SegwitMultisig,
     Taproot,
+    TaprootMusig,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -272,6 +279,10 @@ mod specs {
         CleartextSpec {
             kind: TopLevelPattern::Taproot,
             parts: &[lit("Primary path: "), KeyIndex],
+        },
+        CleartextSpec {
+            kind: TopLevelPattern::TaprootMusig,
+            parts: &[lit("Primary path: "), Threshold, lit(" of "), KeyIndices],
         },
     ];
 
@@ -501,6 +512,19 @@ impl DescriptorTemplate {
                         .unwrap_or_default(),
                 }
             },
+            tr(musig(key_indices), tree) => {
+                let keys = key_indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, 0, 1))
+                    .collect();
+                DescriptorClass::TaprootMusig {
+                    keys,
+                    leaves: tree
+                        .as_ref()
+                        .map(|t| t.tapleaves().map(|l| l.classify_as_tapleaf()).collect())
+                        .unwrap_or_default(),
+                }
+            },
             _ => { DescriptorClass::Other },
         })
     }
@@ -682,6 +706,13 @@ impl DescriptorClass {
             DescriptorClass::Taproot { internal_key, .. } => Some((
                 TopLevelPattern::Taproot,
                 vec![CleartextValue::KeyIndex(internal_key.clone())],
+            )),
+            DescriptorClass::TaprootMusig { keys, .. } => Some((
+                TopLevelPattern::TaprootMusig,
+                vec![
+                    CleartextValue::Threshold(keys.len() as u32),
+                    CleartextValue::KeyIndices(keys.clone()),
+                ],
             )),
             DescriptorClass::Other => None,
         }
@@ -905,7 +936,8 @@ impl ClearText for DescriptorTemplate {
             DescriptorClass::LegacySingleSig { .. } => 1,
             DescriptorClass::SegwitSingleSig { .. } => 2, // wpkh and sh(wpkh)
             DescriptorClass::SegwitMultisig { .. } => 4, // multi or sortedmulti / normal or wrapped
-            DescriptorClass::Taproot { leaves, .. } => {
+            DescriptorClass::Taproot { leaves, .. }
+            | DescriptorClass::TaprootMusig { leaves, .. } => {
                 // The confusion score of a taproot descriptor is the product of the confusion scores of the internal key and all the leaves,
                 // multiplied by the number T(n) of rearrangements of the tree.
                 let mut score = 1u64;
@@ -958,12 +990,15 @@ impl ClearText for DescriptorTemplate {
                     .expect("missing cleartext")],
                 canonical,
             ),
-            class @ DescriptorClass::Taproot { .. } => {
+            class @ DescriptorClass::Taproot { .. }
+            | class @ DescriptorClass::TaprootMusig { .. } => {
                 let primary_path = class
                     .to_cleartext_string(canonical)
                     .expect("missing cleartext");
-                let DescriptorClass::Taproot { mut leaves, .. } = class else {
-                    unreachable!();
+                let mut leaves = match class {
+                    DescriptorClass::Taproot { leaves, .. } => leaves,
+                    DescriptorClass::TaprootMusig { leaves, .. } => leaves,
+                    _ => unreachable!(),
                 };
                 leaves.sort_by(|a, b| a.display_cmp(b));
                 let mut descriptions = vec![primary_path];
@@ -1134,6 +1169,17 @@ impl DescriptorClass {
                 internal_key: values.key_index()?,
                 leaves: Vec::new(),
             },
+            TopLevelPattern::TaprootMusig => {
+                let threshold = values.threshold()?;
+                let keys = values.key_indices()?;
+                if threshold as usize != keys.len() {
+                    return None;
+                }
+                DescriptorClass::TaprootMusig {
+                    keys,
+                    leaves: Vec::new(),
+                }
+            }
         };
         values.finish()?;
         Some(result)
@@ -1416,23 +1462,32 @@ fn parse_top_level_candidates(
             );
 
             for (kind, values) in parse_with_specs(TOP_LEVEL_SPECS, first) {
-                if kind != TopLevelPattern::Taproot {
-                    continue;
-                }
                 let base_class = DescriptorClass::from_cleartext_pattern(kind, values)
                     .expect("spec/from_cleartext_pattern mismatch: this is a bug");
-                let DescriptorClass::Taproot { internal_key, .. } = base_class else {
-                    continue;
-                };
-
-                for leaves in &leaf_combinations {
-                    push_unique(
-                        &mut classes,
-                        DescriptorClass::Taproot {
-                            internal_key: internal_key.clone(),
-                            leaves: leaves.clone(),
-                        },
-                    );
+                match base_class {
+                    DescriptorClass::Taproot { internal_key, .. } => {
+                        for leaves in &leaf_combinations {
+                            push_unique(
+                                &mut classes,
+                                DescriptorClass::Taproot {
+                                    internal_key: internal_key.clone(),
+                                    leaves: leaves.clone(),
+                                },
+                            );
+                        }
+                    }
+                    DescriptorClass::TaprootMusig { keys, .. } => {
+                        for leaves in &leaf_combinations {
+                            push_unique(
+                                &mut classes,
+                                DescriptorClass::TaprootMusig {
+                                    keys: keys.clone(),
+                                    leaves: leaves.clone(),
+                                },
+                            );
+                        }
+                    }
+                    _ => continue,
                 }
             }
 
@@ -1738,6 +1793,41 @@ fn top_level_variants(
                 dt
             })))
         }
+        DescriptorClass::TaprootMusig { keys, leaves } => {
+            let key_indices: Vec<u32> = keys
+                .iter()
+                .map(|k| {
+                    k.plain_key_index()
+                        .expect("TaprootMusig keys must be plain")
+                })
+                .collect();
+            let num1 = keys.first().map(|k| k.num1).unwrap_or(0);
+            let num2 = keys.first().map(|k| k.num2).unwrap_or(1);
+            let internal_key = KeyPlaceholder::musig(key_indices, num1, num2);
+            if leaves.is_empty() {
+                return Ok(Box::new(core::iter::once(DescriptorTemplate::Tr(
+                    internal_key,
+                    None,
+                ))));
+            }
+            let mut per_leaf_variants = Vec::new();
+            for leaf in &leaves {
+                per_leaf_variants.push(tapleaf_to_descriptors(leaf)?);
+            }
+            let trees = enumerate_taptrees(per_leaf_variants);
+            Ok(Box::new(trees.map(move |t| {
+                let mut dt = DescriptorTemplate::Tr(internal_key.clone(), Some(t));
+                let mut next_per_key: alloc::collections::BTreeMap<super::KeyExpressionType, u32> =
+                    alloc::collections::BTreeMap::new();
+                for kp in dt.placeholders_mut() {
+                    let next = next_per_key.entry(kp.key_type.clone()).or_insert(0);
+                    kp.num1 = *next;
+                    kp.num2 = *next + 1;
+                    *next += 2;
+                }
+                dt
+            })))
+        }
         DescriptorClass::Other => Err(CleartextError::ParseError(
             "cannot enumerate variants for unrecognized descriptor class".into(),
         )),
@@ -1800,6 +1890,16 @@ mod tests {
                 "tr(@0/**,{pk(@1/**),and_v(v:multi_a(2,@2/<0;1>/*,@3/<0;1>/*),older(4194484))})",
                 1,
             ),
+            // Taproot with musig internal key: key-path only (score 1)
+            ("tr(musig(@0,@1)/**)", 1),
+            // Taproot with musig internal key: 3 keys (score 1)
+            ("tr(musig(@0,@1,@2)/**)", 1),
+            // Taproot with musig internal key + 1 SingleSig leaf (score 1)
+            ("tr(musig(@0,@1)/**,pk(@2/**))", 1),
+            // Taproot with musig internal key + 2 SingleSig leaves: T(2)=1 → 1
+            ("tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})", 1),
+            // Taproot with musig internal key + 3 SingleSig leaves: T(3)=3 → 3
+            ("tr(musig(@0,@1)/**,{{pk(@2/**),pk(@3/**)},pk(@4/**)})", 3),
         ];
 
         for &(desc_str, expected) in cases {
@@ -1842,6 +1942,11 @@ mod tests {
             "tr(@0/**,{pk(@1/**),and_v(v:multi_a(2,@2/<0;1>/*,@3/<0;1>/*),after(840000))})",
             "tr(@0/**,and_v(v:pk(@1/<0;1>/*),after(500000000)))",
             "tr(@0/**,{pk(@1/**),and_v(v:multi_a(2,@2/<0;1>/*,@3/<0;1>/*),after(1700000000))})",
+            // Taproot with musig internal key
+            "tr(musig(@0,@1)/**)",
+            "tr(musig(@0,@1,@2)/**)",
+            "tr(musig(@0,@1)/**,pk(@2/**))",
+            "tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})",
         ];
         for &desc_str in cases {
             assert!(
@@ -2072,6 +2177,49 @@ mod tests {
                 true,
             ),
             // --------------------------------------------------------------------------------------
+            // Taproot with musig() internal key
+            // --------------------------------------------------------------------------------------
+            // Taproot: musig key-path only (2-of-2)
+            (
+                "tr(musig(@0,@1)/**)",
+                &["Primary path: 2 of @0 and @1"],
+                true,
+            ),
+            // Taproot: musig key-path only (3-of-3)
+            (
+                "tr(musig(@0,@1,@2)/**)",
+                &["Primary path: 3 of @0, @1 and @2"],
+                true,
+            ),
+            // Taproot: musig key-path + single leaf
+            (
+                "tr(musig(@0,@1)/**,pk(@2/**))",
+                &[
+                    "Primary path: 2 of @0 and @1",
+                    "Single-signature (@2)",
+                ],
+                true,
+            ),
+            // Taproot: musig key-path + two leaves
+            (
+                "tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})",
+                &[
+                    "Primary path: 2 of @0 and @1",
+                    "Single-signature (@2)",
+                    "Single-signature (@3)",
+                ],
+                true,
+            ),
+            // Taproot: musig key-path + relative heightlock leaf
+            (
+                "tr(musig(@0,@1)/**,and_v(v:pk(@2/<0;1>/*),older(1008)))",
+                &[
+                    "Primary path: 2 of @0 and @1",
+                    "@2 after 1008 blocks",
+                ],
+                true,
+            ),
+            // --------------------------------------------------------------------------------------
             // Non-canonical key derivations: cleartext must includes <num1;num2> for all derivations
             // --------------------------------------------------------------------------------------
             // Legacy single-sig: num1 is not 0 for the first (and only) occurrence
@@ -2178,6 +2326,14 @@ mod tests {
             // Taproot: BothMustSign (key repeated across leaves with canonical derivations)
             "tr(@0/<0;1>/*,{and_v(v:pk(@1/<0;1>/*),older(4383)),and_v(v:pk(@2/<0;1>/*),pk(@1/<2;3>/*))})",
             "tr(@0/<0;1>/*,{and_v(v:multi_a(2,@1/<0;1>/*,@2/<0;1>/*,@3/<0;1>/*),older(144)),and_v(v:pk(@1/<2;3>/*),pk(@2/<2;3>/*))})",
+            // Taproot: musig key-path only
+            "tr(musig(@0,@1)/**)",
+            "tr(musig(@0,@1,@2)/**)",
+            // Taproot: musig key-path with leaves
+            "tr(musig(@0,@1)/**,pk(@2/**))",
+            "tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})",
+            "tr(musig(@0,@1)/**,and_v(v:pk(@2/<0;1>/*),older(1008)))",
+            "tr(musig(@0,@1)/**,{pk(@2/**),and_v(v:pk(@3/<0;1>/*),after(840000))})",
         ];
 
         for &desc_str in cases {

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -463,19 +463,16 @@ impl TapleafClass {
 impl DescriptorTemplate {
     fn classify(&self) -> DescriptorClass {
         descriptor_match!(self, {
-            pkh(_key_index) => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                DescriptorClass::LegacySingleSig { key }
+            pkh(key) => {
+                DescriptorClass::LegacySingleSig { key: key.clone() }
             },
             // normal or wrapped
-            wpkh(_key_index) | sh(wpkh(_key_index)) => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                DescriptorClass::SegwitSingleSig { key }
+            wpkh(key) | sh(wpkh(key)) => {
+                DescriptorClass::SegwitSingleSig { key: key.clone() }
             },
             // 4 combinations: multi/sortedmulti; normal/wrapped
-            wsh(multi(threshold, _key_indices)) | wsh(sortedmulti(threshold, _key_indices)) | sh(wsh(multi(threshold, _key_indices))) | sh(wsh(sortedmulti(threshold, _key_indices))) => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                DescriptorClass::SegwitMultisig { threshold, keys }
+            wsh(multi(threshold, keys)) | wsh(sortedmulti(threshold, keys)) | sh(wsh(multi(threshold, keys))) | sh(wsh(sortedmulti(threshold, keys))) => {
+                DescriptorClass::SegwitMultisig { threshold, keys: keys.clone() }
             },
             tr(internal_key, tree) => {
                 DescriptorClass::Taproot {
@@ -492,79 +489,53 @@ impl DescriptorTemplate {
 
     fn classify_as_tapleaf(&self) -> TapleafClass {
         descriptor_match!(self, {
-            sortedmulti_a(threshold, _key_indices) => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                TapleafClass::SortedMultisig { threshold, keys }
+            sortedmulti_a(threshold, keys) => {
+                TapleafClass::SortedMultisig { threshold, keys: keys.clone() }
             },
-            pk(_key_index) | pkh(_key_index) => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                TapleafClass::SingleSig { key }
+            pk(key) | pkh(key) => {
+                TapleafClass::SingleSig { key: key.clone() }
             },
-            multi_a(threshold, _key_indices) => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                TapleafClass::Multisig { threshold, keys }
+            multi_a(threshold, keys) => {
+                TapleafClass::Multisig { threshold, keys: keys.clone() }
             },
-            and_v(v:pk(_key_index), older(blocks)) if blocks >= 1 && blocks < 65536 => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                TapleafClass::RelativeHeightlockSingleSig { key, blocks }
+            and_v(v:pk(key), older(blocks)) if blocks >= 1 && blocks < 65536 => {
+                TapleafClass::RelativeHeightlockSingleSig { key: key.clone(), blocks }
             },
-            and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), older(blocks)) if blocks >= 1 && blocks < 65536 => {
-                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
-                let key1 = phs.next().unwrap();
-                let key2 = phs.next().unwrap();
-                TapleafClass::RelativeHeightlockBothMustSign { key1, key2, blocks }
+            and_v(v:and_v(v:pk(key1), pk(key2)), older(blocks)) if blocks >= 1 && blocks < 65536 => {
+                TapleafClass::RelativeHeightlockBothMustSign { key1: key1.clone(), key2: key2.clone(), blocks }
             },
-            and_v(v:multi_a(threshold, _key_indices), older(blocks)) if blocks >= 1 && blocks < 65536 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                TapleafClass::RelativeHeightlockMultiSig { threshold, keys, blocks }
+            and_v(v:multi_a(threshold, keys), older(blocks)) if blocks >= 1 && blocks < 65536 => {
+                TapleafClass::RelativeHeightlockMultiSig { threshold, keys: keys.clone(), blocks }
             },
-            and_v(v:pk(_key_index), older(time)) if time >= 4194305 && time < 4259840 => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                TapleafClass::RelativeTimelockSingleSig { key, time }
+            and_v(v:pk(key), older(time)) if time >= 4194305 && time < 4259840 => {
+                TapleafClass::RelativeTimelockSingleSig { key: key.clone(), time }
             },
-            and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), older(time)) if time >= 4194305 && time < 4259840 => {
-                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
-                let key1 = phs.next().unwrap();
-                let key2 = phs.next().unwrap();
-                TapleafClass::RelativeTimelockBothMustSign { key1, key2, time }
+            and_v(v:and_v(v:pk(key1), pk(key2)), older(time)) if time >= 4194305 && time < 4259840 => {
+                TapleafClass::RelativeTimelockBothMustSign { key1: key1.clone(), key2: key2.clone(), time }
             },
-            and_v(v:multi_a(threshold, _key_indices), older(time)) if time >= 4194305 && time < 4259840 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                TapleafClass::RelativeTimelockMultiSig { threshold, keys, time }
+            and_v(v:multi_a(threshold, keys), older(time)) if time >= 4194305 && time < 4259840 => {
+                TapleafClass::RelativeTimelockMultiSig { threshold, keys: keys.clone(), time }
             },
-            and_v(v:pk(_key_index), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                TapleafClass::AbsoluteHeightlockSingleSig { key, block_height }
+            and_v(v:pk(key), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
+                TapleafClass::AbsoluteHeightlockSingleSig { key: key.clone(), block_height }
             },
-            and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
-                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
-                let key1 = phs.next().unwrap();
-                let key2 = phs.next().unwrap();
-                TapleafClass::AbsoluteHeightlockBothMustSign { key1, key2, block_height }
+            and_v(v:and_v(v:pk(key1), pk(key2)), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
+                TapleafClass::AbsoluteHeightlockBothMustSign { key1: key1.clone(), key2: key2.clone(), block_height }
             },
-            and_v(v:multi_a(threshold, _key_indices), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                TapleafClass::AbsoluteHeightlockMultiSig { threshold, keys, block_height }
+            and_v(v:multi_a(threshold, keys), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
+                TapleafClass::AbsoluteHeightlockMultiSig { threshold, keys: keys.clone(), block_height }
             },
-            and_v(v:pk(_key_index), after(timestamp)) if timestamp >= 500000000 => {
-                let key = self.placeholders().next().map(|(kp, _)| kp.clone()).unwrap();
-                TapleafClass::AbsoluteTimelockSingleSig { key, timestamp }
+            and_v(v:pk(key), after(timestamp)) if timestamp >= 500000000 => {
+                TapleafClass::AbsoluteTimelockSingleSig { key: key.clone(), timestamp }
             },
-            and_v(v:and_v(v:pk(_key_index1), pk(_key_index2)), after(timestamp)) if timestamp >= 500000000 => {
-                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
-                let key1 = phs.next().unwrap();
-                let key2 = phs.next().unwrap();
-                TapleafClass::AbsoluteTimelockBothMustSign { key1, key2, timestamp }
+            and_v(v:and_v(v:pk(key1), pk(key2)), after(timestamp)) if timestamp >= 500000000 => {
+                TapleafClass::AbsoluteTimelockBothMustSign { key1: key1.clone(), key2: key2.clone(), timestamp }
             },
-            and_v(v:multi_a(threshold, _key_indices), after(timestamp)) if timestamp >= 500000000 => {
-                let keys: Vec<KeyPlaceholder> = self.placeholders().map(|(kp, _)| kp.clone()).collect();
-                TapleafClass::AbsoluteTimelockMultiSig { threshold, keys, timestamp }
+            and_v(v:multi_a(threshold, keys), after(timestamp)) if timestamp >= 500000000 => {
+                TapleafClass::AbsoluteTimelockMultiSig { threshold, keys: keys.clone(), timestamp }
             },
-            and_v(v:pk(_key_index1), pk(_key_index2)) => {
-                let mut phs = self.placeholders().map(|(kp, _)| kp.clone());
-                let key1 = phs.next().unwrap();
-                let key2 = phs.next().unwrap();
-                TapleafClass::BothMustSign { key1, key2 }
+            and_v(v:pk(key1), pk(key2)) => {
+                TapleafClass::BothMustSign { key1: key1.clone(), key2: key2.clone() }
             },
             _ => { TapleafClass::Other(self.to_string()) },
         })
@@ -576,7 +547,8 @@ fn format_key(kp: &KeyPlaceholder, canonical: bool) -> String {
         match &kp.key_type {
             super::KeyExpressionType::PlainKey(key_index) => format!("@{}", key_index),
             super::KeyExpressionType::Musig(key_indices) => {
-                let inner: Vec<String> = key_indices.iter().map(|idx| format!("@{}", idx)).collect();
+                let inner: Vec<String> =
+                    key_indices.iter().map(|idx| format!("@{}", idx)).collect();
                 format!("musig({})", inner.join(","))
             }
         }
@@ -587,7 +559,8 @@ fn format_key(kp: &KeyPlaceholder, canonical: bool) -> String {
                 format!("@{}/<{};{}>/*", key_index, kp.num1, kp.num2)
             }
             super::KeyExpressionType::Musig(key_indices) => {
-                let inner: Vec<String> = key_indices.iter().map(|idx| format!("@{}", idx)).collect();
+                let inner: Vec<String> =
+                    key_indices.iter().map(|idx| format!("@{}", idx)).collect();
                 format!("musig({})/<{};{}>/*", inner.join(","), kp.num1, kp.num2)
             }
         }
@@ -897,7 +870,9 @@ impl DescriptorTemplate {
             alloc::collections::BTreeMap::new();
 
         for (kp, _) in self.placeholders() {
-            let next_num1 = next_num1_per_key.entry(kp.plain_key_index().unwrap_or(0)).or_insert(0);
+            let next_num1 = next_num1_per_key
+                .entry(kp.plain_key_index().unwrap_or(0))
+                .or_insert(0);
             if kp.num1 as u64 != *next_num1 || kp.num2 as u64 != *next_num1 + 1 {
                 return false;
             }
@@ -1739,7 +1714,9 @@ fn top_level_variants(
                 let mut next_per_key: alloc::collections::BTreeMap<u32, u32> =
                     alloc::collections::BTreeMap::new();
                 for kp in dt.placeholders_mut() {
-                    let next = next_per_key.entry(kp.plain_key_index().unwrap_or(0)).or_insert(0);
+                    let next = next_per_key
+                        .entry(kp.plain_key_index().unwrap_or(0))
+                        .or_insert(0);
                     kp.num1 = *next;
                     kp.num2 = *next + 1;
                     *next += 2;

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -76,7 +76,7 @@ enum DescriptorClass {
     },
     TaprootMusig {
         // taproot descriptor templates where the internal key is a musig expression
-        keys: Vec<KeyPlaceholder>,
+        internal_key: KeyPlaceholder,
         leaves: Vec<TapleafClass>,
     },
     Other,
@@ -512,13 +512,9 @@ impl DescriptorTemplate {
                         .unwrap_or_default(),
                 }
             },
-            tr(musig(key_indices), tree) => {
-                let keys = key_indices
-                    .iter()
-                    .map(|&idx| KeyPlaceholder::plain(idx, 0, 1))
-                    .collect();
+            tr(musig(musig_key), tree) => {
                 DescriptorClass::TaprootMusig {
-                    keys,
+                    internal_key: musig_key.clone(),
                     leaves: tree
                         .as_ref()
                         .map(|t| t.tapleaves().map(|l| l.classify_as_tapleaf()).collect())
@@ -575,6 +571,46 @@ impl DescriptorTemplate {
             },
             and_v(v:multi_a(threshold, keys), after(timestamp)) if timestamp >= 500000000 => {
                 TapleafClass::AbsoluteTimelockMultiSig { threshold, keys: keys.clone(), timestamp }
+            },
+            pk(musig(musig_key)) | pkh(musig(musig_key)) => {
+                let indices = musig_key.musig_key_indices().unwrap();
+                let keys: Vec<KeyPlaceholder> = indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, musig_key.num1, musig_key.num2))
+                    .collect();
+                TapleafClass::Multisig { threshold: keys.len() as u32, keys }
+            },
+            and_v(v:pk(musig(musig_key)), older(blocks)) if blocks >= 1 && blocks < 65536 => {
+                let indices = musig_key.musig_key_indices().unwrap();
+                let keys: Vec<KeyPlaceholder> = indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, musig_key.num1, musig_key.num2))
+                    .collect();
+                TapleafClass::RelativeHeightlockMultiSig { threshold: keys.len() as u32, keys, blocks }
+            },
+            and_v(v:pk(musig(musig_key)), older(time)) if time >= 4194305 && time < 4259840 => {
+                let indices = musig_key.musig_key_indices().unwrap();
+                let keys: Vec<KeyPlaceholder> = indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, musig_key.num1, musig_key.num2))
+                    .collect();
+                TapleafClass::RelativeTimelockMultiSig { threshold: keys.len() as u32, keys, time }
+            },
+            and_v(v:pk(musig(musig_key)), after(block_height)) if block_height >= 1 && block_height < 500000000 => {
+                let indices = musig_key.musig_key_indices().unwrap();
+                let keys: Vec<KeyPlaceholder> = indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, musig_key.num1, musig_key.num2))
+                    .collect();
+                TapleafClass::AbsoluteHeightlockMultiSig { threshold: keys.len() as u32, keys, block_height }
+            },
+            and_v(v:pk(musig(musig_key)), after(timestamp)) if timestamp >= 500000000 => {
+                let indices = musig_key.musig_key_indices().unwrap();
+                let keys: Vec<KeyPlaceholder> = indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, musig_key.num1, musig_key.num2))
+                    .collect();
+                TapleafClass::AbsoluteTimelockMultiSig { threshold: keys.len() as u32, keys, timestamp }
             },
             and_v(v:pk(key1), pk(key2)) => {
                 TapleafClass::BothMustSign { key1: key1.clone(), key2: key2.clone() }
@@ -707,13 +743,22 @@ impl DescriptorClass {
                 TopLevelPattern::Taproot,
                 vec![CleartextValue::KeyIndex(internal_key.clone())],
             )),
-            DescriptorClass::TaprootMusig { keys, .. } => Some((
-                TopLevelPattern::TaprootMusig,
-                vec![
-                    CleartextValue::Threshold(keys.len() as u32),
-                    CleartextValue::KeyIndices(keys.clone()),
-                ],
-            )),
+            DescriptorClass::TaprootMusig { internal_key, .. } => {
+                let key_indices = internal_key
+                    .musig_key_indices()
+                    .expect("TaprootMusig internal_key must be musig");
+                let keys: Vec<KeyPlaceholder> = key_indices
+                    .iter()
+                    .map(|&idx| KeyPlaceholder::plain(idx, internal_key.num1, internal_key.num2))
+                    .collect();
+                Some((
+                    TopLevelPattern::TaprootMusig,
+                    vec![
+                        CleartextValue::Threshold(keys.len() as u32),
+                        CleartextValue::KeyIndices(keys),
+                    ],
+                ))
+            }
             DescriptorClass::Other => None,
         }
     }
@@ -946,20 +991,58 @@ impl ClearText for DescriptorTemplate {
                     let leaf_score = match leaf {
                         TapleafClass::SingleSig { .. } => 1,
                         TapleafClass::SortedMultisig { .. } => 1,
-                        TapleafClass::Multisig { .. } => 1,
+                        TapleafClass::Multisig { threshold, keys } => {
+                            if *threshold as usize == keys.len() {
+                                2
+                            } else {
+                                1
+                            }
+                        }
                         TapleafClass::BothMustSign { .. } => 1,
                         TapleafClass::RelativeHeightlockSingleSig { .. } => 1,
                         TapleafClass::RelativeHeightlockBothMustSign { .. } => 1,
-                        TapleafClass::RelativeHeightlockMultiSig { .. } => 1,
+                        TapleafClass::RelativeHeightlockMultiSig {
+                            threshold, keys, ..
+                        } => {
+                            if *threshold as usize == keys.len() {
+                                2
+                            } else {
+                                1
+                            }
+                        }
                         TapleafClass::RelativeTimelockSingleSig { .. } => 1,
                         TapleafClass::RelativeTimelockBothMustSign { .. } => 1,
-                        TapleafClass::RelativeTimelockMultiSig { .. } => 1,
+                        TapleafClass::RelativeTimelockMultiSig {
+                            threshold, keys, ..
+                        } => {
+                            if *threshold as usize == keys.len() {
+                                2
+                            } else {
+                                1
+                            }
+                        }
                         TapleafClass::AbsoluteHeightlockSingleSig { .. } => 1,
                         TapleafClass::AbsoluteHeightlockBothMustSign { .. } => 1,
-                        TapleafClass::AbsoluteHeightlockMultiSig { .. } => 1,
+                        TapleafClass::AbsoluteHeightlockMultiSig {
+                            threshold, keys, ..
+                        } => {
+                            if *threshold as usize == keys.len() {
+                                2
+                            } else {
+                                1
+                            }
+                        }
                         TapleafClass::AbsoluteTimelockSingleSig { .. } => 1,
                         TapleafClass::AbsoluteTimelockBothMustSign { .. } => 1,
-                        TapleafClass::AbsoluteTimelockMultiSig { .. } => 1,
+                        TapleafClass::AbsoluteTimelockMultiSig {
+                            threshold, keys, ..
+                        } => {
+                            if *threshold as usize == keys.len() {
+                                2
+                            } else {
+                                1
+                            }
+                        }
                         TapleafClass::Other(_) => 1,
                     };
                     score = score.saturating_mul(leaf_score);
@@ -1175,8 +1258,15 @@ impl DescriptorClass {
                 if threshold as usize != keys.len() {
                     return None;
                 }
+                let key_indices: Vec<u32> =
+                    keys.iter().filter_map(|k| k.plain_key_index()).collect();
+                if key_indices.len() != keys.len() {
+                    return None;
+                }
+                let num1 = keys.first().map(|k| k.num1).unwrap_or(0);
+                let num2 = keys.first().map(|k| k.num2).unwrap_or(1);
                 DescriptorClass::TaprootMusig {
-                    keys,
+                    internal_key: KeyPlaceholder::musig(key_indices, num1, num2),
                     leaves: Vec::new(),
                 }
             }
@@ -1476,12 +1566,12 @@ fn parse_top_level_candidates(
                             );
                         }
                     }
-                    DescriptorClass::TaprootMusig { keys, .. } => {
+                    DescriptorClass::TaprootMusig { internal_key, .. } => {
                         for leaves in &leaf_combinations {
                             push_unique(
                                 &mut classes,
                                 DescriptorClass::TaprootMusig {
-                                    keys: keys.clone(),
+                                    internal_key: internal_key.clone(),
                                     leaves: leaves.clone(),
                                 },
                             );
@@ -1521,7 +1611,15 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             )])
         }
         TapleafClass::Multisig { threshold, keys } => {
-            Ok(vec![DescriptorTemplate::Multi_a(*threshold, keys.clone())])
+            let mut variants = vec![DescriptorTemplate::Multi_a(*threshold, keys.clone())];
+            if *threshold as usize == keys.len() {
+                variants.push(DescriptorTemplate::Pk(KeyPlaceholder::musig(
+                    keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                    0,
+                    1,
+                )));
+            }
+            Ok(variants)
         }
         TapleafClass::RelativeHeightlockSingleSig { key, blocks } => {
             Ok(vec![DescriptorTemplate::And_v(
@@ -1546,12 +1644,27 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             threshold,
             keys,
             blocks,
-        } => Ok(vec![DescriptorTemplate::And_v(
-            Box::new(DescriptorTemplate::V(Box::new(
-                DescriptorTemplate::Multi_a(*threshold, keys.clone()),
-            ))),
-            Box::new(DescriptorTemplate::Older(*blocks)),
-        )]),
+        } => {
+            let mut variants = vec![DescriptorTemplate::And_v(
+                Box::new(DescriptorTemplate::V(Box::new(
+                    DescriptorTemplate::Multi_a(*threshold, keys.clone()),
+                ))),
+                Box::new(DescriptorTemplate::Older(*blocks)),
+            )];
+            if *threshold as usize == keys.len() {
+                variants.push(DescriptorTemplate::And_v(
+                    Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
+                        KeyPlaceholder::musig(
+                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            0,
+                            1,
+                        ),
+                    )))),
+                    Box::new(DescriptorTemplate::Older(*blocks)),
+                ));
+            }
+            Ok(variants)
+        }
         TapleafClass::RelativeTimelockSingleSig { key, time } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
@@ -1575,12 +1688,27 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             threshold,
             keys,
             time,
-        } => Ok(vec![DescriptorTemplate::And_v(
-            Box::new(DescriptorTemplate::V(Box::new(
-                DescriptorTemplate::Multi_a(*threshold, keys.clone()),
-            ))),
-            Box::new(DescriptorTemplate::Older(*time)),
-        )]),
+        } => {
+            let mut variants = vec![DescriptorTemplate::And_v(
+                Box::new(DescriptorTemplate::V(Box::new(
+                    DescriptorTemplate::Multi_a(*threshold, keys.clone()),
+                ))),
+                Box::new(DescriptorTemplate::Older(*time)),
+            )];
+            if *threshold as usize == keys.len() {
+                variants.push(DescriptorTemplate::And_v(
+                    Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
+                        KeyPlaceholder::musig(
+                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            0,
+                            1,
+                        ),
+                    )))),
+                    Box::new(DescriptorTemplate::Older(*time)),
+                ));
+            }
+            Ok(variants)
+        }
         TapleafClass::AbsoluteHeightlockSingleSig { key, block_height } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
@@ -1606,12 +1734,27 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             threshold,
             keys,
             block_height,
-        } => Ok(vec![DescriptorTemplate::And_v(
-            Box::new(DescriptorTemplate::V(Box::new(
-                DescriptorTemplate::Multi_a(*threshold, keys.clone()),
-            ))),
-            Box::new(DescriptorTemplate::After(*block_height)),
-        )]),
+        } => {
+            let mut variants = vec![DescriptorTemplate::And_v(
+                Box::new(DescriptorTemplate::V(Box::new(
+                    DescriptorTemplate::Multi_a(*threshold, keys.clone()),
+                ))),
+                Box::new(DescriptorTemplate::After(*block_height)),
+            )];
+            if *threshold as usize == keys.len() {
+                variants.push(DescriptorTemplate::And_v(
+                    Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
+                        KeyPlaceholder::musig(
+                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            0,
+                            1,
+                        ),
+                    )))),
+                    Box::new(DescriptorTemplate::After(*block_height)),
+                ));
+            }
+            Ok(variants)
+        }
         TapleafClass::AbsoluteTimelockSingleSig { key, timestamp } => {
             Ok(vec![DescriptorTemplate::And_v(
                 Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
@@ -1637,12 +1780,27 @@ fn tapleaf_to_descriptors(leaf: &TapleafClass) -> Result<Vec<DescriptorTemplate>
             threshold,
             keys,
             timestamp,
-        } => Ok(vec![DescriptorTemplate::And_v(
-            Box::new(DescriptorTemplate::V(Box::new(
-                DescriptorTemplate::Multi_a(*threshold, keys.clone()),
-            ))),
-            Box::new(DescriptorTemplate::After(*timestamp)),
-        )]),
+        } => {
+            let mut variants = vec![DescriptorTemplate::And_v(
+                Box::new(DescriptorTemplate::V(Box::new(
+                    DescriptorTemplate::Multi_a(*threshold, keys.clone()),
+                ))),
+                Box::new(DescriptorTemplate::After(*timestamp)),
+            )];
+            if *threshold as usize == keys.len() {
+                variants.push(DescriptorTemplate::And_v(
+                    Box::new(DescriptorTemplate::V(Box::new(DescriptorTemplate::Pk(
+                        KeyPlaceholder::musig(
+                            keys.iter().map(|k| k.plain_key_index().unwrap()).collect(),
+                            0,
+                            1,
+                        ),
+                    )))),
+                    Box::new(DescriptorTemplate::After(*timestamp)),
+                ));
+            }
+            Ok(variants)
+        }
         TapleafClass::Other(s) => {
             let dt = DescriptorTemplate::from_str(s)
                 .map_err(|e| CleartextError::ParseError(format!("{:?}", e)))?;
@@ -1793,17 +1951,10 @@ fn top_level_variants(
                 dt
             })))
         }
-        DescriptorClass::TaprootMusig { keys, leaves } => {
-            let key_indices: Vec<u32> = keys
-                .iter()
-                .map(|k| {
-                    k.plain_key_index()
-                        .expect("TaprootMusig keys must be plain")
-                })
-                .collect();
-            let num1 = keys.first().map(|k| k.num1).unwrap_or(0);
-            let num2 = keys.first().map(|k| k.num2).unwrap_or(1);
-            let internal_key = KeyPlaceholder::musig(key_indices, num1, num2);
+        DescriptorClass::TaprootMusig {
+            internal_key,
+            leaves,
+        } => {
             if leaves.is_empty() {
                 return Ok(Box::new(core::iter::once(DescriptorTemplate::Tr(
                     internal_key,
@@ -1885,10 +2036,10 @@ mod tests {
                 "tr(@0/**,{pk(@1/**),and_v(v:pk(@2/<0;1>/*),older(4194305))})",
                 1,
             ),
-            // Taproot with 2 leaves: RelativeTimelockMultiSig (score 1) + SingleSig (score 1), T(2)=1 → 1
+            // Taproot with 2 leaves: RelativeTimelockMultiSig (score 2, threshold==keys) + SingleSig (score 1), T(2)=1 → 2
             (
                 "tr(@0/**,{pk(@1/**),and_v(v:multi_a(2,@2/<0;1>/*,@3/<0;1>/*),older(4194484))})",
-                1,
+                2,
             ),
             // Taproot with musig internal key: key-path only (score 1)
             ("tr(musig(@0,@1)/**)", 1),
@@ -1900,6 +2051,31 @@ mod tests {
             ("tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})", 1),
             // Taproot with musig internal key + 3 SingleSig leaves: T(3)=3 → 3
             ("tr(musig(@0,@1)/**,{{pk(@2/**),pk(@3/**)},pk(@4/**)})", 3),
+            // --------------------------------------------------------------------------------------
+            // Taproot with musig() tapleaf (pk(musig(...)) maps to Multisig)
+            // --------------------------------------------------------------------------------------
+            // pk(musig) leaf: 2-of-2 (threshold==keys, score 2)
+            ("tr(@0/**,pk(musig(@1,@2)/**))", 2),
+            // pk(musig) leaf: 3-of-3 (threshold==keys, score 2)
+            ("tr(@0/**,pk(musig(@1,@2,@3)/**))", 2),
+            // pk(musig) + relative heightlock (threshold==keys, score 2)
+            ("tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(1008)))", 2),
+            // pk(musig) + relative timelock (threshold==keys, score 2)
+            ("tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(4194484)))", 2),
+            // pk(musig) + absolute heightlock (threshold==keys, score 2)
+            ("tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(840000)))", 2),
+            // pk(musig) + absolute timelock (threshold==keys, score 2)
+            (
+                "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(1700000000)))",
+                2,
+            ),
+            // pk(musig) alongside SingleSig: 1*2*T(2)=2
+            ("tr(@0/**,{pk(@1/**),pk(musig(@2,@3)/**)})", 2),
+            // multi_a with threshold < keys.len() alongside pk(musig): 1*2*T(2)=2
+            (
+                "tr(@0/**,{multi_a(2,@1/**,@2/**,@3/**),pk(musig(@4,@5)/**)})",
+                2,
+            ),
         ];
 
         for &(desc_str, expected) in cases {
@@ -1947,6 +2123,13 @@ mod tests {
             "tr(musig(@0,@1,@2)/**)",
             "tr(musig(@0,@1)/**,pk(@2/**))",
             "tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})",
+            // Taproot with musig tapleaf
+            "tr(@0/**,pk(musig(@1,@2)/**))",
+            "tr(@0/**,pk(musig(@1,@2,@3)/**))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(1008)))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(4194484)))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(840000)))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(1700000000)))",
         ];
         for &desc_str in cases {
             assert!(
@@ -2220,6 +2403,55 @@ mod tests {
                 true,
             ),
             // --------------------------------------------------------------------------------------
+            // Taproot with musig() tapleaf (pk(musig(...)) maps to Multisig)
+            // --------------------------------------------------------------------------------------
+            // pk(musig) leaf: 2-of-2
+            (
+                "tr(@0/**,pk(musig(@1,@2)/**))",
+                &["Primary path: @0", "2 of @1 and @2"],
+                true,
+            ),
+            // pk(musig) leaf: 3-of-3
+            (
+                "tr(@0/**,pk(musig(@1,@2,@3)/**))",
+                &["Primary path: @0", "3 of @1, @2 and @3"],
+                true,
+            ),
+            // pk(musig) + relative heightlock
+            (
+                "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(1008)))",
+                &["Primary path: @0", "2 of @1 and @2 after 1008 blocks"],
+                true,
+            ),
+            // pk(musig) + relative timelock (180 units = 92160s = 1d 1h 36m)
+            (
+                "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(4194484)))",
+                &["Primary path: @0", "2 of @1 and @2 after 1d 1h 36m"],
+                true,
+            ),
+            // pk(musig) + absolute heightlock (block 840000)
+            (
+                "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(840000)))",
+                &["Primary path: @0", "2 of @1 and @2 after block height 840000"],
+                true,
+            ),
+            // pk(musig) + absolute timelock (timestamp 1700000000 = 2023-11-14 22:13:20)
+            (
+                "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(1700000000)))",
+                &["Primary path: @0", "2 of @1 and @2 after date 2023-11-14 22:13:20"],
+                true,
+            ),
+            // pk(musig) alongside a plain single-sig
+            (
+                "tr(@0/**,{pk(@1/**),pk(musig(@2,@3)/**)})",
+                &[
+                    "Primary path: @0",
+                    "Single-signature (@1)",
+                    "2 of @2 and @3",
+                ],
+                true,
+            ),
+            // --------------------------------------------------------------------------------------
             // Non-canonical key derivations: cleartext must includes <num1;num2> for all derivations
             // --------------------------------------------------------------------------------------
             // Legacy single-sig: num1 is not 0 for the first (and only) occurrence
@@ -2334,6 +2566,13 @@ mod tests {
             "tr(musig(@0,@1)/**,{pk(@2/**),pk(@3/**)})",
             "tr(musig(@0,@1)/**,and_v(v:pk(@2/<0;1>/*),older(1008)))",
             "tr(musig(@0,@1)/**,{pk(@2/**),and_v(v:pk(@3/<0;1>/*),after(840000))})",
+            // Taproot: musig tapleaf (pk(musig(...)))
+            "tr(@0/**,pk(musig(@1,@2)/**))",
+            "tr(@0/**,pk(musig(@1,@2,@3)/**))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(1008)))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),older(4194484)))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(840000)))",
+            "tr(@0/**,and_v(v:pk(musig(@1,@2)/**),after(1700000000)))",
         ];
 
         for &desc_str in cases {
@@ -2433,5 +2672,70 @@ mod tests {
                 .collect::<Vec<_>>(),
             "TAPLEAF_SPECS",
         );
+    }
+
+    /// Verify that `descriptor_match!` with musig() preserves the full `KeyExpression`
+    /// (including derivation paths), and that `DescriptorClass::TaprootMusig` stores it
+    /// as a single `internal_key` of type `Musig`.
+    #[test]
+    fn test_musig_classify_preserves_derivations() {
+        use super::{DescriptorClass, KeyPlaceholder};
+        use crate::bip388::KeyExpressionType;
+
+        // musig internal key with non-standard derivation <2;3>
+        let desc = dt("tr(musig(@0,@1)/<2;3>/*,pk(@2/**))");
+        let class = desc.classify();
+        match class {
+            DescriptorClass::TaprootMusig {
+                internal_key,
+                leaves,
+            } => {
+                // The internal_key must be a single musig KeyExpression
+                assert!(internal_key.is_musig());
+                assert_eq!(
+                    internal_key.key_type,
+                    KeyExpressionType::Musig(alloc::vec![0, 1])
+                );
+                // Derivation paths must be preserved (not hardcoded to 0, 1)
+                assert_eq!(internal_key.num1, 2);
+                assert_eq!(internal_key.num2, 3);
+                // Should have one leaf
+                assert_eq!(leaves.len(), 1);
+            }
+            other => panic!("expected TaprootMusig, got {:?}", other),
+        }
+
+        // musig in tapleaf with non-standard derivation <4;5>
+        let desc2 = dt("tr(@0/**,pk(musig(@1,@2)/<4;5>/*))");
+        let class2 = desc2.classify();
+        match class2 {
+            DescriptorClass::Taproot { leaves, .. } => {
+                assert_eq!(leaves.len(), 1);
+                match &leaves[0] {
+                    super::TapleafClass::Multisig { threshold, keys } => {
+                        assert_eq!(*threshold, 2);
+                        assert_eq!(keys.len(), 2);
+                        // The individual key placeholders must carry the derivation from the
+                        // musig expression
+                        for k in keys {
+                            assert_eq!(k.num1, 4);
+                            assert_eq!(k.num2, 5);
+                        }
+                    }
+                    other => panic!("expected Multisig tapleaf, got {:?}", other),
+                }
+            }
+            other => panic!("expected Taproot, got {:?}", other),
+        }
+
+        // Standard derivation musig internal key (sanity check: num1=0, num2=1)
+        let desc3 = dt("tr(musig(@0,@1)/**)");
+        let class3 = desc3.classify();
+        match class3 {
+            DescriptorClass::TaprootMusig { internal_key, .. } => {
+                assert_eq!(internal_key, KeyPlaceholder::musig(alloc::vec![0, 1], 0, 1));
+            }
+            other => panic!("expected TaprootMusig, got {:?}", other),
+        }
     }
 }

--- a/apps/bitcoin/common/src/bip388/cleartext.rs
+++ b/apps/bitcoin/common/src/bip388/cleartext.rs
@@ -1528,24 +1528,51 @@ fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
     }
 }
 
+/// Lazy iterator that generates permutations of `[0, 1, ..., n-1]` in lexicographic order
+/// without storing them all in memory.
 #[cfg(any(test, feature = "cleartext-decode"))]
-fn permutations(n: usize) -> Vec<Vec<usize>> {
-    let mut result = Vec::new();
-    let mut current: Vec<usize> = (0..n).collect();
-    permute_helper(&mut current, 0, &mut result);
-    result
+struct PermutationIter {
+    current: Vec<usize>,
+    first: bool,
+    done: bool,
 }
 
 #[cfg(any(test, feature = "cleartext-decode"))]
-fn permute_helper(arr: &mut Vec<usize>, start: usize, out: &mut Vec<Vec<usize>>) {
-    if start == arr.len() {
-        out.push(arr.clone());
-        return;
+impl PermutationIter {
+    fn new(n: usize) -> Self {
+        Self {
+            current: (0..n).collect(),
+            first: true,
+            done: n == 0,
+        }
     }
-    for i in start..arr.len() {
-        arr.swap(start, i);
-        permute_helper(arr, start + 1, out);
-        arr.swap(start, i);
+}
+
+#[cfg(any(test, feature = "cleartext-decode"))]
+impl Iterator for PermutationIter {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        if self.first {
+            self.first = false;
+            return Some(self.current.clone());
+        }
+        let n = self.current.len();
+        // Find largest i such that current[i] < current[i + 1]
+        let Some(i) = (0..n - 1).rfind(|&k| self.current[k] < self.current[k + 1]) else {
+            self.done = true;
+            return None;
+        };
+        // Find largest j such that current[i] < current[j]
+        let j = (0..n)
+            .rfind(|&j| self.current[i] < self.current[j])
+            .unwrap();
+        self.current.swap(i, j);
+        self.current[i + 1..].reverse();
+        Some(self.current.clone())
     }
 }
 
@@ -1564,16 +1591,13 @@ fn expand_derivation_orderings(base: DescriptorTemplate) -> Vec<DescriptorTempla
     }
 
     let positions_per_group: Vec<Vec<usize>> = groups.into_values().collect();
-    let perms_per_group: Vec<Vec<Vec<usize>>> = positions_per_group
-        .iter()
-        .map(|positions| permutations(positions.len()))
-        .collect();
+    let group_sizes: Vec<usize> = positions_per_group.iter().map(|p| p.len()).collect();
 
     let mut results = Vec::new();
-    let mut chosen: Vec<&Vec<usize>> = Vec::with_capacity(perms_per_group.len());
+    let mut chosen: Vec<Vec<usize>> = Vec::with_capacity(group_sizes.len());
     expand_derivation_orderings_rec(
         &positions_per_group,
-        &perms_per_group,
+        &group_sizes,
         &mut chosen,
         &base,
         &mut results,
@@ -1582,14 +1606,14 @@ fn expand_derivation_orderings(base: DescriptorTemplate) -> Vec<DescriptorTempla
 }
 
 #[cfg(any(test, feature = "cleartext-decode"))]
-fn expand_derivation_orderings_rec<'a>(
+fn expand_derivation_orderings_rec(
     positions_per_group: &[Vec<usize>],
-    perms_per_group: &'a [Vec<Vec<usize>>],
-    chosen: &mut Vec<&'a Vec<usize>>,
+    group_sizes: &[usize],
+    chosen: &mut Vec<Vec<usize>>,
     base: &DescriptorTemplate,
     results: &mut Vec<DescriptorTemplate>,
 ) {
-    if chosen.len() == perms_per_group.len() {
+    if chosen.len() == group_sizes.len() {
         // Build mapping: source-position -> (num1, num2)
         let mut mapping: alloc::collections::BTreeMap<usize, (u32, u32)> =
             alloc::collections::BTreeMap::new();
@@ -1612,15 +1636,9 @@ fn expand_derivation_orderings_rec<'a>(
         return;
     }
     let g = chosen.len();
-    for p in &perms_per_group[g] {
-        chosen.push(p);
-        expand_derivation_orderings_rec(
-            positions_per_group,
-            perms_per_group,
-            chosen,
-            base,
-            results,
-        );
+    for perm in PermutationIter::new(group_sizes[g]) {
+        chosen.push(perm);
+        expand_derivation_orderings_rec(positions_per_group, group_sizes, chosen, base, results);
         chosen.pop();
     }
 }

--- a/apps/bitcoin/common/src/bip388/mod.rs
+++ b/apps/bitcoin/common/src/bip388/mod.rs
@@ -56,12 +56,54 @@ pub enum ParseError {
     InvalidTopLevelPolicy,
     /// Writing a descriptor to a `String` buffer failed.
     FormatError,
-    /// `sh`/`wsh`/`wpkh` used in a position that is not allowed by the spec.
+    /// `sh`/`wsh`/`wpkh`/`musig` used in a position that is not allowed by the spec.
     InvalidScriptContext,
     /// Too many keys for a multisig fragment.
     TooManyKeys,
     /// Invalid multisig quorum (threshold).
     InvalidMultisigQuorum,
+}
+
+/// The parsing context, tracking which top-level descriptor we are inside.
+/// This determines which fragments and key expression forms are valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParseContext {
+    /// Top-level: no enclosing descriptor yet.
+    TopLevel,
+    /// Inside a `sh()` descriptor (legacy P2SH).
+    Legacy,
+    /// Inside a top-level `wsh()` descriptor (native segwit).
+    Segwit,
+    /// Inside `sh(wsh())` (wrapped segwit).
+    WrappedSegwit,
+    /// Inside a `tr()` descriptor (BIP-390: musig allowed).
+    Taproot,
+}
+
+impl ParseContext {
+    fn musig_allowed(self) -> bool {
+        matches!(self, ParseContext::Taproot)
+    }
+
+    /// `sh()` is only allowed at the top level.
+    fn sh_allowed(self) -> bool {
+        matches!(self, ParseContext::TopLevel)
+    }
+
+    /// `wpkh()` is only allowed at the top level or inside `sh()`.
+    fn wpkh_allowed(self) -> bool {
+        matches!(self, ParseContext::TopLevel | ParseContext::Legacy)
+    }
+
+    /// `wsh()` is only allowed at the top level or inside `sh()`.
+    fn wsh_allowed(self) -> bool {
+        matches!(self, ParseContext::TopLevel | ParseContext::Legacy)
+    }
+
+    /// `tr()` is only allowed at the top level.
+    fn tr_allowed(self) -> bool {
+        matches!(self, ParseContext::TopLevel)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -76,29 +118,69 @@ pub struct KeyInformation {
     pub origin_info: Option<KeyOrigin>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct KeyPlaceholder {
-    pub key_index: u32,
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum KeyExpressionType {
+    PlainKey(u32),
+    Musig(Vec<u32>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct KeyExpression {
+    pub key_type: KeyExpressionType,
     pub num1: u32,
     pub num2: u32,
 }
+
+impl KeyExpression {
+    pub fn plain(key_index: u32, num1: u32, num2: u32) -> Self {
+        KeyExpression {
+            key_type: KeyExpressionType::PlainKey(key_index),
+            num1,
+            num2,
+        }
+    }
+
+    pub fn musig(key_indices: Vec<u32>, num1: u32, num2: u32) -> Self {
+        KeyExpression {
+            key_type: KeyExpressionType::Musig(key_indices),
+            num1,
+            num2,
+        }
+    }
+
+    pub fn is_musig(&self) -> bool {
+        matches!(self.key_type, KeyExpressionType::Musig(_))
+    }
+
+    /// Returns the key index for a plain key expression.
+    /// Returns `None` for musig key expressions.
+    pub fn plain_key_index(&self) -> Option<u32> {
+        match &self.key_type {
+            KeyExpressionType::PlainKey(idx) => Some(*idx),
+            KeyExpressionType::Musig(_) => None,
+        }
+    }
+}
+
+/// Backward-compatible alias.
+pub type KeyPlaceholder = KeyExpression;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum DescriptorTemplate {
     Sh(Box<DescriptorTemplate>),
     Wsh(Box<DescriptorTemplate>),
-    Pkh(KeyPlaceholder),
-    Wpkh(KeyPlaceholder),
-    Sortedmulti(u32, Vec<KeyPlaceholder>),
-    Sortedmulti_a(u32, Vec<KeyPlaceholder>),
-    Tr(KeyPlaceholder, Option<TapTree>),
+    Pkh(KeyExpression),
+    Wpkh(KeyExpression),
+    Sortedmulti(u32, Vec<KeyExpression>),
+    Sortedmulti_a(u32, Vec<KeyExpression>),
+    Tr(KeyExpression, Option<TapTree>),
 
     Zero,
     One,
-    Pk(KeyPlaceholder),
-    Pk_k(KeyPlaceholder),
-    Pk_h(KeyPlaceholder),
+    Pk(KeyExpression),
+    Pk_k(KeyExpression),
+    Pk_h(KeyExpression),
     Older(u32),
     After(u32),
     Sha256([u8; 32]),
@@ -118,8 +200,8 @@ pub enum DescriptorTemplate {
     Or_d(Box<DescriptorTemplate>, Box<DescriptorTemplate>),
     Or_i(Box<DescriptorTemplate>, Box<DescriptorTemplate>),
     Thresh(u32, Vec<DescriptorTemplate>),
-    Multi(u32, Vec<KeyPlaceholder>),
-    Multi_a(u32, Vec<KeyPlaceholder>),
+    Multi(u32, Vec<KeyExpression>),
+    Multi_a(u32, Vec<KeyExpression>),
 
     // wrappers
     A(Box<DescriptorTemplate>),
@@ -136,7 +218,7 @@ pub enum DescriptorTemplate {
 
 pub struct DescriptorTemplateIter<'a> {
     fragments: Vec<(&'a DescriptorTemplate, Option<&'a DescriptorTemplate>)>, // Store DescriptorTemplate and its associated leaf context
-    placeholders: Vec<(&'a KeyPlaceholder, Option<&'a DescriptorTemplate>)>, // Placeholders also carry the leaf context
+    placeholders: Vec<(&'a KeyExpression, Option<&'a DescriptorTemplate>)>, // Placeholders also carry the leaf context
 }
 
 impl<'a> From<&'a DescriptorTemplate> for DescriptorTemplateIter<'a> {
@@ -149,7 +231,7 @@ impl<'a> From<&'a DescriptorTemplate> for DescriptorTemplateIter<'a> {
 }
 
 impl<'a> Iterator for DescriptorTemplateIter<'a> {
-    type Item = (&'a KeyPlaceholder, Option<&'a DescriptorTemplate>);
+    type Item = (&'a KeyExpression, Option<&'a DescriptorTemplate>);
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.placeholders.len() > 0 || self.fragments.len() > 0 {
@@ -259,12 +341,12 @@ impl<'a> Iterator for DescriptorTemplateIter<'a> {
 /// providing a safe interface through the `placeholders_mut` method.
 pub struct DescriptorTemplateIterMut<'a> {
     fragments: Vec<*mut DescriptorTemplate>,
-    placeholders: Vec<*mut KeyPlaceholder>,
+    placeholders: Vec<*mut KeyExpression>,
     _marker: core::marker::PhantomData<&'a mut DescriptorTemplate>,
 }
 
 impl<'a> Iterator for DescriptorTemplateIterMut<'a> {
-    type Item = &'a mut KeyPlaceholder;
+    type Item = &'a mut KeyExpression;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -318,7 +400,7 @@ impl<'a> Iterator for DescriptorTemplateIterMut<'a> {
                 }
 
                 DescriptorTemplate::Tr(key, tree) => {
-                    self.placeholders.push(key as *mut KeyPlaceholder);
+                    self.placeholders.push(key as *mut KeyExpression);
                     if let Some(t) = tree {
                         // Traverse the TapTree to collect mutable pointers to all
                         // leaves in left-to-right order (matching TapleavesIter),
@@ -350,7 +432,7 @@ impl<'a> Iterator for DescriptorTemplateIterMut<'a> {
                 | DescriptorTemplate::Pk_k(key)
                 | DescriptorTemplate::Pk_h(key) => {
                     // SAFETY: key is a field of frag which is valid for 'a.
-                    return Some(unsafe { &mut *(key as *mut KeyPlaceholder) });
+                    return Some(unsafe { &mut *(key as *mut KeyExpression) });
                 }
 
                 DescriptorTemplate::Sortedmulti(_, keys)
@@ -358,7 +440,7 @@ impl<'a> Iterator for DescriptorTemplateIterMut<'a> {
                 | DescriptorTemplate::Multi(_, keys)
                 | DescriptorTemplate::Multi_a(_, keys) => {
                     for key in keys.iter_mut().rev() {
-                        self.placeholders.push(key as *mut KeyPlaceholder);
+                        self.placeholders.push(key as *mut KeyExpression);
                     }
                 }
 
@@ -504,12 +586,30 @@ impl core::fmt::Display for KeyInformation {
     }
 }
 
-impl core::fmt::Display for KeyPlaceholder {
+impl core::fmt::Display for KeyExpression {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.num1 == 0 && self.num2 == 1 {
-            write!(f, "@{}/**", self.key_index)
-        } else {
-            write!(f, "@{}/<{};{}>/*", self.key_index, self.num1, self.num2)
+        match &self.key_type {
+            KeyExpressionType::PlainKey(key_index) => {
+                if self.num1 == 0 && self.num2 == 1 {
+                    write!(f, "@{}/**", key_index)
+                } else {
+                    write!(f, "@{}/<{};{}>/*", key_index, self.num1, self.num2)
+                }
+            }
+            KeyExpressionType::Musig(key_indices) => {
+                write!(f, "musig(")?;
+                for (i, idx) in key_indices.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ",")?;
+                    }
+                    write!(f, "@{}", idx)?;
+                }
+                if self.num1 == 0 && self.num2 == 1 {
+                    write!(f, ")/**")
+                } else {
+                    write!(f, ")/<{};{}>/*", self.num1, self.num2)
+                }
+            }
         }
     }
 }
@@ -571,7 +671,7 @@ fn parse_number_up_to(input: &str, max: u32) -> ParseResult<'_, u32> {
 
 // Entry-point: parse a complete descriptor template string.
 fn parse_descriptor_template(input: &str) -> Result<DescriptorTemplate, ParseError> {
-    let (rest, descriptor) = parse_descriptor(input)?;
+    let (rest, descriptor) = parse_descriptor(input, ParseContext::TopLevel)?;
     if rest.is_empty() {
         Ok(descriptor)
     } else {
@@ -589,19 +689,15 @@ fn parse_derivation_step_number(input: &str) -> ParseResult<'_, u32> {
     }
 }
 
-// Parses a key placeholder: @N/** or @N/<num1;num2>/*
-fn parse_key_placeholder(input: &str) -> ParseResult<'_, KeyPlaceholder> {
-    if !input.starts_with('@') {
+// Parses the derivation suffix: /** or /<num1;num2>/*
+fn parse_derivation_suffix(input: &str) -> ParseResult<'_, (u32, u32)> {
+    if !input.starts_with('/') {
         return Err(ParseError::InvalidSyntax);
     }
-    let (rest, key_index) = parse_number_up_to(&input[1..], u32::MAX)?;
-    if !rest.starts_with('/') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    let rest = &rest[1..];
+    let rest = &input[1..];
 
-    let (rest, (num1, num2)) = if rest.starts_with("**") {
-        (&rest[2..], (0u32, 1u32))
+    if rest.starts_with("**") {
+        Ok((&rest[2..], (0u32, 1u32)))
     } else if rest.starts_with('<') {
         let rest = &rest[1..];
         let (rest, num1) = parse_derivation_step_number(rest)?;
@@ -612,23 +708,62 @@ fn parse_key_placeholder(input: &str) -> ParseResult<'_, KeyPlaceholder> {
         if !rest.starts_with(">/*") {
             return Err(ParseError::InvalidSyntax);
         }
-        (&rest[3..], (num1, num2))
+        Ok((&rest[3..], (num1, num2)))
     } else {
-        return Err(ParseError::InvalidSyntax);
-    };
+        Err(ParseError::InvalidSyntax)
+    }
+}
 
-    Ok((
-        rest,
-        KeyPlaceholder {
-            key_index,
-            num1,
-            num2,
-        },
-    ))
+// Parses a key expression: @N/** or @N/<num1;num2>/*
+// When the context allows musig, also accepts: musig(@N1,@N2,...)/** or musig(@N1,@N2,...)/<num1;num2>/*
+// musig() is only valid inside tr() (BIP-390).
+fn parse_key_expression(input: &str, ctx: ParseContext) -> ParseResult<'_, KeyExpression> {
+    if input.starts_with("musig(") {
+        if !ctx.musig_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        return parse_musig_key_expression(input);
+    }
+    if !input.starts_with('@') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let (rest, key_index) = parse_number_up_to(&input[1..], u32::MAX)?;
+    let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
+
+    Ok((rest, KeyExpression::plain(key_index, num1, num2)))
+}
+
+// Parses a musig key expression: musig(@N1,@N2,...)/** or musig(@N1,@N2,...)/<num1;num2>/*
+fn parse_musig_key_expression(input: &str) -> ParseResult<'_, KeyExpression> {
+    let mut rest = &input[6..]; // skip "musig("
+    let mut key_indices = Vec::new();
+    loop {
+        if !rest.starts_with('@') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        let (r, idx) = parse_number_up_to(&rest[1..], u32::MAX)?;
+        key_indices.push(idx);
+        rest = r;
+        if rest.starts_with(',') {
+            rest = &rest[1..];
+        } else {
+            break;
+        }
+    }
+    if key_indices.len() < 2 {
+        return Err(ParseError::InvalidSyntax);
+    }
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    rest = &rest[1..]; // skip ')'
+    let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
+
+    Ok((rest, KeyExpression::musig(key_indices, num1, num2)))
 }
 
 // Parses a descriptor, optionally preceded by a wrapper prefix like "asc:".
-fn parse_descriptor(input: &str) -> ParseResult<'_, DescriptorTemplate> {
+fn parse_descriptor(input: &str, ctx: ParseContext) -> ParseResult<'_, DescriptorTemplate> {
     // A wrapper prefix is a run of ASCII alphabetic chars followed by ':'.
     // Fragment keywords are always followed by '(' instead, so no ambiguity.
     let alpha_end = input
@@ -642,7 +777,7 @@ fn parse_descriptor(input: &str) -> ParseResult<'_, DescriptorTemplate> {
         (input, "")
     };
 
-    let (input, inner) = parse_inner_descriptor(input)?;
+    let (input, inner) = parse_inner_descriptor(input, ctx)?;
 
     // Apply wrappers in reverse character order (rightmost char = outermost wrapper)
     let mut result = inner;
@@ -664,58 +799,82 @@ fn parse_descriptor(input: &str) -> ParseResult<'_, DescriptorTemplate> {
     Ok((input, result))
 }
 
-fn parse_inner_descriptor(input: &str) -> ParseResult<'_, DescriptorTemplate> {
+fn parse_inner_descriptor(input: &str, ctx: ParseContext) -> ParseResult<'_, DescriptorTemplate> {
     // Longer names checked before shorter to avoid premature prefix matches.
     if input.starts_with("sortedmulti_a(") {
         return parse_threshold_kp_fragment(
             input,
             "sortedmulti_a",
             DescriptorTemplate::Sortedmulti_a,
+            ctx,
         );
     }
     if input.starts_with("sortedmulti(") {
-        return parse_threshold_kp_fragment(input, "sortedmulti", DescriptorTemplate::Sortedmulti);
+        return parse_threshold_kp_fragment(
+            input,
+            "sortedmulti",
+            DescriptorTemplate::Sortedmulti,
+            ctx,
+        );
     }
     if input.starts_with("multi_a(") {
-        return parse_threshold_kp_fragment(input, "multi_a", DescriptorTemplate::Multi_a);
+        return parse_threshold_kp_fragment(input, "multi_a", DescriptorTemplate::Multi_a, ctx);
     }
     if input.starts_with("multi(") {
-        return parse_threshold_kp_fragment(input, "multi", DescriptorTemplate::Multi);
+        return parse_threshold_kp_fragment(input, "multi", DescriptorTemplate::Multi, ctx);
     }
     if input.starts_with("thresh(") {
-        return parse_thresh(input);
+        return parse_thresh(input, ctx);
     }
     if input.starts_with("wsh(") {
-        let (rest, scripts) = parse_n_subscripts(&input[4..], 1)?;
+        if !ctx.wsh_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        let inner_ctx = match ctx {
+            ParseContext::TopLevel => ParseContext::Segwit,
+            ParseContext::Legacy => ParseContext::WrappedSegwit,
+            _ => unreachable!(), // not possible since wsh_allowed returned true
+        };
+
+        let (rest, scripts) = parse_n_subscripts(&input[4..], 1, inner_ctx)?;
         return Ok((
             rest,
             DescriptorTemplate::Wsh(Box::new(scripts.into_iter().next().unwrap())),
         ));
     }
     if input.starts_with("sh(") {
-        let (rest, scripts) = parse_n_subscripts(&input[3..], 1)?;
+        if !ctx.sh_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        let (rest, scripts) = parse_n_subscripts(&input[3..], 1, ParseContext::Legacy)?;
         return Ok((
             rest,
             DescriptorTemplate::Sh(Box::new(scripts.into_iter().next().unwrap())),
         ));
     }
     if input.starts_with("wpkh(") {
-        return parse_kp_fragment(input, "wpkh", DescriptorTemplate::Wpkh);
+        if !ctx.wpkh_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        return parse_kp_fragment(input, "wpkh", DescriptorTemplate::Wpkh, ctx);
     }
     if input.starts_with("pkh(") {
-        return parse_kp_fragment(input, "pkh", DescriptorTemplate::Pkh);
+        return parse_kp_fragment(input, "pkh", DescriptorTemplate::Pkh, ctx);
     }
     if input.starts_with("tr(") {
+        if !ctx.tr_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
         return parse_tr(input);
     }
     if input.starts_with("pk_k(") {
-        return parse_kp_fragment(input, "pk_k", DescriptorTemplate::Pk_k);
+        return parse_kp_fragment(input, "pk_k", DescriptorTemplate::Pk_k, ctx);
     }
     if input.starts_with("pk_h(") {
-        return parse_kp_fragment(input, "pk_h", DescriptorTemplate::Pk_h);
+        return parse_kp_fragment(input, "pk_h", DescriptorTemplate::Pk_h, ctx);
     }
     if input.starts_with("pk(") {
-        return parse_kp_fragment(input, "pk", DescriptorTemplate::Pk);
+        return parse_kp_fragment(input, "pk", DescriptorTemplate::Pk, ctx);
     }
     if input.starts_with("older(") {
         return parse_num_fragment(input, "older", MAX_OLDER_AFTER, DescriptorTemplate::Older);
@@ -736,50 +895,50 @@ fn parse_inner_descriptor(input: &str) -> ParseResult<'_, DescriptorTemplate> {
         return parse_hex20_fragment(input, "hash160", DescriptorTemplate::Hash160);
     }
     if input.starts_with("andor(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 3)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 3, ctx)?;
         let z = Box::new(scripts.remove(2));
         let y = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::Andor(x, y, z)));
     }
     if input.starts_with("and_b(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 2, ctx)?;
         let y = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::And_b(x, y)));
     }
     if input.starts_with("and_v(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 2, ctx)?;
         let y = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::And_v(x, y)));
     }
     if input.starts_with("and_n(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[6..], 2, ctx)?;
         let y = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::And_n(x, y)));
     }
     if input.starts_with("or_b(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2, ctx)?;
         let z = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::Or_b(x, z)));
     }
     if input.starts_with("or_c(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2, ctx)?;
         let z = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::Or_c(x, z)));
     }
     if input.starts_with("or_d(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2, ctx)?;
         let z = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::Or_d(x, z)));
     }
     if input.starts_with("or_i(") {
-        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2)?;
+        let (rest, mut scripts) = parse_n_subscripts(&input[5..], 2, ctx)?;
         let z = Box::new(scripts.remove(1));
         let x = Box::new(scripts.remove(0));
         return Ok((rest, DescriptorTemplate::Or_i(x, z)));
@@ -794,14 +953,15 @@ fn parse_inner_descriptor(input: &str) -> ParseResult<'_, DescriptorTemplate> {
     Err(ParseError::UnrecognizedFragment)
 }
 
-// Parses a named fragment that wraps a single key placeholder: name(@...)
+// Parses a named fragment that wraps a single key expression: name(@...)
 fn parse_kp_fragment<'a>(
     input: &'a str,
     name: &str,
-    constructor: fn(KeyPlaceholder) -> DescriptorTemplate,
+    constructor: fn(KeyExpression) -> DescriptorTemplate,
+    ctx: ParseContext,
 ) -> ParseResult<'a, DescriptorTemplate> {
     let rest = &input[name.len()..]; // caller already checked starts_with(name)
-    let (rest, kp) = parse_key_placeholder(&rest[1..])?; // skip '('
+    let (rest, kp) = parse_key_expression(&rest[1..], ctx)?; // skip '('
     if !rest.starts_with(')') {
         return Err(ParseError::InvalidSyntax);
     }
@@ -859,20 +1019,21 @@ fn parse_hex32_fragment<'a>(
     Ok((&rest[1..], constructor(bytes)))
 }
 
-// Parses "name(threshold,@kp1,@kp2,...)".
+// Parses "name(threshold,<key1>,<key1>,...)".
 fn parse_threshold_kp_fragment<'a>(
     input: &'a str,
     name: &str,
-    constructor: fn(u32, Vec<KeyPlaceholder>) -> DescriptorTemplate,
+    constructor: fn(u32, Vec<KeyExpression>) -> DescriptorTemplate,
+    ctx: ParseContext,
 ) -> ParseResult<'a, DescriptorTemplate> {
     let rest = &input[name.len() + 1..]; // skip name and '('
     let (mut rest, threshold) = parse_number_up_to(rest, u32::MAX)?;
-    let mut keys: Vec<KeyPlaceholder> = Vec::new();
+    let mut keys: Vec<KeyExpression> = Vec::new();
     loop {
         if !rest.starts_with(',') {
             break;
         }
-        match parse_key_placeholder(&rest[1..]) {
+        match parse_key_expression(&rest[1..], ctx) {
             Ok((r, kp)) => {
                 keys.push(kp);
                 rest = r;
@@ -880,6 +1041,7 @@ fn parse_threshold_kp_fragment<'a>(
                     break;
                 }
             }
+            Err(ParseError::InvalidScriptContext) => return Err(ParseError::InvalidScriptContext),
             Err(_) => break,
         }
     }
@@ -894,11 +1056,15 @@ fn parse_threshold_kp_fragment<'a>(
 
 // Parses exactly n comma-separated sub-descriptors, then ')'.
 // Called after the opening '(' of the enclosing fragment has been consumed.
-fn parse_n_subscripts(input: &str, n: usize) -> ParseResult<'_, Vec<DescriptorTemplate>> {
+fn parse_n_subscripts(
+    input: &str,
+    n: usize,
+    ctx: ParseContext,
+) -> ParseResult<'_, Vec<DescriptorTemplate>> {
     let mut rest = input;
     let mut scripts: Vec<DescriptorTemplate> = Vec::new();
     for i in 0..n {
-        let (r, desc) = parse_descriptor(rest)?;
+        let (r, desc) = parse_descriptor(rest, ctx)?;
         scripts.push(desc);
         rest = r;
         if i + 1 < n {
@@ -919,7 +1085,7 @@ fn parse_wsh(input: &str) -> ParseResult<'_, DescriptorTemplate> {
     if !input.starts_with("wsh(") {
         return Err(ParseError::InvalidSyntax);
     }
-    let (rest, scripts) = parse_n_subscripts(&input[4..], 1)?;
+    let (rest, scripts) = parse_n_subscripts(&input[4..], 1, ParseContext::Segwit)?;
     Ok((
         rest,
         DescriptorTemplate::Wsh(Box::new(scripts.into_iter().next().unwrap())),
@@ -928,24 +1094,29 @@ fn parse_wsh(input: &str) -> ParseResult<'_, DescriptorTemplate> {
 
 #[cfg(test)]
 fn parse_sortedmulti(input: &str) -> ParseResult<'_, DescriptorTemplate> {
-    parse_threshold_kp_fragment(input, "sortedmulti", DescriptorTemplate::Sortedmulti)
+    parse_threshold_kp_fragment(
+        input,
+        "sortedmulti",
+        DescriptorTemplate::Sortedmulti,
+        ParseContext::TopLevel,
+    )
 }
 
-fn parse_thresh(input: &str) -> ParseResult<'_, DescriptorTemplate> {
+fn parse_thresh(input: &str, ctx: ParseContext) -> ParseResult<'_, DescriptorTemplate> {
     // input starts with "thresh("
     let (rest, k) = parse_number_up_to(&input[7..], u32::MAX)?;
     if !rest.starts_with(',') {
         return Err(ParseError::InvalidSyntax);
     }
     // parse first script (mandatory)
-    let (rest, first) = parse_descriptor(&rest[1..])?;
+    let (rest, first) = parse_descriptor(&rest[1..], ctx)?;
     let mut scripts = vec![first];
     let mut rest = rest;
     loop {
         if !rest.starts_with(',') {
             break;
         }
-        match parse_descriptor(&rest[1..]) {
+        match parse_descriptor(&rest[1..], ctx) {
             Ok((r, desc)) => {
                 scripts.push(desc);
                 rest = r;
@@ -964,7 +1135,7 @@ fn parse_thresh(input: &str) -> ParseResult<'_, DescriptorTemplate> {
 
 fn parse_tr(input: &str) -> ParseResult<'_, DescriptorTemplate> {
     // input starts with "tr("
-    let (rest, key_placeholder) = parse_key_placeholder(&input[3..])?;
+    let (rest, key_placeholder) = parse_key_expression(&input[3..], ParseContext::Taproot)?;
     let (rest, tree) = if rest.starts_with(',') {
         let (rest, tree) = parse_tap_tree(&rest[1..])?;
         (rest, Some(tree))
@@ -989,7 +1160,7 @@ fn parse_tap_tree(input: &str) -> ParseResult<'_, TapTree> {
         }
         Ok((&rest[1..], TapTree::Branch(Box::new(left), Box::new(right))))
     } else {
-        let (rest, desc) = parse_descriptor(input)?;
+        let (rest, desc) = parse_descriptor(input, ParseContext::Taproot)?;
         Ok((rest, TapTree::Script(Box::new(desc))))
     }
 }
@@ -1312,26 +1483,44 @@ impl WalletPolicy {
     //     }
 }
 
-fn write_key_placeholder(
+fn write_key_expression(
     w: &mut String,
     key_information: &[KeyInformation],
-    kp: &KeyPlaceholder,
+    kp: &KeyExpression,
     is_change: bool,
     address_index: u32,
 ) -> Result<(), ParseError> {
     use core::fmt::Write;
-    let key_info = key_information
-        .get(kp.key_index as usize)
-        .ok_or(ParseError::InvalidKeyIndex)?;
     let change_step = if is_change { kp.num2 } else { kp.num1 };
-    write!(w, "{}/{}/{}", key_info, change_step, address_index).map_err(|_| ParseError::FormatError)
+    match &kp.key_type {
+        KeyExpressionType::PlainKey(key_index) => {
+            let key_info = key_information
+                .get(*key_index as usize)
+                .ok_or(ParseError::InvalidKeyIndex)?;
+            write!(w, "{}/{}/{}", key_info, change_step, address_index)
+                .map_err(|_| ParseError::FormatError)
+        }
+        KeyExpressionType::Musig(key_indices) => {
+            w.push_str("musig(");
+            for (i, key_index) in key_indices.iter().enumerate() {
+                if i > 0 {
+                    w.push(',');
+                }
+                let key_info = key_information
+                    .get(*key_index as usize)
+                    .ok_or(ParseError::InvalidKeyIndex)?;
+                write!(w, "{}", key_info).map_err(|_| ParseError::FormatError)?;
+            }
+            write!(w, ")/{}/{}", change_step, address_index).map_err(|_| ParseError::FormatError)
+        }
+    }
 }
 
-// Writes a comma-separated list of key placeholders to a buffer.
-fn write_key_placeholders(
+// Writes a comma-separated list of key expressions to a buffer.
+fn write_key_expressions(
     w: &mut String,
     key_information: &[KeyInformation],
-    kps: &[KeyPlaceholder],
+    kps: &[KeyExpression],
     is_change: bool,
     address_index: u32,
 ) -> Result<(), ParseError> {
@@ -1339,7 +1528,7 @@ fn write_key_placeholders(
         if i > 0 {
             w.push(',');
         }
-        write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+        write_key_expression(w, key_information, kp, is_change, address_index)?;
     }
     Ok(())
 }
@@ -1405,27 +1594,27 @@ impl DescriptorTemplate {
             }
             DescriptorTemplate::Pkh(kp) => {
                 w.push_str("pkh(");
-                write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+                write_key_expression(w, key_information, kp, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Wpkh(kp) => {
                 w.push_str("wpkh(");
-                write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+                write_key_expression(w, key_information, kp, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Sortedmulti(threshold, kps) => {
                 write!(w, "sortedmulti({}, ", threshold).map_err(|_| ParseError::FormatError)?;
-                write_key_placeholders(w, key_information, kps, is_change, address_index)?;
+                write_key_expressions(w, key_information, kps, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Sortedmulti_a(threshold, kps) => {
                 write!(w, "sortedmulti_a({}, ", threshold).map_err(|_| ParseError::FormatError)?;
-                write_key_placeholders(w, key_information, kps, is_change, address_index)?;
+                write_key_expressions(w, key_information, kps, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Tr(kp, tap_tree) => {
                 w.push_str("tr(");
-                write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+                write_key_expression(w, key_information, kp, is_change, address_index)?;
                 if let Some(tree) = tap_tree {
                     w.push_str(", ");
                     tree.write_to(w, key_information, is_change, address_index)?;
@@ -1436,17 +1625,17 @@ impl DescriptorTemplate {
             DescriptorTemplate::One => w.push('1'),
             DescriptorTemplate::Pk(kp) => {
                 w.push_str("pk(");
-                write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+                write_key_expression(w, key_information, kp, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Pk_k(kp) => {
                 w.push_str("pk_k(");
-                write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+                write_key_expression(w, key_information, kp, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Pk_h(kp) => {
                 w.push_str("pk_h(");
-                write_key_placeholder(w, key_information, kp, is_change, address_index)?;
+                write_key_expression(w, key_information, kp, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Older(n) => {
@@ -1545,12 +1734,12 @@ impl DescriptorTemplate {
             }
             DescriptorTemplate::Multi(threshold, kps) => {
                 write!(w, "multi({}, ", threshold).map_err(|_| ParseError::FormatError)?;
-                write_key_placeholders(w, key_information, kps, is_change, address_index)?;
+                write_key_expressions(w, key_information, kps, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::Multi_a(threshold, kps) => {
                 write!(w, "multi_a({}, ", threshold).map_err(|_| ParseError::FormatError)?;
-                write_key_placeholders(w, key_information, kps, is_change, address_index)?;
+                write_key_expressions(w, key_information, kps, is_change, address_index)?;
                 w.push(')');
             }
             DescriptorTemplate::A(inner) => {
@@ -1695,52 +1884,17 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_key_placeholder() {
+    fn test_parse_key_expression() {
         let test_cases_success = vec![
-            (
-                "@0/**",
-                KeyPlaceholder {
-                    key_index: 0,
-                    num1: 0,
-                    num2: 1,
-                },
-            ),
-            (
-                "@4294967295/**",
-                KeyPlaceholder {
-                    key_index: 4294967295,
-                    num1: 0,
-                    num2: 1,
-                },
-            ), // u32::MAX
-            (
-                "@1/<0;1>/*",
-                KeyPlaceholder {
-                    key_index: 1,
-                    num1: 0,
-                    num2: 1,
-                },
-            ),
-            (
-                "@2/<3;4>/*",
-                KeyPlaceholder {
-                    key_index: 2,
-                    num1: 3,
-                    num2: 4,
-                },
-            ),
-            (
-                "@3/<1;9>/*",
-                KeyPlaceholder {
-                    key_index: 3,
-                    num1: 1,
-                    num2: 9,
-                },
-            ),
+            ("@0/**", KeyExpression::plain(0, 0, 1)),
+            ("@4294967295/**", KeyExpression::plain(4294967295, 0, 1)), // u32::MAX
+            ("@1/<0;1>/*", KeyExpression::plain(1, 0, 1)),
+            ("@2/<3;4>/*", KeyExpression::plain(2, 3, 4)),
+            ("@3/<1;9>/*", KeyExpression::plain(3, 1, 9)),
         ];
 
         for (input, expected) in test_cases_success {
-            let result = parse_key_placeholder(input);
+            let result = parse_key_expression(input, ParseContext::TopLevel);
             assert_eq!(result, Ok(("", expected)));
         }
 
@@ -1756,7 +1910,7 @@ mod tests {
         ];
 
         for input in test_cases_err {
-            assert!(parse_key_placeholder(input).is_err());
+            assert!(parse_key_expression(input, ParseContext::TopLevel).is_err());
         }
     }
 
@@ -1767,18 +1921,7 @@ mod tests {
             "",
             DescriptorTemplate::Sortedmulti(
                 2,
-                vec![
-                    KeyPlaceholder {
-                        key_index: 0,
-                        num1: 0,
-                        num2: 1,
-                    },
-                    KeyPlaceholder {
-                        key_index: 1,
-                        num1: 0,
-                        num2: 1,
-                    },
-                ],
+                vec![KeyExpression::plain(0, 0, 1), KeyExpression::plain(1, 0, 1)],
             ),
         ));
         assert_eq!(parse_sortedmulti(input), expected);
@@ -1791,18 +1934,7 @@ mod tests {
             "",
             DescriptorTemplate::Wsh(Box::new(DescriptorTemplate::Sortedmulti(
                 2,
-                vec![
-                    KeyPlaceholder {
-                        key_index: 0,
-                        num1: 0,
-                        num2: 1,
-                    },
-                    KeyPlaceholder {
-                        key_index: 1,
-                        num1: 0,
-                        num2: 1,
-                    },
-                ],
+                vec![KeyExpression::plain(0, 0, 1), KeyExpression::plain(1, 0, 1)],
             ))),
         ));
         assert_eq!(parse_wsh(input), expected);
@@ -1813,14 +1945,7 @@ mod tests {
         let input = "tr(@0/**)";
         let expected = Ok((
             "",
-            DescriptorTemplate::Tr(
-                KeyPlaceholder {
-                    key_index: 0,
-                    num1: 0,
-                    num2: 1,
-                },
-                None,
-            ),
+            DescriptorTemplate::Tr(KeyExpression::plain(0, 0, 1), None),
         ));
         assert_eq!(parse_tr(input), expected);
 
@@ -1828,46 +1953,26 @@ mod tests {
         let expected = Ok((
             "",
             DescriptorTemplate::Tr(
-                KeyPlaceholder {
-                    key_index: 0,
-                    num1: 0,
-                    num2: 1,
-                },
+                KeyExpression::plain(0, 0, 1),
                 Some(TapTree::Script(Box::new(DescriptorTemplate::Pkh(
-                    KeyPlaceholder {
-                        key_index: 1,
-                        num1: 0,
-                        num2: 1,
-                    },
+                    KeyExpression::plain(1, 0, 1),
                 )))),
             ),
         ));
         assert_eq!(parse_tr(input), expected);
 
-        let input = "tr(@0/<2;1>/*,{pkh(@1/<2;7>/*),sh(wpkh(@2/**))})";
+        let input = "tr(@0/<2;1>/*,{pkh(@1/<2;7>/*),pk(@2/**)})";
         let expected = Ok((
             "",
             DescriptorTemplate::Tr(
-                KeyPlaceholder {
-                    key_index: 0,
-                    num1: 2,
-                    num2: 1,
-                },
+                KeyExpression::plain(0, 2, 1),
                 Some(TapTree::Branch(
                     Box::new(TapTree::Script(Box::new(DescriptorTemplate::Pkh(
-                        KeyPlaceholder {
-                            key_index: 1,
-                            num1: 2,
-                            num2: 7,
-                        },
+                        KeyExpression::plain(1, 2, 7),
                     )))),
-                    Box::new(TapTree::Script(Box::new(DescriptorTemplate::Sh(Box::new(
-                        DescriptorTemplate::Wpkh(KeyPlaceholder {
-                            key_index: 2,
-                            num1: 0,
-                            num2: 1,
-                        }),
-                    ))))),
+                    Box::new(TapTree::Script(Box::new(DescriptorTemplate::Pk(
+                        KeyExpression::plain(2, 0, 1),
+                    )))),
                 )),
             ),
         ));
@@ -1883,10 +1988,12 @@ mod tests {
 
     #[test]
     fn test_parse_valid_descriptor_templates() {
-        assert!(parse_descriptor("sln:older(12960)").is_ok());
-        assert!(
-            parse_thresh("thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@2/**),sln:older(12960))").is_ok()
-        );
+        assert!(parse_descriptor("sln:older(12960)", ParseContext::TopLevel).is_ok());
+        assert!(parse_thresh(
+            "thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@2/**),sln:older(12960))",
+            ParseContext::TopLevel
+        )
+        .is_ok());
 
         let test_cases = vec![
             "wsh(sortedmulti(2,@0/**,@1/**))",
@@ -2046,8 +2153,9 @@ mod tests {
 
     #[test]
     fn test_descriptortemplate_placeholders_iterator() {
-        fn format_kp(kp: &KeyPlaceholder) -> String {
-            format!("@{}/<{};{}>/*", kp.key_index, kp.num1, kp.num2)
+        fn format_kp(kp: &KeyExpression) -> String {
+            let key_index = kp.plain_key_index().expect("expected plain key in test");
+            format!("@{}/<{};{}>/*", key_index, kp.num1, kp.num2)
         }
 
         struct TestCase {
@@ -2109,7 +2217,7 @@ mod tests {
             "sln:older(12960)",
             "tr(@0/**)",
             "tr(@0/**,pkh(@1/**))",
-            "tr(@0/<2;1>/*,{pkh(@1/<2;7>/*),sh(wpkh(@2/**))})",
+            "tr(@0/<2;1>/*,{pkh(@1/<2;7>/*),pk(@2/**)})",
             "after(12345)",
             "older(65535)",
             "sha256(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)",
@@ -2127,5 +2235,186 @@ mod tests {
             let displayed = parsed.to_string();
             assert_eq!(displayed, s, "roundtrip failed for {:?}", s);
         }
+    }
+
+    #[test]
+    fn test_musig_inside_tr_parses() {
+        // musig() as the internal key of tr()
+        let result = DescriptorTemplate::from_str("tr(musig(@0,@1)/**)");
+        assert!(
+            result.is_ok(),
+            "musig as tr internal key should parse: {:?}",
+            result
+        );
+
+        // musig() inside a tr() taptree leaf
+        let result = DescriptorTemplate::from_str("tr(@0/**,pk(musig(@1,@2)/**))");
+        assert!(
+            result.is_ok(),
+            "musig inside tr taptree should parse: {:?}",
+            result
+        );
+
+        // musig() with more than two keys
+        let result = DescriptorTemplate::from_str("tr(musig(@0,@1,@2)/**)");
+        assert!(
+            result.is_ok(),
+            "musig with 3 keys should parse: {:?}",
+            result
+        );
+
+        // musig() with <num1;num2>/* derivation
+        let result = DescriptorTemplate::from_str("tr(musig(@0,@1)/<3;4>/*)");
+        assert!(
+            result.is_ok(),
+            "musig with custom derivation should parse: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_musig_outside_tr_rejected() {
+        // musig() inside wpkh() should fail
+        assert_eq!(
+            DescriptorTemplate::from_str("wpkh(musig(@0,@1)/**)"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // musig() inside pkh() should fail
+        assert_eq!(
+            DescriptorTemplate::from_str("pkh(musig(@0,@1)/**)"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // musig() inside wsh(sortedmulti()) should fail
+        assert_eq!(
+            DescriptorTemplate::from_str("wsh(sortedmulti(2,musig(@0,@1)/**,@2/**))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // musig() inside sh() should fail
+        assert_eq!(
+            DescriptorTemplate::from_str("sh(pk(musig(@0,@1)/**))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // musig() inside wsh(pk()) should fail
+        assert_eq!(
+            DescriptorTemplate::from_str("wsh(pk(musig(@0,@1)/**))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+    }
+
+    #[test]
+    fn test_musig_nested_not_allowed() {
+        // musig() inside musig() is not valid because musig() arguments
+        // must be plain @N key references, not nested key expressions
+        assert!(
+            DescriptorTemplate::from_str("tr(musig(musig(@0,@1),@2)/**)").is_err(),
+            "nested musig should not parse"
+        );
+    }
+
+    #[test]
+    fn test_musig_display_roundtrip() {
+        let cases = vec![
+            "tr(musig(@0,@1)/**)",
+            "tr(musig(@0,@1)/<3;4>/*)",
+            "tr(musig(@0,@1,@2)/**)",
+            "tr(@0/**,pk(musig(@1,@2)/**))",
+        ];
+        for s in cases {
+            let parsed = DescriptorTemplate::from_str(s)
+                .unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", s, e));
+            let displayed = parsed.to_string();
+            assert_eq!(displayed, s, "roundtrip failed for {:?}", s);
+        }
+    }
+
+    #[test]
+    fn test_sh_only_allowed_top_level() {
+        // sh() at top level is valid
+        assert!(DescriptorTemplate::from_str("sh(wsh(sortedmulti(2,@0/**,@1/**)))").is_ok());
+        assert!(DescriptorTemplate::from_str("sh(sortedmulti(2,@0/**,@1/**))").is_ok());
+
+        // sh() inside wsh() is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("wsh(sh(pk(@0/**)))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // sh() inside sh() is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("sh(sh(pk(@0/**)))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // sh() inside tr() taptree is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("tr(@0/**,sh(pk(@1/**)))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+    }
+
+    #[test]
+    fn test_wsh_only_allowed_top_level_or_inside_sh() {
+        // wsh() at top level is valid
+        assert!(DescriptorTemplate::from_str("wsh(sortedmulti(2,@0/**,@1/**))").is_ok());
+
+        // wsh() inside sh() is valid
+        assert!(DescriptorTemplate::from_str("sh(wsh(sortedmulti(2,@0/**,@1/**)))").is_ok());
+
+        // wsh() inside wsh() is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("wsh(wsh(pk(@0/**)))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // wsh() inside tr() taptree is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("tr(@0/**,wsh(pk(@1/**)))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // wsh() inside sh(wsh()) is not allowed (double wrapping)
+        assert_eq!(
+            DescriptorTemplate::from_str("sh(wsh(wsh(pk(@0/**))))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+    }
+
+    #[test]
+    fn test_tr_only_allowed_top_level() {
+        // tr() at top level is valid
+        assert!(DescriptorTemplate::from_str("tr(@0/**)").is_ok());
+        assert!(DescriptorTemplate::from_str("tr(@0/**,pk(@1/**))").is_ok());
+
+        // tr() inside sh() is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("sh(tr(@0/**))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // tr() inside wsh() is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("wsh(tr(@0/**))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+
+        // tr() inside tr() taptree is not allowed
+        assert_eq!(
+            DescriptorTemplate::from_str("tr(@0/**,tr(@1/**))"),
+            Err(ParseError::InvalidScriptContext)
+        );
+    }
+
+    #[test]
+    fn test_musig_not_allowed_in_wsh_inside_tr() {
+        // musig() inside wsh() even within a tapscript should fail,
+        // because wsh() is not allowed inside tr() in the first place
+        assert_eq!(
+            DescriptorTemplate::from_str("tr(@0/**,wsh(pk(musig(@1,@2)/**)))"),
+            Err(ParseError::InvalidScriptContext)
+        );
     }
 }

--- a/apps/bitcoin/common/src/bip388/mod.rs
+++ b/apps/bitcoin/common/src/bip388/mod.rs
@@ -118,7 +118,7 @@ pub struct KeyInformation {
     pub origin_info: Option<KeyOrigin>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum KeyExpressionType {
     PlainKey(u32),
     Musig(Vec<u32>),

--- a/apps/bitcoin/common/src/bip388/mod.rs
+++ b/apps/bitcoin/common/src/bip388/mod.rs
@@ -140,6 +140,10 @@ impl KeyExpression {
         }
     }
 
+    pub fn is_plain(&self) -> bool {
+        matches!(self.key_type, KeyExpressionType::PlainKey(_))
+    }
+
     pub fn musig(key_indices: Vec<u32>, num1: u32, num2: u32) -> Self {
         KeyExpression {
             key_type: KeyExpressionType::Musig(key_indices),
@@ -158,6 +162,15 @@ impl KeyExpression {
         match &self.key_type {
             KeyExpressionType::PlainKey(idx) => Some(*idx),
             KeyExpressionType::Musig(_) => None,
+        }
+    }
+
+    /// Returns the key indices for a musig key expression.
+    /// Returns `None` for plain key expressions.
+    pub fn musig_key_indices(&self) -> Option<&Vec<u32>> {
+        match &self.key_type {
+            KeyExpressionType::Musig(indices) => Some(indices),
+            KeyExpressionType::PlainKey(_) => None,
         }
     }
 }

--- a/apps/bitcoin/common/src/errors.rs
+++ b/apps/bitcoin/common/src/errors.rs
@@ -17,6 +17,7 @@ pub enum Error {
     InvalidScriptContext,
     TooManyKeys,
     InvalidMultisigQuorum,
+    UnsupportedWalletPolicy,
 
     // Derivation / crypto
     DerivationPathTooLong,
@@ -82,7 +83,7 @@ impl fmt::Display for Error {
             InvalidScriptContext => write!(f, "Invalid script context"),
             TooManyKeys => write!(f, "Too many keys"),
             InvalidMultisigQuorum => write!(f, "Invalid multisig quorum"),
-
+            UnsupportedWalletPolicy => write!(f, "Unsupported wallet policy"),
             DerivationPathTooLong => write!(f, "Derivation path is too long"),
             KeyDerivationFailed => write!(f, "Failed to derive key for the given path"),
             HardenedDerivationNotSupported => write!(f, "Hardened derivation is not supported for resident keys"),

--- a/apps/bitcoin/common/src/message/mod.rs
+++ b/apps/bitcoin/common/src/message/mod.rs
@@ -101,7 +101,7 @@ pub enum Request {
         /// Optional per-key Schnorr signatures over the cosigner xpubs.
         /// `key_signatures[i]` covers `keys_info[i]`; `None` means unsigned.
         key_signatures: Option<Vec<Option<IdentitySignature>>>,
-        /// If true and the descriptor template's complexity score is at most
+        /// If true and the descriptor template's confusion score is at most
         /// `MAX_CONFUSION_SCORE`, show a human-readable cleartext description
         /// of the descriptor template on screen.
         show_cleartext: bool,

--- a/apps/bitcoin/common/src/psbt/account.rs
+++ b/apps/bitcoin/common/src/psbt/account.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::{AccountCoordinates, WalletPolicy, WalletPolicyCoordinates},
-    bip388::KeyPlaceholder,
+    bip388::KeyExpression,
 };
 
 use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
@@ -35,6 +35,7 @@ pub enum PsbtAccountError {
     InvalidValue,
     TooManyAccounts,
     DeserializeError,
+    Unsupported,
 }
 
 fn is_valid_account_name(value: &[u8]) -> bool {
@@ -372,7 +373,7 @@ fn get_wallet_policy_coordinates(
     >,
     fingerprint: Fingerprint,
     origin_path_len: usize,
-    key_placeholder: &KeyPlaceholder,
+    key_placeholder: &KeyExpression,
 ) -> Option<WalletPolicyCoordinates> {
     // iterate over all derivations; if it's a key derived from the internal key,
     // deduce the coordinates and insert them
@@ -432,7 +433,7 @@ pub fn fill_psbt_with_bip388_coordinates(
     wallet_policy: &WalletPolicy,
     name: Option<&str>,
     proof_of_registrations: Option<&[u8]>,
-    key_placeholder: &KeyPlaceholder,
+    key_placeholder: &KeyExpression,
     account_id: u32,
 ) -> Result<(), PsbtAccountError> {
     psbt.set_account(account_id, PsbtAccount::WalletPolicy(wallet_policy.clone()))?;
@@ -443,8 +444,13 @@ pub fn fill_psbt_with_bip388_coordinates(
         psbt.set_account_proof_of_registration(account_id, por)?;
     }
 
+    // Musig key expressions are not yet supported for PSBT coordinate filling.
+    let key_index = key_placeholder
+        .plain_key_index()
+        .ok_or(PsbtAccountError::Unsupported)?;
+
     // we will look for keys derived from this
-    let key_expr = &wallet_policy.key_information[key_placeholder.key_index as usize];
+    let key_expr = &wallet_policy.key_information[key_index as usize];
     // When origin info is present, use its fingerprint and derivation-path length to
     // locate derived keys inside the PSBT.  When it is absent (e.g. a bare/resident
     // xpub), fall back to the xpub's own fingerprint with an origin path length of 0.
@@ -499,7 +505,7 @@ pub fn prepare_psbt(
     // TODO: generalize this function to support transactions involving multiple accounts, and accounts of different types.
     assert!(named_accounts.len() == 1);
     for (wallet_policy, account_name, por) in named_accounts {
-        let placeholders: Vec<KeyPlaceholder> = wallet_policy
+        let placeholders: Vec<KeyExpression> = wallet_policy
             .descriptor_template
             .placeholders()
             .map(|(k, _)| k.clone())
@@ -650,13 +656,13 @@ mod tests {
         let psbt_str = "cHNidP8BAKYCAAAAAp4s/ifwrYe3iiN9XXQF1KMGZso2HVhaRnsN/kImK020AQAAAAD9////r7+uBlkPdB/xr1m2rEYRJjNqTEqC21U99v76tzesM/MAAAAAAP3///8CqDoGAAAAAAAWABTrOPqbgSj4HybpXtsMX/rqg2kP5OCTBAAAAAAAIgAgP6lmyd3Nwv2W5KXhvHZbn69s6LPrTxEEqta993Mk5b4AAAAAAAEAcQIAAAABk2qy4BBy95PP5Ml3VN4bYf4D59tlNsiy8h3QtXQsSEUBAAAAAP7///8C3uHHAAAAAAAWABTreNfEC/EGOw4/zinDVltonIVZqxAnAAAAAAAAFgAUIxjWb4T+9cSHX5M7A43GODH42hP5lx4AAQEfECcAAAAAAAAWABQjGNZvhP71xIdfkzsDjcY4MfjaEyIGA0Ve587cl7C6Q1uABm/JLJY6NMYAMXmB0TUzDE7kOsejGPWswv1UAACAAQAAgAAAAIAAAAAAAQAAAAABAHEBAAAAAQ5HHvTpLBrLUe/IZg+NP2mTbqnJsr/3L/m8gcUe/PRkAQAAAAAAAAAAAmCuCgAAAAAAFgAUNcbg3W08hLFrqIXcpzrIY9C1k+yvBjIAAAAAABYAFNwobgzS5r03zr6ew0n7XwiQVnL8AAAAAAEBH2CuCgAAAAAAFgAUNcbg3W08hLFrqIXcpzrIY9C1k+wiBgJxtbd5rYcIOFh3l7z28MeuxavnanCdck9I0uJs+HTwoBj1rML9VAAAgAEAAIAAAACAAQAAAAAAAAAAIgICKexHcnEx7SWIogxG7amrt9qm9J/VC6/nC5xappYcTswY9azC/VQAAIABAACAAAAAgAEAAAAKAAAAAAA=";
         let mut psbt = psbt_from_str(psbt_str).unwrap();
 
-        let placeholders: Vec<KeyPlaceholder> = wallet_policy
+        let placeholders: Vec<KeyExpression> = wallet_policy
             .descriptor_template
             .placeholders()
             .map(|(k, _)| k.clone())
             .collect();
         assert!(placeholders.len() == 1);
-        let key_placeholder = placeholders[0];
+        let key_placeholder = &placeholders[0];
 
         let result = fill_psbt_with_bip388_coordinates(
             &mut psbt,

--- a/apps/bitcoin/common/src/script.rs
+++ b/apps/bitcoin/common/src/script.rs
@@ -36,7 +36,7 @@ impl<const N: usize> BubbleSort for Vec<[u8; N]> {
     }
 }
 
-use crate::account::{DescriptorTemplate, KeyInformation, KeyPlaceholder, WalletPolicy};
+use crate::account::{DescriptorTemplate, KeyExpression, KeyInformation, WalletPolicy};
 
 const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
 const MAX_PUBKEYS_PER_MULTI_A: usize = 999;
@@ -108,11 +108,14 @@ impl ToScriptWithKeyInfoInner for DescriptorTemplate {
         mut builder: Builder,
         ctx: ScriptContext,
     ) -> Result<Builder, Error> {
-        let derive = |kp: &KeyPlaceholder| -> Result<Xpub, Error> {
+        let derive = |kp: &KeyExpression| -> Result<Xpub, Error> {
             let change_step = ChildNumber::from(if is_change { kp.num2 } else { kp.num1 });
 
+            // this does not yet handle musig() key expressions
+            let key_index = kp.plain_key_index().ok_or(Error::UnsupportedWalletPolicy)?;
+
             let key_info = key_information
-                .get(kp.key_index as usize)
+                .get(key_index as usize)
                 .ok_or(Error::InvalidKeyIndex)?;
 
             let root_pubkey = &key_info.pubkey;
@@ -291,7 +294,7 @@ impl ToScriptWithKeyInfoInner for DescriptorTemplate {
             DescriptorTemplate::One => builder.push_opcode(OP_PUSHNUM_1),
             DescriptorTemplate::Pk(k) => {
                 // c:pk_k(key)
-                let desc = DescriptorTemplate::C(Box::new(DescriptorTemplate::Pk_k(*k)));
+                let desc = DescriptorTemplate::C(Box::new(DescriptorTemplate::Pk_k(k.clone())));
                 desc.to_script_inner(key_information, is_change, address_index, builder, ctx)?
             }
             DescriptorTemplate::Pk_k(kp) => {

--- a/apps/bitcoin/macros/src/descriptor_match.rs
+++ b/apps/bitcoin/macros/src/descriptor_match.rs
@@ -399,10 +399,10 @@ fn flatten_pattern(
                 match arg {
                     PatternArg::Binding(ident) => {
                         let extraction = match kind {
-                            ArgKind::Key => quote!(#tv.key_index),
+                            ArgKind::Key => quote!(#tv),
                             ArgKind::Num => quote!(*#tv),
                             ArgKind::KeyList => {
-                                quote!(#tv.iter().map(|__kp| __kp.key_index).collect::<Vec<u32>>())
+                                quote!(#tv)
                             }
                             ArgKind::Sub => quote!(#tv),
                         };

--- a/apps/bitcoin/macros/src/descriptor_match.rs
+++ b/apps/bitcoin/macros/src/descriptor_match.rs
@@ -95,7 +95,7 @@ enum DescPattern {
 
 enum PatternArg {
     Binding(Ident),
-    /// Match only `musig()` key expressions; binds the musig key indices.
+    /// Match only `musig()` key expressions; binds the whole musig key expression.
     MusigBinding(Ident),
     SubPattern {
         wrappers: Vec<String>,
@@ -373,11 +373,12 @@ enum MatchStep {
         /// The key list expression to check (as tokens).
         key_list_expr: TokenStream,
     },
-    /// Check that a key expression is `musig()` and bind the musig key indices.
+    /// Check that a key expression is `musig()` and bind a temporary variable
+    /// for the matched musig key expression used by later code generation.
     MusigKey {
         /// The key expression to check (as tokens).
         key_expr: TokenStream,
-        /// Temporary variable for the musig key indices.
+        /// Temporary variable holding the matched musig key expression.
         temp_var: Ident,
     },
 }

--- a/apps/bitcoin/macros/src/descriptor_match.rs
+++ b/apps/bitcoin/macros/src/descriptor_match.rs
@@ -241,6 +241,12 @@ fn parse_keyword_call_from_ident(
                     let musig_content;
                     parenthesized!(musig_content in content);
                     let binding: Ident = musig_content.parse()?;
+                    if !musig_content.is_empty() {
+                        return Err(syn::Error::new(
+                            musig_content.span(),
+                            "musig(...) expects exactly one identifier",
+                        ));
+                    }
                     PatternArg::MusigBinding(binding)
                 } else {
                     let binding: Ident = content.parse()?;

--- a/apps/bitcoin/macros/src/descriptor_match.rs
+++ b/apps/bitcoin/macros/src/descriptor_match.rs
@@ -549,7 +549,8 @@ fn fold_steps(steps: &[MatchStep], inner_code: TokenStream) -> TokenStream {
             }
             MatchStep::MusigKey { key_expr, temp_var } => {
                 code = quote! {
-                    if let Some(#temp_var) = #key_expr.musig_key_indices() {
+                    if #key_expr.is_musig() {
+                        let #temp_var = #key_expr;
                         #code
                     }
                 };

--- a/apps/bitcoin/macros/src/descriptor_match.rs
+++ b/apps/bitcoin/macros/src/descriptor_match.rs
@@ -64,6 +64,7 @@ fn variant_arg_kinds(variant: &str) -> &'static [ArgKind] {
         "Pk" | "Pk_k" | "Pk_h" | "Pkh" | "Wpkh" => &[Key],
         "Older" | "After" => &[Num],
         "Multi" | "Multi_a" | "Sortedmulti" | "Sortedmulti_a" => &[Num, KeyList],
+        "Tr" => &[Key, Sub],
         "And_v" | "And_b" | "And_n" | "Or_b" | "Or_c" | "Or_d" | "Or_i" => &[Sub, Sub],
         "Andor" => &[Sub, Sub, Sub],
         "Sh" | "Wsh" | "A" | "S" | "C" | "T" | "D" | "V" | "J" | "N" | "L" | "U" => &[Sub],
@@ -94,6 +95,8 @@ enum DescPattern {
 
 enum PatternArg {
     Binding(Ident),
+    /// Match only `musig()` key expressions; binds the musig key indices.
+    MusigBinding(Ident),
     SubPattern {
         wrappers: Vec<String>,
         inner: Box<DescPattern>,
@@ -228,7 +231,23 @@ fn parse_keyword_call_from_ident(
         }
         let kind = arg_kinds.get(i).copied().unwrap_or(ArgKind::Sub);
         let arg = match kind {
-            ArgKind::Key | ArgKind::Num | ArgKind::KeyList => {
+            ArgKind::Key => {
+                // Check if this is a musig() pattern in key position
+                let fork = content.fork();
+                let is_musig = fork.parse::<Ident>().map_or(false, |id| id == "musig")
+                    && fork.peek(token::Paren);
+                if is_musig {
+                    content.parse::<Ident>()?; // consume "musig"
+                    let musig_content;
+                    parenthesized!(musig_content in content);
+                    let binding: Ident = musig_content.parse()?;
+                    PatternArg::MusigBinding(binding)
+                } else {
+                    let binding: Ident = content.parse()?;
+                    PatternArg::Binding(binding)
+                }
+            }
+            ArgKind::Num | ArgKind::KeyList => {
                 let binding: Ident = content.parse()?;
                 PatternArg::Binding(binding)
             }
@@ -334,13 +353,33 @@ fn parse_possibly_wrapped_sub(input: ParseStream) -> syn::Result<PatternArg> {
 // innermost block containing the let-bindings and the body.
 
 /// A single destructuring step in a flattened pattern.
-struct MatchStep {
-    /// The expression to match (as tokens).
-    matchee: TokenStream,
-    /// The variant to match against.
-    variant: String,
-    /// Temporary variable names for each positional argument.
-    temp_vars: Vec<Ident>,
+enum MatchStep {
+    /// Match a `DescriptorTemplate` variant, destructuring its fields.
+    Variant {
+        /// The expression to match (as tokens).
+        matchee: TokenStream,
+        /// The variant to match against.
+        variant: String,
+        /// Temporary variable names for each positional argument.
+        temp_vars: Vec<Ident>,
+    },
+    /// Check that a key expression is a plain key (not musig).
+    PlainKey {
+        /// The key expression to check (as tokens).
+        key_expr: TokenStream,
+    },
+    /// Check that all key expressions in a list are plain keys (not musig).
+    PlainKeyList {
+        /// The key list expression to check (as tokens).
+        key_list_expr: TokenStream,
+    },
+    /// Check that a key expression is `musig()` and bind the musig key indices.
+    MusigKey {
+        /// The key expression to check (as tokens).
+        key_expr: TokenStream,
+        /// Temporary variable for the musig key indices.
+        temp_var: Ident,
+    },
 }
 
 /// A user-visible binding extracted from the pattern.
@@ -388,7 +427,7 @@ fn flatten_pattern(
                 .map(|(i, _)| counter.next(&format!("p{}_", i)))
                 .collect();
 
-            steps.push(MatchStep {
+            steps.push(MatchStep::Variant {
                 matchee,
                 variant: variant.clone(),
                 temp_vars: temp_vars.clone(),
@@ -399,9 +438,19 @@ fn flatten_pattern(
                 match arg {
                     PatternArg::Binding(ident) => {
                         let extraction = match kind {
-                            ArgKind::Key => quote!(#tv),
+                            ArgKind::Key => {
+                                // Plain binding in Key position: require plain key
+                                steps.push(MatchStep::PlainKey {
+                                    key_expr: quote!(#tv),
+                                });
+                                quote!(#tv)
+                            }
                             ArgKind::Num => quote!(*#tv),
                             ArgKind::KeyList => {
+                                // Plain binding in KeyList position: require all plain keys
+                                steps.push(MatchStep::PlainKeyList {
+                                    key_list_expr: quote!(#tv),
+                                });
                                 quote!(#tv)
                             }
                             ArgKind::Sub => quote!(#tv),
@@ -409,6 +458,17 @@ fn flatten_pattern(
                         user_bindings.push(UserBinding {
                             name: ident.clone(),
                             extraction,
+                        });
+                    }
+                    PatternArg::MusigBinding(ident) => {
+                        let musig_tv = counter.next("musig_");
+                        steps.push(MatchStep::MusigKey {
+                            key_expr: quote!(#tv),
+                            temp_var: musig_tv.clone(),
+                        });
+                        user_bindings.push(UserBinding {
+                            name: ident.clone(),
+                            extraction: quote!(#musig_tv),
                         });
                     }
                     PatternArg::SubPattern { wrappers, inner } => {
@@ -423,7 +483,7 @@ fn flatten_pattern(
                             } else {
                                 current_expr.clone()
                             };
-                            steps.push(MatchStep {
+                            steps.push(MatchStep::Variant {
                                 matchee: wmatchee,
                                 variant: w.clone(),
                                 temp_vars: vec![wtv.clone()],
@@ -452,21 +512,49 @@ fn flatten_pattern(
 fn fold_steps(steps: &[MatchStep], inner_code: TokenStream) -> TokenStream {
     let mut code = inner_code;
     for step in steps.iter().rev() {
-        let variant_ident = Ident::new(&step.variant, Span::call_site());
-        let matchee = &step.matchee;
-        let tvs: Vec<&Ident> = step.temp_vars.iter().collect();
+        match step {
+            MatchStep::Variant {
+                matchee,
+                variant,
+                temp_vars,
+            } => {
+                let variant_ident = Ident::new(variant, Span::call_site());
+                let tvs: Vec<&Ident> = temp_vars.iter().collect();
 
-        let destructure = if tvs.is_empty() {
-            quote!(DescriptorTemplate::#variant_ident)
-        } else {
-            quote!(DescriptorTemplate::#variant_ident(#(#tvs),*))
-        };
+                let destructure = if tvs.is_empty() {
+                    quote!(DescriptorTemplate::#variant_ident)
+                } else {
+                    quote!(DescriptorTemplate::#variant_ident(#(#tvs),*))
+                };
 
-        code = quote! {
-            if let #destructure = #matchee {
-                #code
+                code = quote! {
+                    if let #destructure = #matchee {
+                        #code
+                    }
+                };
             }
-        };
+            MatchStep::PlainKey { key_expr } => {
+                code = quote! {
+                    if #key_expr.is_plain() {
+                        #code
+                    }
+                };
+            }
+            MatchStep::PlainKeyList { key_list_expr } => {
+                code = quote! {
+                    if #key_list_expr.iter().all(|__ke| __ke.is_plain()) {
+                        #code
+                    }
+                };
+            }
+            MatchStep::MusigKey { key_expr, temp_var } => {
+                code = quote! {
+                    if let Some(#temp_var) = #key_expr.musig_key_indices() {
+                        #code
+                    }
+                };
+            }
+        }
     }
     code
 }


### PR DESCRIPTION
Adds support for MuSig2 key placeholders in the `bip388` and the `cleartext` module. Adds support for `musig` spending conditions in:
- the taproot keypath
- `pk()` tapleaves
- `pk()` tapleaves with additional relative/absolute timelocks

Signing support in the app is not yet implemented.

Other changes:
- For any repeated key placeholder, verifies that the all its `k` occurrences have derivations `<0;1>/*`, `<2;3>/*`, ..., `<2n-2;2n-1>/*`, _in some order_, for the cleartext representation. Multiply the confusion_score by `k!`. If not, the policy does not admit a cleartext representation. While this increases the complexity_scores for some policies (and therefore its bruteforcing cost), this is simpler than forcing wallets to be extremely strict about the exact derivations that appear in the policy.
- make parsing of descriptor templates keep track of the parsing context, and add tests for illegal fragments in the relevant contexts
