### PR TITLE
[WIP] Make Bip388 core code and cleartext no_alloc and remove heavy dependencies; implement bindings in C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "common",
  "env_logger",
  "git2",
+ "rhai_codegen",
  "tokio",
  "vanadium-client-sdk",
  "which",

--- a/apps/bitcoin/app/src/handlers/musig_signing.rs
+++ b/apps/bitcoin/app/src/handlers/musig_signing.rs
@@ -526,6 +526,7 @@ fn map_musig_err(err: MusigError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use common::bip388::keyview_to_owned;
 
     const ID_A: [u8; 32] = [0xAAu8; 32];
     const ID_B: [u8; 32] = [0xBBu8; 32];
@@ -728,13 +729,14 @@ mod tests {
     #[test]
     fn compute_per_input_info_keypath_matches_script_derivation() {
         let policy = make_musig_keypath_policy();
-        let placeholder = policy
-            .descriptor_template()
-            .placeholders()
-            .next()
-            .unwrap()
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            policy
+                .descriptor_cursor()
+                .placeholders()
+                .next()
+                .unwrap()
+                .0,
+        );
 
         let info = compute_per_input_info(
             policy.key_information(),
@@ -779,13 +781,14 @@ mod tests {
 
         // Find the musig placeholder (it's the second one yielded; the first
         // is the outer plain @0).
-        let placeholder = policy
-            .descriptor_template()
-            .placeholders()
-            .find(|(kp, _)| kp.is_musig())
-            .expect("musig placeholder present")
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            policy
+                .descriptor_cursor()
+                .placeholders()
+                .find(|(kv, _)| kv.is_musig())
+                .expect("musig placeholder present")
+                .0,
+        );
 
         // Tapscript: we don't strictly need a real leaf_hash for this shape
         // check; any 32-byte value works.
@@ -817,13 +820,14 @@ mod tests {
             vec![COSIGNER_1_XPUB.try_into().unwrap()],
         )
         .unwrap();
-        let placeholder = policy
-            .descriptor_template()
-            .placeholders()
-            .next()
-            .unwrap()
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            policy
+                .descriptor_cursor()
+                .placeholders()
+                .next()
+                .unwrap()
+                .0,
+        );
 
         let err = compute_per_input_info(
             policy.key_information(),
@@ -839,13 +843,14 @@ mod tests {
     #[test]
     fn produce_pubnonce_shape_and_session_dependence() {
         let policy = make_musig_keypath_policy();
-        let placeholder = policy
-            .descriptor_template()
-            .placeholders()
-            .next()
-            .unwrap()
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            policy
+                .descriptor_cursor()
+                .placeholders()
+                .next()
+                .unwrap()
+                .0,
+        );
         let info = compute_per_input_info(
             policy.key_information(),
             &placeholder,
@@ -916,13 +921,14 @@ mod tests {
             ],
         )
         .unwrap();
-        let placeholder = policy
-            .descriptor_template()
-            .placeholders()
-            .find(|(kp, _)| kp.is_musig())
-            .unwrap()
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            policy
+                .descriptor_cursor()
+                .placeholders()
+                .find(|(kv, _)| kv.is_musig())
+                .unwrap()
+                .0,
+        );
         let leaf_hash = hex!("F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0");
         let info = compute_per_input_info(
             policy.key_information(),

--- a/apps/bitcoin/app/src/handlers/register_account.rs
+++ b/apps/bitcoin/app/src/handlers/register_account.rs
@@ -18,7 +18,7 @@ async fn display_wallet_policy(
     show_cleartext: bool,
 ) -> bool {
     use alloc::{format, string::ToString, vec::Vec};
-    use common::bip388::{ClearText, MAX_CONFUSION_SCORE};
+    use common::bip388::MAX_CONFUSION_SCORE;
     use sdk::ux::TagValue;
 
     let mut pairs = Vec::with_capacity(2 + wallet_policy.key_information().len());
@@ -28,12 +28,11 @@ async fn display_wallet_policy(
         value: name.into(),
     });
 
-    let use_cleartext = show_cleartext
-        && wallet_policy.descriptor_template().confusion_score() <= MAX_CONFUSION_SCORE;
+    let use_cleartext =
+        show_cleartext && wallet_policy.confusion_score() <= MAX_CONFUSION_SCORE;
 
     if use_cleartext {
-        let (descriptions, _all_have_cleartext) =
-            wallet_policy.descriptor_template().to_cleartext();
+        let (descriptions, _all_have_cleartext) = wallet_policy.to_cleartext();
         for (i, desc) in descriptions.iter().enumerate() {
             let tag = format!("Spending path #{}", i + 1);
             pairs.push(TagValue {

--- a/apps/bitcoin/app/src/handlers/sign_psbt.rs
+++ b/apps/bitcoin/app/src/handlers/sign_psbt.rs
@@ -7,7 +7,10 @@ use alloc::{
 
 use common::{
     account::Account,
-    bip388::{DescriptorTemplate, KeyExpression, SegwitVersion},
+    bip388::{
+        arena::{Cursor, DescriptorNode, VecArena},
+        keyview_to_owned, KeyExpression, SegwitVersion,
+    },
     errors::Error,
     identity::{build_identity_message, IdentityKey, MSG_TYPE_OUTPUT},
     message::{MuSig2PartialSignature, MuSig2Pubnonce, PartialSignature, Response},
@@ -764,9 +767,8 @@ fn taptree_hash_for(
     wallet_policy: &common::bip388::WalletPolicy,
     coords: &common::message::WalletPolicyCoordinates,
 ) -> Result<Option<[u8; 32]>, Error> {
-    match wallet_policy.descriptor_template() {
-        DescriptorTemplate::Tr(_, tree) => tree
-            .as_ref()
+    match wallet_policy.descriptor_cursor().view() {
+        DescriptorNode::Tr(_, tree) => tree
             .map(|t| {
                 t.get_taptree_hash(
                     wallet_policy.key_information(),
@@ -783,13 +785,13 @@ fn taptree_hash_for(
 /// Computes the tapleaf hash for a script-path placeholder, or `None` for
 /// keypath / non-taproot placeholders.
 fn leaf_hash_for(
-    tapleaf_desc: Option<&DescriptorTemplate>,
+    tapleaf: Option<Cursor<'_, VecArena>>,
     wallet_policy: &common::bip388::WalletPolicy,
     coords: &common::message::WalletPolicyCoordinates,
 ) -> Result<Option<TapLeafHash>, Error> {
-    tapleaf_desc
-        .map(|desc| {
-            desc.get_tapleaf_hash(
+    tapleaf
+        .map(|leaf| {
+            leaf.get_tapleaf_hash(
                 wallet_policy.key_information(),
                 coords.is_change,
                 coords.address_index,
@@ -840,11 +842,12 @@ fn sign_all_inputs(
         let wallet_id = wallet_policy.get_id(account_name);
         let session_id = musig_signing::compute_psbt_session_id(&wallet_id, &unsigned_tx_id);
 
-        for (placeholder_index, (kp, tapleaf_desc)) in wallet_policy
-            .descriptor_template()
+        for (placeholder_index, (kv, tapleaf)) in wallet_policy
+            .descriptor_cursor()
             .placeholders()
             .enumerate()
         {
+            let kp = keyview_to_owned(kv);
             let change_step: ChildNumber = if !coords.is_change {
                 kp.num1.into()
             } else {
@@ -857,8 +860,8 @@ fn sign_all_inputs(
                     input,
                     input_index,
                     placeholder_index,
-                    kp,
-                    tapleaf_desc,
+                    &kp,
+                    tapleaf,
                     wallet_policy,
                     coords,
                     session_id,
@@ -899,7 +902,7 @@ fn sign_all_inputs(
                     }
                     Ok(SegwitVersion::Taproot) => {
                         let taptree_hash = taptree_hash_for(wallet_policy, coords)?;
-                        let leaf_hash = leaf_hash_for(tapleaf_desc, wallet_policy, coords)?;
+                        let leaf_hash = leaf_hash_for(tapleaf, wallet_policy, coords)?;
                         let prev = ensure_prevouts(&mut prevouts, psbt);
                         out.signatures.push(sign_input_schnorr(
                             input_index,
@@ -934,7 +937,7 @@ fn handle_musig_placeholder(
     input_index: usize,
     placeholder_index: usize,
     kp: &KeyExpression,
-    tapleaf_desc: Option<&DescriptorTemplate>,
+    tapleaf: Option<Cursor<'_, VecArena>>,
     wallet_policy: &common::bip388::WalletPolicy,
     coords: &common::message::WalletPolicyCoordinates,
     session_id: [u8; 32],
@@ -948,7 +951,7 @@ fn handle_musig_placeholder(
 ) -> Result<(), Error> {
     // musig() can only appear inside tr() per BIP-388.
     let taptree_hash = taptree_hash_for(wallet_policy, coords)?;
-    let leaf_hash = leaf_hash_for(tapleaf_desc, wallet_policy, coords)?;
+    let leaf_hash = leaf_hash_for(tapleaf, wallet_policy, coords)?;
     let leaf_hash_bytes: Option<[u8; 32]> = leaf_hash.map(|l| l.to_byte_array());
 
     let spend = match leaf_hash_bytes.as_ref() {
@@ -1663,13 +1666,14 @@ mod tests {
         // ---- Off-device: cosigner's partial signature ----
         // Reproduce the per-input info to get tweaks/keys/order; the cosigner
         // and device run the exact same protocol, so they share the SessionContext.
-        let placeholder = wallet_policy
-            .descriptor_template()
-            .placeholders()
-            .next()
-            .unwrap()
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            wallet_policy
+                .descriptor_cursor()
+                .placeholders()
+                .next()
+                .unwrap()
+                .0,
+        );
         let info = musig_signing::compute_per_input_info(
             wallet_policy.key_information(),
             &placeholder,
@@ -1740,13 +1744,14 @@ mod tests {
 
         // Compute what the agg_pk would be so we can inject pubnonces under
         // the right BIP-373 key — the device will *try* to enter round 2.
-        let placeholder = wallet_policy
-            .descriptor_template()
-            .placeholders()
-            .next()
-            .unwrap()
-            .0
-            .clone();
+        let placeholder = keyview_to_owned(
+            wallet_policy
+                .descriptor_cursor()
+                .placeholders()
+                .next()
+                .unwrap()
+                .0,
+        );
         let info = musig_signing::compute_per_input_info(
             wallet_policy.key_information(),
             &placeholder,

--- a/apps/bitcoin/bip388-c/Cargo.toml
+++ b/apps/bitcoin/bip388-c/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "bip388-c"
+version = "0.1.0"
+edition = "2021"
+description = "C ABI bindings for the bip388 cleartext / confusion-score API (no_std, no allocator)"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+# The minimal, allocation-free, bitcoin-free core.
+bip388 = { path = "../bip388", default-features = false }
+
+[profile.release]
+opt-level = "z"
+lto = true
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
+
+[workspace]

--- a/apps/bitcoin/bip388-c/include/bip388.h
+++ b/apps/bitcoin/bip388-c/include/bip388.h
@@ -1,0 +1,70 @@
+/*
+ * C ABI for the bip388 cleartext / confusion-score API.
+ *
+ * Allocation-free and bitcoin-free: every entry point works entirely within
+ * caller-provided memory and the library has no global allocator.
+ *
+ * Usage:
+ *   1. Call bip388_min_arena_size() to size the scratch `arena` buffer.
+ *   2. bip388_confusion_score() returns an upper bound on how many distinct
+ *      descriptor templates map to the same cleartext. Show cleartext only when
+ *      it is <= BIP388_MAX_CONFUSION_SCORE.
+ *   3. bip388_to_cleartext() renders the human-readable descriptions into the
+ *      caller's `out` buffer; each line is reported as a (ptr,len) into `out`.
+ *
+ * This header is maintained by hand; keep it in sync with src/lib.rs.
+ */
+#ifndef BIP388_H
+#define BIP388_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Status codes. BIP388_OK is 0; errors are negative. */
+#define BIP388_OK 0
+#define BIP388_NULL_ARG (-1)
+#define BIP388_INVALID_UTF8 (-2)
+#define BIP388_PARSE_ERROR (-3)
+#define BIP388_ARENA_TOO_SMALL (-4)
+#define BIP388_BUFFER_TOO_SMALL (-5)
+#define BIP388_TOO_MANY_LINES (-6)
+
+/* Confusion-score display threshold (inclusive). */
+#define BIP388_MAX_CONFUSION_SCORE ((uint64_t)100000)
+
+/* A rendered cleartext line: a pointer into the caller's output buffer and a
+ * byte length (not NUL-terminated). */
+typedef struct Bip388Line {
+  const uint8_t *ptr;
+  size_t len;
+} Bip388Line;
+
+/* Minimum `arena` size (bytes) needed by the calls below for `template`.
+ * On BIP388_OK, *out_size is set. */
+int32_t bip388_min_arena_size(const uint8_t *tmpl, size_t tmpl_len,
+                              size_t *out_size);
+
+/* Parse `template` and write its confusion score to *out_score. */
+int32_t bip388_confusion_score(const uint8_t *tmpl, size_t tmpl_len,
+                               uint8_t *arena, size_t arena_len,
+                               uint64_t *out_score);
+
+/* Parse `template` and render its cleartext into `out`, recording one
+ * Bip388Line per description in `lines` (capacity `max_lines`). On BIP388_OK,
+ * *out_n_lines is the number of lines and *out_has_cleartext (if non-NULL) is
+ * whether every part has a cleartext form. */
+int32_t bip388_to_cleartext(const uint8_t *tmpl, size_t tmpl_len, uint8_t *arena,
+                            size_t arena_len, uint8_t *out, size_t out_len,
+                            Bip388Line *lines, size_t max_lines,
+                            size_t *out_n_lines, bool *out_has_cleartext);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* BIP388_H */

--- a/apps/bitcoin/bip388-c/src/lib.rs
+++ b/apps/bitcoin/bip388-c/src/lib.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
 
 use bip388::embedded::{
-    measure, parse, ArenaCounts, BufLineSink, Cursor, KeyExprRec, Link, LineSpan, Node, SliceArena,
+    measure, parse, ArenaCounts, BufLineSink, Cursor, KeyExprRec, LineSpan, Link, Node, SliceArena,
 };
 
 #[cfg(not(test))]
@@ -113,12 +113,32 @@ fn layout(c: &ArenaCounts) -> usize {
         *off += size;
     }
     let mut off = 0usize;
-    bump(&mut off, align_of::<Node>(), size_of::<Node>() * c.nodes as usize);
-    bump(&mut off, align_of::<KeyExprRec>(), size_of::<KeyExprRec>() * c.keys as usize);
-    bump(&mut off, align_of::<Link>(), size_of::<Link>() * c.links as usize);
-    bump(&mut off, align_of::<u32>(), 4 * (c.keys + c.members) as usize); // orderings
+    bump(
+        &mut off,
+        align_of::<Node>(),
+        size_of::<Node>() * c.nodes as usize,
+    );
+    bump(
+        &mut off,
+        align_of::<KeyExprRec>(),
+        size_of::<KeyExprRec>() * c.keys as usize,
+    );
+    bump(
+        &mut off,
+        align_of::<Link>(),
+        size_of::<Link>() * c.links as usize,
+    );
+    bump(
+        &mut off,
+        align_of::<u32>(),
+        4 * (c.keys + c.members) as usize,
+    ); // orderings
     bump(&mut off, align_of::<u32>(), 4 * c.members as usize); // members
-    bump(&mut off, align_of::<KeyExprRec>(), size_of::<KeyExprRec>() * c.keys as usize); // canon
+    bump(
+        &mut off,
+        align_of::<KeyExprRec>(),
+        size_of::<KeyExprRec>() * c.keys as usize,
+    ); // canon
     bump(&mut off, align_of::<u32>(), 4 * c.nodes as usize); // leaf
     bump(&mut off, align_of::<u8>(), c.bytes as usize); // bytes
     bump(
@@ -226,7 +246,13 @@ pub unsafe extern "C" fn bip388_confusion_score(
         Some(p) => p,
         None => return BIP388_ARENA_TOO_SMALL,
     };
-    let mut sa = SliceArena::new(pools.nodes, pools.keys, pools.links, pools.members, pools.bytes);
+    let mut sa = SliceArena::new(
+        pools.nodes,
+        pools.keys,
+        pools.links,
+        pools.members,
+        pools.bytes,
+    );
     let root = match parse(s, &mut sa) {
         Ok(r) => r,
         Err(_) => return BIP388_PARSE_ERROR,
@@ -277,7 +303,13 @@ pub unsafe extern "C" fn bip388_to_cleartext(
     };
     let out_buf = core::slice::from_raw_parts_mut(out, out_len);
 
-    let mut sa = SliceArena::new(pools.nodes, pools.keys, pools.links, pools.members, pools.bytes);
+    let mut sa = SliceArena::new(
+        pools.nodes,
+        pools.keys,
+        pools.links,
+        pools.members,
+        pools.bytes,
+    );
     let root = match parse(s, &mut sa) {
         Ok(r) => r,
         Err(_) => return BIP388_PARSE_ERROR,

--- a/apps/bitcoin/bip388-c/src/lib.rs
+++ b/apps/bitcoin/bip388-c/src/lib.rs
@@ -1,0 +1,312 @@
+//! C ABI for the bip388 cleartext / confusion-score API.
+//!
+//! Allocation-free: the caller supplies a scratch *arena* byte buffer (carved
+//! internally into the bip388 record pools and working scratch) and, for
+//! `to_cleartext`, an output byte buffer plus a `Bip388Line` array. Nothing
+//! Rust-owned escapes; there is no global allocator.
+#![no_std]
+#![allow(clippy::missing_safety_doc)]
+
+use core::marker::PhantomData;
+use core::mem::{align_of, size_of};
+
+use bip388::embedded::{
+    measure, parse, ArenaCounts, BufLineSink, Cursor, KeyExprRec, Link, LineSpan, Node, SliceArena,
+};
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    // The library is panic-free in normal operation; abort hard if reached.
+    loop {}
+}
+
+/// Status codes returned by every entry point. `BIP388_OK` is 0; errors are
+/// negative.
+pub const BIP388_OK: i32 = 0;
+pub const BIP388_NULL_ARG: i32 = -1;
+pub const BIP388_INVALID_UTF8: i32 = -2;
+pub const BIP388_PARSE_ERROR: i32 = -3;
+pub const BIP388_ARENA_TOO_SMALL: i32 = -4;
+pub const BIP388_BUFFER_TOO_SMALL: i32 = -5;
+pub const BIP388_TOO_MANY_LINES: i32 = -6;
+
+/// Threshold (inclusive upper bound) below which cleartext is considered
+/// safe to show; mirrors `bip388::MAX_CONFUSION_SCORE`.
+pub const BIP388_MAX_CONFUSION_SCORE: u64 = 100_000;
+
+/// A rendered cleartext line: a pointer into the caller's output buffer and a
+/// byte length (not NUL-terminated).
+#[repr(C)]
+pub struct Bip388Line {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Bump carving of the caller arena into typed pools (no allocation)
+// ---------------------------------------------------------------------------
+
+/// Bump allocator over a caller-provided byte buffer. Hands out disjoint,
+/// type-aligned, zero-initialized sub-slices that live as long as the buffer.
+struct Bump<'a> {
+    ptr: *mut u8,
+    cap: usize,
+    off: usize,
+    _marker: PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> Bump<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Bump {
+            ptr: buf.as_mut_ptr(),
+            cap: buf.len(),
+            off: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    fn take<T>(&mut self, n: usize) -> Option<&'a mut [T]> {
+        let align = align_of::<T>();
+        let start = (self.off.checked_add(align - 1)?) & !(align - 1);
+        let size = size_of::<T>().checked_mul(n)?;
+        let end = start.checked_add(size)?;
+        if end > self.cap {
+            return None;
+        }
+        // SAFETY: `start..end` is in-bounds and disjoint from every previously
+        // handed-out region (`off` only grows). Zeroing makes the bytes a valid
+        // `[T]` for every record type used here (all are valid when zeroed:
+        // `NodeTag::Sh` / `KeyKind::Plain` have discriminant 0, others are
+        // integers). The lifetime is tied to the original `&'a mut [u8]`.
+        unsafe {
+            let p = self.ptr.add(start);
+            core::ptr::write_bytes(p, 0, size);
+            self.off = end;
+            Some(core::slice::from_raw_parts_mut(p as *mut T, n))
+        }
+    }
+}
+
+/// All pools and working scratch carved from one arena buffer.
+struct Pools<'a> {
+    nodes: &'a mut [Node],
+    keys: &'a mut [KeyExprRec],
+    links: &'a mut [Link],
+    members: &'a mut [u32],
+    bytes: &'a mut [u8],
+    /// Scratch for `confusion_score` (musig-expanded key indices).
+    orderings: &'a mut [u32],
+    /// Scratch for the canonical-derivation check.
+    canon: &'a mut [KeyExprRec],
+    /// Scratch for the tap-leaf display sort.
+    leaf: &'a mut [u32],
+    /// Scratch for the rendered line spans.
+    line_spans: &'a mut [LineSpan],
+}
+
+/// The number of bytes [`carve`] needs for the given counts. Must stay in lock
+/// step with `carve`'s allocation sequence.
+fn layout(c: &ArenaCounts) -> usize {
+    fn bump(off: &mut usize, align: usize, size: usize) {
+        *off = (*off + align - 1) & !(align - 1);
+        *off += size;
+    }
+    let mut off = 0usize;
+    bump(&mut off, align_of::<Node>(), size_of::<Node>() * c.nodes as usize);
+    bump(&mut off, align_of::<KeyExprRec>(), size_of::<KeyExprRec>() * c.keys as usize);
+    bump(&mut off, align_of::<Link>(), size_of::<Link>() * c.links as usize);
+    bump(&mut off, align_of::<u32>(), 4 * (c.keys + c.members) as usize); // orderings
+    bump(&mut off, align_of::<u32>(), 4 * c.members as usize); // members
+    bump(&mut off, align_of::<KeyExprRec>(), size_of::<KeyExprRec>() * c.keys as usize); // canon
+    bump(&mut off, align_of::<u32>(), 4 * c.nodes as usize); // leaf
+    bump(&mut off, align_of::<u8>(), c.bytes as usize); // bytes
+    bump(
+        &mut off,
+        align_of::<LineSpan>(),
+        size_of::<LineSpan>() * (c.nodes as usize + 1),
+    ); // line spans
+    off
+}
+
+fn carve<'a>(buf: &'a mut [u8], c: &ArenaCounts) -> Option<Pools<'a>> {
+    let mut b = Bump::new(buf);
+    // Order must match `layout`.
+    let nodes = b.take::<Node>(c.nodes as usize)?;
+    let keys = b.take::<KeyExprRec>(c.keys as usize)?;
+    let links = b.take::<Link>(c.links as usize)?;
+    let orderings = b.take::<u32>((c.keys + c.members) as usize)?;
+    let members = b.take::<u32>(c.members as usize)?;
+    let canon = b.take::<KeyExprRec>(c.keys as usize)?;
+    let leaf = b.take::<u32>(c.nodes as usize)?;
+    let bytes = b.take::<u8>(c.bytes as usize)?;
+    let line_spans = b.take::<LineSpan>(c.nodes as usize + 1)?;
+    Some(Pools {
+        nodes,
+        keys,
+        links,
+        members,
+        bytes,
+        orderings,
+        canon,
+        leaf,
+        line_spans,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Validate and convert a `(ptr, len)` pair into `&str`, or a status code.
+unsafe fn template_str<'a>(tmpl: *const u8, tmpl_len: usize) -> Result<&'a str, i32> {
+    if tmpl.is_null() {
+        return Err(BIP388_NULL_ARG);
+    }
+    let bytes = core::slice::from_raw_parts(tmpl, tmpl_len);
+    core::str::from_utf8(bytes).map_err(|_| BIP388_INVALID_UTF8)
+}
+
+// ---------------------------------------------------------------------------
+// C ABI entry points
+// ---------------------------------------------------------------------------
+
+/// Minimum arena size (in bytes) needed by the other entry points for
+/// `template`. Returns a status; on `BIP388_OK`, `*out_size` is set.
+///
+/// # Safety
+/// `tmpl` must point to `tmpl_len` readable bytes; `out_size` must be writable.
+#[no_mangle]
+pub unsafe extern "C" fn bip388_min_arena_size(
+    tmpl: *const u8,
+    tmpl_len: usize,
+    out_size: *mut usize,
+) -> i32 {
+    if out_size.is_null() {
+        return BIP388_NULL_ARG;
+    }
+    let s = match template_str(tmpl, tmpl_len) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match measure(s) {
+        Ok(c) => {
+            *out_size = layout(&c);
+            BIP388_OK
+        }
+        Err(_) => BIP388_PARSE_ERROR,
+    }
+}
+
+/// Parse `template` and compute its confusion score into `*out_score`.
+///
+/// # Safety
+/// All pointers must be valid for their given lengths; `out_score` writable.
+#[no_mangle]
+pub unsafe extern "C" fn bip388_confusion_score(
+    tmpl: *const u8,
+    tmpl_len: usize,
+    arena: *mut u8,
+    arena_len: usize,
+    out_score: *mut u64,
+) -> i32 {
+    if arena.is_null() || out_score.is_null() {
+        return BIP388_NULL_ARG;
+    }
+    let s = match template_str(tmpl, tmpl_len) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let counts = match measure(s) {
+        Ok(c) => c,
+        Err(_) => return BIP388_PARSE_ERROR,
+    };
+    let arena_buf = core::slice::from_raw_parts_mut(arena, arena_len);
+    let pools = match carve(arena_buf, &counts) {
+        Some(p) => p,
+        None => return BIP388_ARENA_TOO_SMALL,
+    };
+    let mut sa = SliceArena::new(pools.nodes, pools.keys, pools.links, pools.members, pools.bytes);
+    let root = match parse(s, &mut sa) {
+        Ok(r) => r,
+        Err(_) => return BIP388_PARSE_ERROR,
+    };
+    let cur = Cursor::new(&sa, root);
+    *out_score = cur.confusion_score(pools.orderings);
+    BIP388_OK
+}
+
+/// Parse `template` and render its cleartext into `out`, recording one
+/// `Bip388Line` (pointer into `out` + length) per description in `lines`.
+///
+/// On `BIP388_OK`: `*out_n_lines` is the number of lines written and
+/// `*out_has_cleartext` is whether every part has a cleartext form; if a
+/// score pointer is supplied it is set too.
+///
+/// # Safety
+/// All pointers must be valid for their given lengths / sizes.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn bip388_to_cleartext(
+    tmpl: *const u8,
+    tmpl_len: usize,
+    arena: *mut u8,
+    arena_len: usize,
+    out: *mut u8,
+    out_len: usize,
+    lines: *mut Bip388Line,
+    max_lines: usize,
+    out_n_lines: *mut usize,
+    out_has_cleartext: *mut bool,
+) -> i32 {
+    if arena.is_null() || out.is_null() || lines.is_null() || out_n_lines.is_null() {
+        return BIP388_NULL_ARG;
+    }
+    let s = match template_str(tmpl, tmpl_len) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let counts = match measure(s) {
+        Ok(c) => c,
+        Err(_) => return BIP388_PARSE_ERROR,
+    };
+    let arena_buf = core::slice::from_raw_parts_mut(arena, arena_len);
+    let pools = match carve(arena_buf, &counts) {
+        Some(p) => p,
+        None => return BIP388_ARENA_TOO_SMALL,
+    };
+    let out_buf = core::slice::from_raw_parts_mut(out, out_len);
+
+    let mut sa = SliceArena::new(pools.nodes, pools.keys, pools.links, pools.members, pools.bytes);
+    let root = match parse(s, &mut sa) {
+        Ok(r) => r,
+        Err(_) => return BIP388_PARSE_ERROR,
+    };
+    let cur = Cursor::new(&sa, root);
+
+    let has_cleartext;
+    let n_lines;
+    {
+        let mut sink = BufLineSink::new(out_buf, pools.line_spans);
+        has_cleartext = cur.to_cleartext(&mut sink, pools.canon, pools.leaf);
+        if sink.overflowed() {
+            return BIP388_BUFFER_TOO_SMALL;
+        }
+        n_lines = sink.line_count();
+        if n_lines > max_lines {
+            return BIP388_TOO_MANY_LINES;
+        }
+        let out_lines = core::slice::from_raw_parts_mut(lines, max_lines);
+        for (i, span) in sink.lines().iter().enumerate() {
+            out_lines[i] = Bip388Line {
+                ptr: out.add(span.offset as usize),
+                len: span.len as usize,
+            };
+        }
+    }
+    *out_n_lines = n_lines;
+    if !out_has_cleartext.is_null() {
+        *out_has_cleartext = has_cleartext;
+    }
+    BIP388_OK
+}

--- a/apps/bitcoin/bip388-c/tests/smoke.c
+++ b/apps/bitcoin/bip388-c/tests/smoke.c
@@ -1,0 +1,71 @@
+/* Smoke test for the bip388-c staticlib.
+ *
+ * Build (from the crate dir):
+ *   cargo build --release
+ *   cc tests/smoke.c target/release/libbip388_c.a -o /tmp/bip388_smoke
+ *   /tmp/bip388_smoke
+ */
+#include "../include/bip388.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int check_one(const char *tmpl) {
+  size_t tlen = strlen(tmpl);
+  size_t need = 0;
+  int rc = bip388_min_arena_size((const uint8_t *)tmpl, tlen, &need);
+  if (rc != BIP388_OK) {
+    printf("FAIL min_arena_size(%s) = %d\n", tmpl, rc);
+    return 1;
+  }
+
+  uint8_t arena[16384];
+  if (need > sizeof arena) {
+    printf("FAIL arena too small for %s: need %zu\n", tmpl, need);
+    return 1;
+  }
+
+  uint64_t score = 0;
+  rc = bip388_confusion_score((const uint8_t *)tmpl, tlen, arena, sizeof arena,
+                              &score);
+  if (rc != BIP388_OK) {
+    printf("FAIL confusion_score(%s) = %d\n", tmpl, rc);
+    return 1;
+  }
+
+  uint8_t out[2048];
+  Bip388Line lines[32];
+  size_t n = 0;
+  bool hct = false;
+  rc = bip388_to_cleartext((const uint8_t *)tmpl, tlen, arena, sizeof arena, out,
+                           sizeof out, lines, 32, &n, &hct);
+  if (rc != BIP388_OK) {
+    printf("FAIL to_cleartext(%s) = %d\n", tmpl, rc);
+    return 1;
+  }
+
+  printf("%s\n  min_arena=%zu  confusion_score=%llu  has_cleartext=%d\n", tmpl,
+         need, (unsigned long long)score, (int)hct);
+  for (size_t i = 0; i < n; i++) {
+    printf("  [%zu] %.*s\n", i, (int)lines[i].len, lines[i].ptr);
+  }
+  if (n == 0) {
+    printf("FAIL: no cleartext lines\n");
+    return 1;
+  }
+  return 0;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += check_one("wsh(multi(2,@0/**,@1/**,@2/**))");
+  failures += check_one("tr(@0/**,{pk(@1/**),and_v(v:pk(@2/**),older(144))})");
+  failures += check_one("pkh(@0/**)");
+  if (failures) {
+    printf("SMOKE TEST FAILED (%d)\n", failures);
+    return 1;
+  }
+  printf("SMOKE TEST OK\n");
+  return 0;
+}

--- a/apps/bitcoin/bip388/Cargo.toml
+++ b/apps/bitcoin/bip388/Cargo.toml
@@ -4,12 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = []
-cleartext-decode = []
+default = ["alloc", "wallet-policy"]
+# Owned `DescriptorTemplate` AST, parser->owned bridge, owned cleartext/Display,
+# and the `Vec<String>` cleartext API. The cursor (arena) path is always built.
+alloc = ["dep:hex"]
+# `KeyOrigin`/`KeyInformation`/`WalletPolicy` + (de)serialization (pulls in `bitcoin`).
+wallet-policy = ["alloc", "dep:bitcoin"]
+# Reverse parsing of cleartext back into descriptor templates.
+cleartext-decode = ["alloc"]
 
 [dependencies]
-bitcoin = { version = "0.32.0", features = ["serde"], default-features = false }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+bitcoin = { version = "0.32.0", features = ["serde"], default-features = false, optional = true }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 toml = { version = "0.8", default-features = false, features = ["parse"] }

--- a/apps/bitcoin/bip388/build.rs
+++ b/apps/bitcoin/bip388/build.rs
@@ -839,6 +839,20 @@ impl ClassKind {
     fn class(self) -> Ident {
         format_ident!("{}", self.class_enum)
     }
+    /// The borrowed/arena-cursor class enum name, e.g. `DescriptorClassRef`.
+    fn class_ref(self) -> Ident {
+        format_ident!("{}Ref", self.class_enum)
+    }
+    /// `Other` constructor for the borrowed class. Top-level is a unit variant;
+    /// tap-leaf carries the matched cursor (for rendering the raw sub-descriptor).
+    fn other_ctor_ref(self) -> TokenStream {
+        let c = self.class_ref();
+        if self.other_has_string {
+            quote!(#c::Other(__m))
+        } else {
+            quote!(#c::Other)
+        }
+    }
     fn pattern(self) -> Ident {
         format_ident!("{}", self.pattern_enum)
     }
@@ -1542,6 +1556,478 @@ fn emit_score_arm(entry: &ProcessedEntry, class_enum: &str) -> TokenStream {
 }
 
 // ---------------------------------------------------------------------------
+// Cursor-based classify (arena, no-alloc) — additive: emits borrowed
+// `*Ref` classes + `classify_ref`/`classify_as_tapleaf_ref` + their scores,
+// alongside the owned ones (which the decode path still needs). The match
+// chains mirror the owned ones via `Cursor::view()`.
+// ---------------------------------------------------------------------------
+
+/// Map an owned `DescriptorTemplate` variant name to the `DescriptorNode` view
+/// variant name (they differ only in casing for `Pk_k`/`Multi_a`/`And_v`/…).
+fn node_variant_name(owned: &str) -> &'static str {
+    match owned {
+        "Pk_k" => "PkK",
+        "Pk_h" => "PkH",
+        "Multi_a" => "MultiA",
+        "Sortedmulti_a" => "SortedmultiA",
+        "And_v" => "AndV",
+        "And_b" => "AndB",
+        "And_n" => "AndN",
+        "Or_b" => "OrB",
+        "Or_c" => "OrC",
+        "Or_d" => "OrD",
+        "Or_i" => "OrI",
+        // Same name in both enums.
+        "Sh" => "Sh",
+        "Wsh" => "Wsh",
+        "Pkh" => "Pkh",
+        "Wpkh" => "Wpkh",
+        "Pk" => "Pk",
+        "Sortedmulti" => "Sortedmulti",
+        "Multi" => "Multi",
+        "Tr" => "Tr",
+        "Older" => "Older",
+        "After" => "After",
+        "Andor" => "Andor",
+        "Thresh" => "Thresh",
+        "A" => "A",
+        "S" => "S",
+        "C" => "C",
+        "T" => "T",
+        "D" => "D",
+        "V" => "V",
+        "J" => "J",
+        "N" => "N",
+        "L" => "L",
+        "U" => "U",
+        other => panic!("no DescriptorNode variant for {other}"),
+    }
+}
+
+/// Borrowed field type for a class field of the given kind.
+fn rust_type_ref(k: BindingKind) -> TokenStream {
+    match k {
+        BindingKind::Key => quote!(KeyView<'a, A>),
+        BindingKind::KeyList => quote!(ClassKeyList<'a, A>),
+        BindingKind::Threshold => quote!(u32),
+        BindingKind::Timelock => quote!(Timelock),
+        BindingKind::Subpolicy => quote!(Cursor<'a, A>),
+        BindingKind::Leaves => quote!(Option<TapCursor<'a, A>>),
+    }
+}
+
+/// Cursor analogue of `MatchStep`.
+enum CStep {
+    Variant {
+        matchee: TokenStream,
+        node_variant: Ident,
+        temps: Vec<Ident>,
+        tr_no_tree: bool,
+    },
+    PlainKey {
+        expr: Ident,
+    },
+    PlainKeyList {
+        expr: Ident,
+    },
+    MusigKey {
+        expr: Ident,
+        temp: Ident,
+    },
+    ClassifyTimelock {
+        expr: TokenStream,
+        bound: Ident,
+    },
+    ClassifySubpolicy {
+        expr: TokenStream,
+        classified: Ident,
+        combinator_variants: Vec<Ident>,
+    },
+}
+
+struct CLowered {
+    steps: Vec<CStep>,
+    bindings: BTreeMap<String, TokenStream>,
+}
+
+fn lower_pattern_cursor(pat: &Pattern, combinator_variants: &[Ident]) -> CLowered {
+    let mut counter = Counter(0);
+    let mut l = CLowered {
+        steps: Vec::new(),
+        bindings: BTreeMap::new(),
+    };
+    lower_cursor(pat, quote!(__m), &mut counter, &mut l, combinator_variants);
+    l
+}
+
+fn lower_cursor(
+    pat: &Pattern,
+    matchee: TokenStream,
+    c: &mut Counter,
+    l: &mut CLowered,
+    combinator_variants: &[Ident],
+) {
+    let variant_str = keyword_to_variant(&pat.keyword).expect("keyword validated");
+    let node_variant = id(node_variant_name(variant_str));
+    let arg_kinds = variant_arg_kinds(variant_str);
+
+    let temps: Vec<Ident> = pat.args.iter().map(|_| c.next()).collect();
+    let tr_no_tree = variant_str == "Tr" && pat.args.len() == 1;
+    l.steps.push(CStep::Variant {
+        matchee,
+        node_variant,
+        temps: temps.clone(),
+        tr_no_tree,
+    });
+
+    for (i, (arg, tv)) in pat.args.iter().zip(temps.iter()).enumerate() {
+        let kind = arg_kinds.get(i).copied().unwrap_or(ArgKind::Sub);
+        match arg {
+            PatternArg::Binding { name, kind: bkind } => match kind {
+                ArgKind::Key => {
+                    l.steps.push(CStep::PlainKey { expr: tv.clone() });
+                    l.bindings.insert(name.clone(), quote!(#tv));
+                }
+                ArgKind::Num => {
+                    l.bindings.insert(name.clone(), quote!(#tv));
+                }
+                ArgKind::KeyList => {
+                    l.steps.push(CStep::PlainKeyList { expr: tv.clone() });
+                    l.bindings
+                        .insert(name.clone(), quote!(ClassKeyList::Explicit(#tv)));
+                }
+                ArgKind::Sub if *bkind == BindingKind::Subpolicy => {
+                    let classified = format_ident!("__cls_{}", name);
+                    l.steps.push(CStep::ClassifySubpolicy {
+                        expr: quote!(#tv),
+                        classified,
+                        combinator_variants: combinator_variants.to_vec(),
+                    });
+                    // The Subpolicy field stores the cursor (re-classified lazily).
+                    l.bindings.insert(name.clone(), quote!(#tv));
+                }
+                ArgKind::Sub if *bkind == BindingKind::Timelock => {
+                    let bound = format_ident!("__tl_{}", name);
+                    l.steps.push(CStep::ClassifyTimelock {
+                        expr: quote!(#tv),
+                        bound: bound.clone(),
+                    });
+                    l.bindings.insert(name.clone(), quote!(#bound));
+                }
+                // Sub (plain) or Tree (Option<TapCursor>): bind the temp directly.
+                ArgKind::Sub | ArgKind::Tree => {
+                    l.bindings.insert(name.clone(), quote!(#tv));
+                }
+            },
+            PatternArg::Musig { threshold, keys } => {
+                let m = c.next();
+                l.steps.push(CStep::MusigKey {
+                    expr: tv.clone(),
+                    temp: m.clone(),
+                });
+                l.bindings.insert(
+                    threshold.clone(),
+                    quote!(#m.musig_key_indices().map(|__x| __x.len() as u32).unwrap_or(0)),
+                );
+                l.bindings
+                    .insert(keys.clone(), quote!(ClassKeyList::MusigExpanded(#m)));
+            }
+            PatternArg::Sub { wrappers, inner } => {
+                let mut current: TokenStream = quote!(#tv);
+                for w in wrappers {
+                    let wv = id(w);
+                    let wt = c.next();
+                    l.steps.push(CStep::Variant {
+                        matchee: current,
+                        node_variant: wv,
+                        temps: vec![wt.clone()],
+                        tr_no_tree: false,
+                    });
+                    current = quote!(#wt);
+                }
+                lower_cursor(inner, current, c, l, combinator_variants);
+            }
+            PatternArg::SubpolicyRef { wrappers, name } => {
+                let mut current: TokenStream = quote!(#tv);
+                for w in wrappers {
+                    let wv = id(w);
+                    let wt = c.next();
+                    l.steps.push(CStep::Variant {
+                        matchee: current,
+                        node_variant: wv,
+                        temps: vec![wt.clone()],
+                        tr_no_tree: false,
+                    });
+                    current = quote!(#wt);
+                }
+                let classified = format_ident!("__cls_{}", name);
+                l.steps.push(CStep::ClassifySubpolicy {
+                    expr: current.clone(),
+                    classified,
+                    combinator_variants: combinator_variants.to_vec(),
+                });
+                l.bindings.insert(name.clone(), current);
+            }
+        }
+    }
+}
+
+fn fold_cursor_steps(steps: &[CStep], inner: TokenStream) -> TokenStream {
+    let mut code = inner;
+    for step in steps.iter().rev() {
+        code = match step {
+            CStep::Variant {
+                matchee,
+                node_variant,
+                temps,
+                tr_no_tree,
+            } => {
+                if temps.is_empty() {
+                    quote!(if let DescriptorNode::#node_variant = #matchee.view() { #code })
+                } else if *tr_no_tree {
+                    let key = &temps[0];
+                    quote!(if let DescriptorNode::Tr(#key, None) = #matchee.view() { #code })
+                } else {
+                    quote!(if let DescriptorNode::#node_variant(#(#temps),*) = #matchee.view() { #code })
+                }
+            }
+            CStep::PlainKey { expr } => quote!(if #expr.is_plain() { #code }),
+            CStep::PlainKeyList { expr } => {
+                quote!(if #expr.iter().all(|__k| __k.is_plain()) { #code })
+            }
+            CStep::MusigKey { expr, temp } => quote! {
+                if #expr.is_musig() {
+                    let #temp = #expr;
+                    #code
+                }
+            },
+            CStep::ClassifyTimelock { expr, bound } => quote! {
+                let __tl = match #expr.view() {
+                    DescriptorNode::Older(__n) if is_valid_relative_locktime(__n) => {
+                        Some(Timelock::Relative(__n))
+                    }
+                    DescriptorNode::After(__n) if is_valid_absolute_locktime(__n) => {
+                        Some(Timelock::Absolute(__n))
+                    }
+                    _ => None,
+                };
+                if let Some(#bound) = __tl { #code }
+            },
+            CStep::ClassifySubpolicy {
+                expr,
+                classified,
+                combinator_variants,
+            } => {
+                let reject_pat = if combinator_variants.is_empty() {
+                    quote!(TapleafClassRef::Other(..))
+                } else {
+                    quote!(TapleafClassRef::Other(..) #(| TapleafClassRef::#combinator_variants { .. })*)
+                };
+                quote! {
+                    let #classified = classify_as_tapleaf_ref(#expr);
+                    if !matches!(#classified, #reject_pat) { #code }
+                }
+            }
+        };
+    }
+    code
+}
+
+fn build_cursor_innermost(
+    l: &CLowered,
+    fields: &ClassFields,
+    ck: ClassKind,
+    variant: &Ident,
+    label: &TokenStream,
+) -> TokenStream {
+    let class = ck.class_ref();
+    if fields.order.is_empty() {
+        quote!(break #label #class::#variant;)
+    } else {
+        let assigns = fields.order.iter().map(|fname| {
+            let bound = l.bindings.get(fname).expect("binding present");
+            let f = id(fname);
+            quote!(#f: #bound)
+        });
+        quote!(break #label #class::#variant { #(#assigns),* };)
+    }
+}
+
+fn emit_ref_class_enum(ck: ClassKind, entries: &[ProcessedEntry]) -> TokenStream {
+    let ident = ck.class_ref();
+    let variants: Vec<TokenStream> = entries
+        .iter()
+        .map(|e| {
+            let v = id(&e.name);
+            if e.fields.order.is_empty() {
+                quote!(#v)
+            } else {
+                let fields = e.fields.order.iter().map(|fname| {
+                    let f = id(fname);
+                    let ty = rust_type_ref(e.fields.kinds[fname]);
+                    quote!(#f: #ty)
+                });
+                quote!(#v { #(#fields),* })
+            }
+        })
+        .collect();
+    let other = if ck.other_has_string {
+        quote!(Other(Cursor<'a, A>))
+    } else {
+        quote!(Other)
+    };
+    quote! {
+        #[allow(dead_code)]
+        pub(super) enum #ident<'a, A: ArenaRead> {
+            #(#variants,)*
+            #other,
+        }
+    }
+}
+
+fn emit_ref_classify(entries: &[ProcessedEntry], ck: ClassKind, fn_name: &str) -> TokenStream {
+    let fn_id = id(fn_name);
+    let class = ck.class_ref();
+    let label: TokenStream = format!("'{fn_name}").parse().unwrap();
+    let other = ck.other_ctor_ref();
+
+    let combinator_variants: Vec<Ident> = entries
+        .iter()
+        .filter(|e| {
+            e.fields
+                .kinds
+                .values()
+                .any(|k| *k == BindingKind::Subpolicy)
+        })
+        .map(|e| id(&e.name))
+        .collect();
+
+    let blocks: Vec<TokenStream> = entries
+        .iter()
+        .flat_map(|entry| {
+            entry.patterns.iter().map(|pat| {
+                let l = lower_pattern_cursor(pat, &combinator_variants);
+                let variant = id(&entry.name);
+                let inner = build_cursor_innermost(&l, &entry.fields, ck, &variant, &label);
+                fold_cursor_steps(&l.steps, inner)
+            })
+        })
+        .collect();
+
+    quote! {
+        #[allow(dead_code)]
+        fn #fn_id<'a, A: ArenaRead>(__m: Cursor<'a, A>) -> #class<'a, A> {
+            #label: {
+                #(#blocks)*
+                #other
+            }
+        }
+    }
+}
+
+/// One score arm for the borrowed classes (mirrors `emit_score_arm`, but
+/// sub-policy fields are cursors re-classified via `classify_as_tapleaf_ref`).
+fn emit_ref_score_arm(entry: &ProcessedEntry, ck: ClassKind) -> TokenStream {
+    let class = ck.class_ref();
+    let variant = id(&entry.name);
+
+    let subpolicy_names: Vec<&str> = entry
+        .fields
+        .order
+        .iter()
+        .filter(|n| entry.fields.kinds[*n] == BindingKind::Subpolicy)
+        .map(String::as_str)
+        .collect();
+
+    if !subpolicy_names.is_empty() {
+        let sub_idents: Vec<Ident> = subpolicy_names.iter().map(|n| id(n)).collect();
+        let destructure = quote!({ #(#sub_idents),*, .. });
+        let product = sub_idents.iter().fold(quote!(1u64), |acc, n| {
+            quote!(#acc.saturating_mul(classify_as_tapleaf_ref(*#n).per_leaf_score()))
+        });
+        return quote!(#class::#variant #destructure => #product,);
+    }
+
+    let plain: u64 = entry
+        .patterns
+        .iter()
+        .filter(|p| !pattern_uses_musig(p))
+        .count() as u64;
+    let musig: u64 = entry
+        .patterns
+        .iter()
+        .filter(|p| pattern_uses_musig(p))
+        .count() as u64;
+
+    let destructure: TokenStream = if entry.fields.order.is_empty() {
+        quote!()
+    } else if musig > 0 {
+        quote!({ threshold, keys, .. })
+    } else {
+        quote!({ .. })
+    };
+
+    let body: TokenStream = if musig == 0 {
+        quote!(#plain)
+    } else if musig == 1 {
+        quote!(#plain + if *threshold as usize == keys.len() { 1 } else { 0 })
+    } else {
+        quote!(#plain + if *threshold as usize == keys.len() { #musig } else { 0 })
+    };
+
+    quote!(#class::#variant #destructure => #body,)
+}
+
+fn emit_ref_outer_score(top_level: &[ProcessedEntry]) -> TokenStream {
+    let arms = top_level.iter().map(|e| emit_ref_score_arm(e, TOP_LEVEL));
+    quote! {
+        #[allow(dead_code)]
+        impl<'a, A: ArenaRead> DescriptorClassRef<'a, A> {
+            fn outer_score(&self) -> u64 {
+                match self {
+                    #(#arms)*
+                    DescriptorClassRef::Other => 1,
+                }
+            }
+        }
+    }
+}
+
+fn emit_ref_tapleaf_score(tapleaf: &[ProcessedEntry]) -> TokenStream {
+    let arms = tapleaf.iter().map(|e| emit_ref_score_arm(e, TAPLEAF));
+    quote! {
+        #[allow(dead_code)]
+        impl<'a, A: ArenaRead> TapleafClassRef<'a, A> {
+            fn per_leaf_score(&self) -> u64 {
+                match self {
+                    #(#arms)*
+                    TapleafClassRef::Other(..) => 1,
+                }
+            }
+        }
+    }
+}
+
+/// Assemble the cursor-based classifier code (borrowed classes + classify +
+/// scores). Added to the always-compiled generated file.
+fn emit_cursor_classifier(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntry]) -> TokenStream {
+    let class_top = emit_ref_class_enum(TOP_LEVEL, top_level);
+    let class_tap = emit_ref_class_enum(TAPLEAF, tapleaf);
+    let classify_top = emit_ref_classify(top_level, TOP_LEVEL, "classify_ref");
+    let classify_tap = emit_ref_classify(tapleaf, TAPLEAF, "classify_as_tapleaf_ref");
+    let outer = emit_ref_outer_score(top_level);
+    let per_leaf = emit_ref_tapleaf_score(tapleaf);
+    quote! {
+        #class_top
+        #class_tap
+        #classify_top
+        #classify_tap
+        #outer
+        #per_leaf
+    }
+}
+
+// ---------------------------------------------------------------------------
 // from_cleartext_pattern (reverse: (PatternKind, Vec<CleartextValue>) -> class)
 // ---------------------------------------------------------------------------
 
@@ -2076,6 +2562,7 @@ fn emit_common(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntry]) -> Stri
     let cleartext_tap = emit_cleartext_pattern(tapleaf, TAPLEAF);
     let tap_helpers = emit_tapleaf_helpers(tapleaf);
     let outer = emit_outer_score(top_level);
+    let cursor_classifier = emit_cursor_classifier(top_level, tapleaf);
 
     pretty_file(quote! {
         #pat_kind_top
@@ -2094,6 +2581,8 @@ fn emit_common(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntry]) -> Stri
         #cleartext_tap
         #tap_helpers
         #outer
+
+        #cursor_classifier
     })
 }
 

--- a/apps/bitcoin/bip388/build.rs
+++ b/apps/bitcoin/bip388/build.rs
@@ -2008,8 +2008,136 @@ fn emit_ref_tapleaf_score(tapleaf: &[ProcessedEntry]) -> TokenStream {
     }
 }
 
+/// `TapleafClassRef::order()` — the leaf's spec-table index, for canonical
+/// display ordering (mirrors the owned `TapleafClass::order`).
+fn emit_ref_tapleaf_order(tapleaf: &[ProcessedEntry]) -> TokenStream {
+    let order_arms = tapleaf.iter().enumerate().map(|(i, e)| {
+        let v = id(&e.name);
+        let pat: TokenStream = if e.fields.order.is_empty() {
+            quote!()
+        } else {
+            quote!({ .. })
+        };
+        let idx = i as u32;
+        quote!(TapleafClassRef::#v #pat => #idx)
+    });
+    let last = tapleaf.len() as u32;
+    quote! {
+        #[allow(dead_code)]
+        impl<'a, A: ArenaRead> TapleafClassRef<'a, A> {
+            fn order(&self) -> u32 {
+                match self {
+                    #(#order_arms,)*
+                    TapleafClassRef::Other(..) => #last,
+                }
+            }
+        }
+    }
+}
+
+/// Emit the unrolled write sequence for one cleartext token list.
+fn emit_render_tokens(tokens: &[CleartextToken]) -> TokenStream {
+    let stmts = tokens.iter().map(|t| match t {
+        CleartextToken::Literal(s) => quote!(sink.write_str(#s)?;),
+        CleartextToken::Field { name, kind } => {
+            let n = id(name);
+            match kind {
+                BindingKind::Threshold => quote!(write!(sink, "{}", #n)?;),
+                BindingKind::Key => quote!(format_key_to(sink, *#n, canonical)?;),
+                BindingKind::KeyList => quote!(format_key_indices_to(sink, *#n, canonical)?;),
+                BindingKind::Timelock => quote!(format_timelock_to(sink, *#n)?;),
+                BindingKind::Subpolicy => {
+                    quote!(classify_as_tapleaf_ref(*#n).cleartext_render(sink, canonical)?;)
+                }
+                // Structural; never rendered (recursed into instead).
+                BindingKind::Leaves => quote!(),
+            }
+        }
+    });
+    quote!(#(#stmts)*)
+}
+
+/// Streaming cleartext renderer for a borrowed class: writes directly into a
+/// `core::fmt::Write` sink (no `Vec<CleartextValue>`), unrolled per variant.
+fn emit_cleartext_render_ref(entries: &[ProcessedEntry], ck: ClassKind) -> TokenStream {
+    let class = ck.class_ref();
+    let other_arm = if ck.other_has_string {
+        quote!(#class::Other(_) => {})
+    } else {
+        quote!(#class::Other => {})
+    };
+
+    let arms: Vec<TokenStream> = entries
+        .iter()
+        .map(|e| {
+            let variant = id(&e.name);
+            match &e.cleartext_all {
+                None => {
+                    let referenced: Vec<Ident> = e
+                        .cleartext
+                        .iter()
+                        .filter_map(|t| match t {
+                            CleartextToken::Field { name, .. } => Some(id(name)),
+                            _ => None,
+                        })
+                        .collect();
+                    let destructure: TokenStream =
+                        match (e.fields.order.is_empty(), referenced.is_empty()) {
+                            (true, _) => quote!(),
+                            (false, true) => quote!({ .. }),
+                            (false, false) => quote!({ #(#referenced),*, .. }),
+                        };
+                    let body = emit_render_tokens(&e.cleartext);
+                    quote! {
+                        #class::#variant #destructure => { #body }
+                    }
+                }
+                Some(all_tokens) => {
+                    let thr = id(&field_of_kind(&e.fields, BindingKind::Threshold)
+                        .expect("cleartext_all requires a Threshold field"));
+                    let keys = id(&field_of_kind(&e.fields, BindingKind::KeyList)
+                        .expect("cleartext_all requires a KeyList field"));
+                    let mut names: BTreeMap<String, ()> = BTreeMap::new();
+                    for t in e.cleartext.iter().chain(all_tokens.iter()) {
+                        if let CleartextToken::Field { name, .. } = t {
+                            names.insert(name.clone(), ());
+                        }
+                    }
+                    names.insert(thr.to_string(), ());
+                    names.insert(keys.to_string(), ());
+                    let bound: Vec<Ident> = names.keys().map(|n| id(n)).collect();
+                    let any_body = emit_render_tokens(&e.cleartext);
+                    let all_body = emit_render_tokens(all_tokens);
+                    quote! {
+                        #class::#variant { #(#bound),*, .. } => {
+                            if *#thr as usize == #keys.len() { #all_body } else { #any_body }
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        #[allow(dead_code)]
+        impl<'a, A: ArenaRead> #class<'a, A> {
+            fn cleartext_render(
+                &self,
+                sink: &mut dyn core::fmt::Write,
+                canonical: bool,
+            ) -> core::fmt::Result {
+                match self {
+                    #(#arms,)*
+                    #other_arm,
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 /// Assemble the cursor-based classifier code (borrowed classes + classify +
-/// scores). Added to the always-compiled generated file.
+/// scores + streaming renderer). Added to the always-compiled generated file.
 fn emit_cursor_classifier(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntry]) -> TokenStream {
     let class_top = emit_ref_class_enum(TOP_LEVEL, top_level);
     let class_tap = emit_ref_class_enum(TAPLEAF, tapleaf);
@@ -2017,6 +2145,9 @@ fn emit_cursor_classifier(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntr
     let classify_tap = emit_ref_classify(tapleaf, TAPLEAF, "classify_as_tapleaf_ref");
     let outer = emit_ref_outer_score(top_level);
     let per_leaf = emit_ref_tapleaf_score(tapleaf);
+    let order = emit_ref_tapleaf_order(tapleaf);
+    let render_top = emit_cleartext_render_ref(top_level, TOP_LEVEL);
+    let render_tap = emit_cleartext_render_ref(tapleaf, TAPLEAF);
     quote! {
         #class_top
         #class_tap
@@ -2024,6 +2155,9 @@ fn emit_cursor_classifier(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntr
         #classify_tap
         #outer
         #per_leaf
+        #order
+        #render_top
+        #render_tap
     }
 }
 

--- a/apps/bitcoin/bip388/build.rs
+++ b/apps/bitcoin/bip388/build.rs
@@ -2699,22 +2699,25 @@ fn emit_common(top_level: &[ProcessedEntry], tapleaf: &[ProcessedEntry]) -> Stri
     let cursor_classifier = emit_cursor_classifier(top_level, tapleaf);
 
     pretty_file(quote! {
-        #pat_kind_top
-        #pat_kind_tap
-        #class_top
-        #class_tap
-        #specs_top
-        #specs_tap
+        // Owned classes + classify + specs + scores are needed only by the
+        // alloc/decode paths; the cursor classifier below is always built.
+        #[cfg(feature = "alloc")] #pat_kind_top
+        #[cfg(feature = "alloc")] #pat_kind_tap
+        #[cfg(feature = "alloc")] #class_top
+        #[cfg(feature = "alloc")] #class_tap
+        #[cfg(feature = "alloc")] #specs_top
+        #[cfg(feature = "alloc")] #specs_tap
 
+        #[cfg(feature = "alloc")]
         impl DescriptorTemplate {
             #classify_top
             #classify_tap
         }
 
-        #cleartext_top
-        #cleartext_tap
-        #tap_helpers
-        #outer
+        #[cfg(feature = "alloc")] #cleartext_top
+        #[cfg(feature = "alloc")] #cleartext_tap
+        #[cfg(feature = "alloc")] #tap_helpers
+        #[cfg(feature = "alloc")] #outer
 
         #cursor_classifier
     })

--- a/apps/bitcoin/bip388/build.rs
+++ b/apps/bitcoin/bip388/build.rs
@@ -1942,9 +1942,10 @@ fn emit_ref_score_arm(entry: &ProcessedEntry, ck: ClassKind) -> TokenStream {
     if !subpolicy_names.is_empty() {
         let sub_idents: Vec<Ident> = subpolicy_names.iter().map(|n| id(n)).collect();
         let destructure = quote!({ #(#sub_idents),*, .. });
-        let product = sub_idents.iter().fold(quote!(1u64), |acc, n| {
-            quote!(#acc.saturating_mul(classify_as_tapleaf_ref(*#n).per_leaf_score()))
-        });
+        let product = sub_idents.iter().fold(
+            quote!(1u64),
+            |acc, n| quote!(#acc.saturating_mul(classify_as_tapleaf_ref(*#n).per_leaf_score())),
+        );
         return quote!(#class::#variant #destructure => #product,);
     }
 

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -805,6 +805,84 @@ impl<'a, A: ArenaRead> Iterator for KeyListIter<'a, A> {
     }
 }
 
+/// The `keys` field of a classified `Multisig`/`TaprootMusig` class. It is
+/// either an explicit `multi*`/`sortedmulti*` key list, or a single musig key
+/// expanded into one synthetic plain key per member (mirroring how the owned
+/// classifier expands `tr(musig($keys))` into `Multisig { keys: Vec<…> }`).
+pub enum ClassKeyList<'a, A: ArenaRead> {
+    Explicit(KeyListView<'a, A>),
+    /// A musig key; yields one synthetic plain key per member, carrying the
+    /// musig's shared `num1`/`num2`.
+    MusigExpanded(KeyView<'a, A>),
+}
+
+impl<'a, A: ArenaRead> Clone for ClassKeyList<'a, A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, A: ArenaRead> Copy for ClassKeyList<'a, A> {}
+
+impl<'a, A: ArenaRead> ClassKeyList<'a, A> {
+    pub fn len(&self) -> usize {
+        match self {
+            ClassKeyList::Explicit(l) => l.len(),
+            ClassKeyList::MusigExpanded(kv) => {
+                kv.musig_key_indices().map(|m| m.len()).unwrap_or(0)
+            }
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn iter(&self) -> ClassKeyIter<'a, A> {
+        match self {
+            ClassKeyList::Explicit(l) => ClassKeyIter::Explicit(l.iter()),
+            ClassKeyList::MusigExpanded(kv) => ClassKeyIter::Musig {
+                arena: kv.arena,
+                members: kv.musig_key_indices().unwrap_or(&[]),
+                pos: 0,
+                num1: kv.num1(),
+                num2: kv.num2(),
+            },
+        }
+    }
+}
+
+pub enum ClassKeyIter<'a, A: ArenaRead> {
+    Explicit(KeyListIter<'a, A>),
+    Musig {
+        arena: &'a A,
+        members: &'a [u32],
+        pos: usize,
+        num1: u32,
+        num2: u32,
+    },
+}
+
+impl<'a, A: ArenaRead> Iterator for ClassKeyIter<'a, A> {
+    type Item = KeyView<'a, A>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ClassKeyIter::Explicit(it) => it.next(),
+            ClassKeyIter::Musig {
+                arena,
+                members,
+                pos,
+                num1,
+                num2,
+            } => {
+                let &idx = members.get(*pos)?;
+                *pos += 1;
+                Some(KeyView {
+                    arena,
+                    rec: KeyExprRec::plain(idx, *num1, *num2),
+                })
+            }
+        }
+    }
+}
+
 /// A borrowed list of sub-script nodes (for `thresh`).
 pub struct NodeList<'a, A: ArenaRead> {
     arena: &'a A,
@@ -1329,6 +1407,47 @@ mod tests {
             }
             _ => panic!("expected Pk(musig)"),
         }
+    }
+
+    #[test]
+    fn class_key_list_explicit_and_musig_expanded() {
+        let mut a = VecArena::new();
+
+        // Explicit list: multi(_, @5, @6)
+        let mut list = ListBuilder::new();
+        for i in [5u32, 6] {
+            let k = a.push_key(KeyExprRec::plain(i, 0, 1)).unwrap();
+            list.push(&mut a, k.0).unwrap();
+        }
+        let explicit = KeyListView {
+            arena: &a,
+            head: list.head(),
+            count: list.count(),
+        };
+        let ckl = ClassKeyList::Explicit(explicit);
+        assert_eq!(ckl.len(), 2);
+        let got: alloc::vec::Vec<(u32, u32, u32)> = ckl
+            .iter()
+            .map(|kv| (kv.plain_key_index().unwrap(), kv.num1(), kv.num2()))
+            .collect();
+        assert_eq!(got, alloc::vec![(5, 0, 1), (6, 0, 1)]);
+
+        // Musig expanded: musig(@1,@2,@3)/<4;5> -> three synthetic plain keys
+        // carrying the shared (4,5) derivation.
+        let start = a.members_begin();
+        for m in [1u32, 2, 3] {
+            a.members_push(m).unwrap();
+        }
+        let span = a.members_end(start);
+        let mk = a.push_key(KeyExprRec::musig(span, 4, 5)).unwrap();
+        let kv = key_view(&a, mk);
+        let ckl = ClassKeyList::MusigExpanded(kv);
+        assert_eq!(ckl.len(), 3);
+        let got: alloc::vec::Vec<(u32, u32, u32)> = ckl
+            .iter()
+            .map(|kv| (kv.plain_key_index().unwrap(), kv.num1(), kv.num2()))
+            .collect();
+        assert_eq!(got, alloc::vec![(1, 4, 5), (2, 4, 5), (3, 4, 5)]);
     }
 
     // Build a tap tree `{leaf(@0), {leaf(@1), leaf(@2)}}` and check left-to-right leaf order.

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -135,7 +135,13 @@ impl Node {
         }
     }
     pub fn with_a(tag: NodeTag, a: u32) -> Node {
-        Node { tag, a, b: 0, c: 0, d: 0 }
+        Node {
+            tag,
+            a,
+            b: 0,
+            c: 0,
+            d: 0,
+        }
     }
 }
 
@@ -583,10 +589,22 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
             One => DescriptorNode::One,
             Older => DescriptorNode::Older(n.a),
             After => DescriptorNode::After(n.a),
-            Sha256 => DescriptorNode::Sha256(self.arena.bytes(Span { start: n.a, len: n.b })),
-            Hash256 => DescriptorNode::Hash256(self.arena.bytes(Span { start: n.a, len: n.b })),
-            Ripemd160 => DescriptorNode::Ripemd160(self.arena.bytes(Span { start: n.a, len: n.b })),
-            Hash160 => DescriptorNode::Hash160(self.arena.bytes(Span { start: n.a, len: n.b })),
+            Sha256 => DescriptorNode::Sha256(self.arena.bytes(Span {
+                start: n.a,
+                len: n.b,
+            })),
+            Hash256 => DescriptorNode::Hash256(self.arena.bytes(Span {
+                start: n.a,
+                len: n.b,
+            })),
+            Ripemd160 => DescriptorNode::Ripemd160(self.arena.bytes(Span {
+                start: n.a,
+                len: n.b,
+            })),
+            Hash160 => DescriptorNode::Hash160(self.arena.bytes(Span {
+                start: n.a,
+                len: n.b,
+            })),
             Andor => DescriptorNode::Andor(self.child(n.a), self.child(n.b), self.child(n.c)),
             AndV => DescriptorNode::AndV(self.child(n.a), self.child(n.b)),
             AndB => DescriptorNode::AndB(self.child(n.a), self.child(n.b)),
@@ -952,9 +970,7 @@ impl<'a, A: ArenaRead> ClassKeyList<'a, A> {
     pub fn len(&self) -> usize {
         match self {
             ClassKeyList::Explicit(l) => l.len(),
-            ClassKeyList::MusigExpanded(kv) => {
-                kv.musig_key_indices().map(|m| m.len()).unwrap_or(0)
-            }
+            ClassKeyList::MusigExpanded(kv) => kv.musig_key_indices().map(|m| m.len()).unwrap_or(0),
         }
     }
     pub fn is_empty(&self) -> bool {
@@ -1449,8 +1465,18 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
                     }
                 }
             }
-            DN::Sh(c) | DN::Wsh(c) | DN::A(c) | DN::S(c) | DN::C(c) | DN::T(c) | DN::D(c)
-            | DN::V(c) | DN::J(c) | DN::N(c) | DN::L(c) | DN::U(c) => c.visit_placeholders(leaf, f),
+            DN::Sh(c)
+            | DN::Wsh(c)
+            | DN::A(c)
+            | DN::S(c)
+            | DN::C(c)
+            | DN::T(c)
+            | DN::D(c)
+            | DN::V(c)
+            | DN::J(c)
+            | DN::N(c)
+            | DN::L(c)
+            | DN::U(c) => c.visit_placeholders(leaf, f),
             DN::Andor(x, y, z) => {
                 x.visit_placeholders(leaf, f);
                 y.visit_placeholders(leaf, f);
@@ -1492,9 +1518,9 @@ fn cmp_key_value<A: ArenaRead>(arena: &A, a: &KeyExprRec, b: &KeyExprRec) -> Ord
         (KeyKind::Plain, KeyKind::Plain) => a.plain_index.cmp(&b.plain_index),
         (KeyKind::Plain, KeyKind::Musig) => Ordering::Less,
         (KeyKind::Musig, KeyKind::Plain) => Ordering::Greater,
-        (KeyKind::Musig, KeyKind::Musig) => {
-            arena.members(a.musig_members).cmp(arena.members(b.musig_members))
-        }
+        (KeyKind::Musig, KeyKind::Musig) => arena
+            .members(a.musig_members)
+            .cmp(arena.members(b.musig_members)),
     }
 }
 
@@ -1661,8 +1687,18 @@ mod placeholder_iter {
 
                 let (frag, leaf) = self.fragments.pop()?;
                 match frag.view() {
-                    DN::Sh(c) | DN::Wsh(c) | DN::A(c) | DN::S(c) | DN::C(c) | DN::T(c)
-                    | DN::D(c) | DN::V(c) | DN::J(c) | DN::N(c) | DN::L(c) | DN::U(c) => {
+                    DN::Sh(c)
+                    | DN::Wsh(c)
+                    | DN::A(c)
+                    | DN::S(c)
+                    | DN::C(c)
+                    | DN::T(c)
+                    | DN::D(c)
+                    | DN::V(c)
+                    | DN::J(c)
+                    | DN::N(c)
+                    | DN::L(c)
+                    | DN::U(c) => {
                         self.fragments.push((c, leaf));
                     }
                     DN::Andor(x, y, z) => {
@@ -1778,8 +1814,10 @@ mod tests {
             DescriptorNode::Multi(k, keys) => {
                 assert_eq!(k, 2);
                 assert_eq!(keys.len(), 3);
-                let indices: alloc::vec::Vec<u32> =
-                    keys.iter().map(|kv| kv.plain_key_index().unwrap()).collect();
+                let indices: alloc::vec::Vec<u32> = keys
+                    .iter()
+                    .map(|kv| kv.plain_key_index().unwrap())
+                    .collect();
                 assert_eq!(indices, alloc::vec![0, 1, 2]);
             }
             _ => panic!("expected Multi"),
@@ -1855,7 +1893,8 @@ mod tests {
         let mk_leaf = |a: &mut VecArena, idx: u32| {
             let k = a.push_key(KeyExprRec::plain(idx, 0, 1)).unwrap();
             let script = a.push_node(Node::with_a(NodeTag::Pk, k.0)).unwrap();
-            a.push_node(Node::with_a(NodeTag::TapLeaf, script.0)).unwrap()
+            a.push_node(Node::with_a(NodeTag::TapLeaf, script.0))
+                .unwrap()
         };
         let l0 = mk_leaf(&mut a, 0);
         let l1 = mk_leaf(&mut a, 1);
@@ -1887,6 +1926,9 @@ mod tests {
         sink.flush_line();
         write!(sink, "second").unwrap();
         let lines = sink.into_lines();
-        assert_eq!(lines, alloc::vec!["first 1".to_string(), "second".to_string()]);
+        assert_eq!(
+            lines,
+            alloc::vec!["first 1".to_string(), "second".to_string()]
+        );
     }
 }

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -284,10 +284,10 @@ impl Default for ListBuilder {
 // VecArena (alloc-backed)
 // ---------------------------------------------------------------------------
 
-// The default build currently always has `alloc`; the explicit `alloc` feature
-// gate (and the no-alloc `SliceArena`) are introduced in later phases.
+#[cfg(feature = "alloc")]
 pub use vec_arena::VecArena;
 
+#[cfg(feature = "alloc")]
 mod vec_arena {
     use super::*;
     use alloc::vec::Vec;
@@ -1103,8 +1103,48 @@ impl<'w> fmt::Write for CapWrite<'w> {
     }
 }
 
+/// A `fmt::Write` sink that captures up to `N` bytes into a fixed stack buffer
+/// (excess is dropped). Used for the allocation-free lexicographic comparison of
+/// two rendered "raw policy" tap leaves (a rare case), avoiding a heap `String`.
+pub struct FixedBuf<const N: usize> {
+    buf: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> FixedBuf<N> {
+    pub fn new() -> Self {
+        FixedBuf {
+            buf: [0u8; N],
+            len: 0,
+        }
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+}
+
+impl<const N: usize> Default for FixedBuf<N> {
+    fn default() -> Self {
+        FixedBuf::new()
+    }
+}
+
+impl<const N: usize> fmt::Write for FixedBuf<N> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for &b in s.as_bytes() {
+            if self.len < N {
+                self.buf[self.len] = b;
+                self.len += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
 pub use vec_sink::VecLineSink;
 
+#[cfg(feature = "alloc")]
 mod vec_sink {
     use super::*;
     use alloc::string::String;

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -1337,7 +1337,7 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
         }
         let arena = self.arena;
         let s = &mut scratch[..n];
-        s.sort_by(|a, b| {
+        s.sort_unstable_by(|a, b| {
             cmp_key_value(arena, a, b)
                 .then(a.num1.cmp(&b.num1))
                 .then(a.num2.cmp(&b.num2))

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -20,6 +20,7 @@
 //! the migration phases; until then several items are intentionally unused.
 #![allow(dead_code, unused_imports)]
 
+use core::cmp::Ordering;
 use core::fmt;
 
 /// Sentinel for "no node" / "no link" in a `u32` reference.
@@ -726,6 +727,10 @@ impl<'a, A: ArenaRead> Clone for KeyView<'a, A> {
 impl<'a, A: ArenaRead> Copy for KeyView<'a, A> {}
 
 impl<'a, A: ArenaRead> KeyView<'a, A> {
+    /// The underlying record (used by confusion-score grouping).
+    pub fn record(&self) -> KeyExprRec {
+        self.rec
+    }
     pub fn num1(&self) -> u32 {
         self.rec.num1
     }
@@ -1124,6 +1129,133 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
             | DN::Hash160(_)
             | DN::TapNode(_) => {}
         }
+    }
+}
+
+/// Total order over key *values* (derivation indices ignored), so equal key
+/// expressions sort adjacently — matches the `KeyExpressionType` equality the
+/// owned canonical check groups by.
+fn cmp_key_value<A: ArenaRead>(arena: &A, a: &KeyExprRec, b: &KeyExprRec) -> Ordering {
+    match (a.kind, b.kind) {
+        (KeyKind::Plain, KeyKind::Plain) => a.plain_index.cmp(&b.plain_index),
+        (KeyKind::Plain, KeyKind::Musig) => Ordering::Less,
+        (KeyKind::Musig, KeyKind::Plain) => Ordering::Greater,
+        (KeyKind::Musig, KeyKind::Musig) => {
+            arena.members(a.musig_members).cmp(arena.members(b.musig_members))
+        }
+    }
+}
+
+impl<'a, A: ArenaRead> Cursor<'a, A> {
+    /// Number of key placeholders (sizing for the canonical-check scratch).
+    pub fn placeholder_count(&self) -> usize {
+        let mut n = 0usize;
+        self.for_each_placeholder(&mut |_, _| n += 1);
+        n
+    }
+
+    /// Number of musig-expanded key-index occurrences (sizing for the
+    /// orderings-count scratch).
+    pub fn expanded_key_occurrences(&self) -> usize {
+        let mut n = 0usize;
+        self.for_each_placeholder(&mut |kv, _| {
+            n += kv.musig_key_indices().map(|m| m.len()).unwrap_or(1);
+        });
+        n
+    }
+
+    /// Whether each distinct key expression's occurrences carry the canonical
+    /// derivation pairs `(0,1),(2,3),…` (in some order). Mirrors the owned
+    /// `are_key_derivations_canonical`. `scratch` must hold at least
+    /// `placeholder_count()` records; if too small, returns `false`
+    /// (conservatively falling back to the raw descriptor).
+    pub fn are_key_derivations_canonical(&self, scratch: &mut [KeyExprRec]) -> bool {
+        let mut n = 0usize;
+        let mut overflow = false;
+        self.for_each_placeholder(&mut |kv, _| {
+            if n < scratch.len() {
+                scratch[n] = kv.record();
+            } else {
+                overflow = true;
+            }
+            n += 1;
+        });
+        if overflow {
+            return false;
+        }
+        let arena = self.arena;
+        let s = &mut scratch[..n];
+        s.sort_by(|a, b| {
+            cmp_key_value(arena, a, b)
+                .then(a.num1.cmp(&b.num1))
+                .then(a.num2.cmp(&b.num2))
+        });
+        let mut i = 0;
+        while i < s.len() {
+            let mut j = i + 1;
+            while j < s.len() && cmp_key_value(arena, &s[i], &s[j]) == Ordering::Equal {
+                j += 1;
+            }
+            for (idx, e) in s[i..j].iter().enumerate() {
+                if (e.num1, e.num2) != (2 * idx as u32, 2 * idx as u32 + 1) {
+                    return false;
+                }
+            }
+            i = j;
+        }
+        true
+    }
+
+    /// Upper bound on the number of canonical derivation-pair orderings across
+    /// repeated keys: the product, over each key *index* (musig groups
+    /// expanded), of `occurrences!`. Mirrors the owned
+    /// `key_derivation_orderings_count`. `scratch` must hold at least
+    /// `expanded_key_occurrences()` entries; if too small, returns `u64::MAX`
+    /// (a safe over-count that only ever hides cleartext, never shows it).
+    pub fn key_derivation_orderings_count(&self, scratch: &mut [u32]) -> u64 {
+        let mut n = 0usize;
+        let mut overflow = false;
+        self.for_each_placeholder(&mut |kv, _| match kv.musig_key_indices() {
+            Some(members) => {
+                for &m in members {
+                    if n < scratch.len() {
+                        scratch[n] = m;
+                    } else {
+                        overflow = true;
+                    }
+                    n += 1;
+                }
+            }
+            None => {
+                let i = kv.plain_key_index().expect("plain or musig key");
+                if n < scratch.len() {
+                    scratch[n] = i;
+                } else {
+                    overflow = true;
+                }
+                n += 1;
+            }
+        });
+        if overflow {
+            return u64::MAX;
+        }
+        let s = &mut scratch[..n];
+        s.sort_unstable();
+        let mut product = 1u64;
+        let mut i = 0;
+        while i < s.len() {
+            let mut j = i + 1;
+            while j < s.len() && s[j] == s[i] {
+                j += 1;
+            }
+            let mut f = 1u64;
+            for k in 1..=(j - i) as u64 {
+                f = f.saturating_mul(k);
+            }
+            product = product.saturating_mul(f);
+            i = j;
+        }
+        product
     }
 }
 

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -1069,6 +1069,40 @@ pub trait LineSink: fmt::Write {
     fn flush_line(&mut self);
 }
 
+/// A `fmt::Write` adapter that upper-cases the first ASCII-lowercase character
+/// written through it, then passes everything else through unchanged. Used to
+/// capitalize the first letter of each standalone cleartext line (composed
+/// sub-policies, written after the first character, stay lowercase) — the
+/// streaming equivalent of the owned `capitalize_first`.
+pub struct CapWrite<'w> {
+    inner: &'w mut dyn fmt::Write,
+    done: bool,
+}
+
+impl<'w> CapWrite<'w> {
+    pub fn new(inner: &'w mut dyn fmt::Write) -> Self {
+        CapWrite { inner, done: false }
+    }
+}
+
+impl<'w> fmt::Write for CapWrite<'w> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if self.done || s.is_empty() {
+            return self.inner.write_str(s);
+        }
+        let first = s.chars().next().expect("non-empty");
+        self.done = true;
+        if first.is_ascii_lowercase() {
+            let mut buf = [0u8; 4];
+            self.inner
+                .write_str(first.to_ascii_uppercase().encode_utf8(&mut buf))?;
+            self.inner.write_str(&s[first.len_utf8()..])
+        } else {
+            self.inner.write_str(s)
+        }
+    }
+}
+
 pub use vec_sink::VecLineSink;
 
 mod vec_sink {

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -380,6 +380,131 @@ mod vec_arena {
 }
 
 // ---------------------------------------------------------------------------
+// SliceArena (no-alloc, caller-provided slices)
+// ---------------------------------------------------------------------------
+
+/// Arena backed by caller-provided slices (one per pool), with bump cursors.
+/// No allocation; `push_*` returns [`ArenaFull`] when a pool is exhausted. This
+/// is the backing used by the no-alloc / C build.
+pub struct SliceArena<'a> {
+    nodes: &'a mut [Node],
+    n_nodes: usize,
+    keys: &'a mut [KeyExprRec],
+    n_keys: usize,
+    links: &'a mut [Link],
+    n_links: usize,
+    members: &'a mut [u32],
+    n_members: usize,
+    bytes: &'a mut [u8],
+    n_bytes: usize,
+}
+
+impl<'a> SliceArena<'a> {
+    pub fn new(
+        nodes: &'a mut [Node],
+        keys: &'a mut [KeyExprRec],
+        links: &'a mut [Link],
+        members: &'a mut [u32],
+        bytes: &'a mut [u8],
+    ) -> Self {
+        SliceArena {
+            nodes,
+            n_nodes: 0,
+            keys,
+            n_keys: 0,
+            links,
+            n_links: 0,
+            members,
+            n_members: 0,
+            bytes,
+            n_bytes: 0,
+        }
+    }
+}
+
+impl<'a> ArenaRead for SliceArena<'a> {
+    fn node(&self, id: NodeId) -> Node {
+        self.nodes[id.0 as usize]
+    }
+    fn key(&self, id: KeyId) -> KeyExprRec {
+        self.keys[id.0 as usize]
+    }
+    fn link(&self, idx: u32) -> Link {
+        self.links[idx as usize]
+    }
+    fn members(&self, span: Span) -> &[u32] {
+        &self.members[span.start as usize..(span.start + span.len) as usize]
+    }
+    fn bytes(&self, span: Span) -> &[u8] {
+        &self.bytes[span.start as usize..(span.start + span.len) as usize]
+    }
+}
+
+impl<'a> ArenaStore for SliceArena<'a> {
+    fn push_node(&mut self, node: Node) -> Result<NodeId, ArenaFull> {
+        if self.n_nodes >= self.nodes.len() {
+            return Err(ArenaFull);
+        }
+        self.nodes[self.n_nodes] = node;
+        self.n_nodes += 1;
+        Ok(NodeId((self.n_nodes - 1) as u32))
+    }
+    fn push_key(&mut self, key: KeyExprRec) -> Result<KeyId, ArenaFull> {
+        if self.n_keys >= self.keys.len() {
+            return Err(ArenaFull);
+        }
+        self.keys[self.n_keys] = key;
+        self.n_keys += 1;
+        Ok(KeyId((self.n_keys - 1) as u32))
+    }
+    fn push_link(&mut self, link: Link) -> Result<u32, ArenaFull> {
+        if self.n_links >= self.links.len() {
+            return Err(ArenaFull);
+        }
+        self.links[self.n_links] = link;
+        self.n_links += 1;
+        Ok((self.n_links - 1) as u32)
+    }
+    fn set_link_next(&mut self, idx: u32, next: u32) {
+        self.links[idx as usize].next = next;
+    }
+    fn members_begin(&self) -> u32 {
+        self.n_members as u32
+    }
+    fn members_push(&mut self, value: u32) -> Result<(), ArenaFull> {
+        if self.n_members >= self.members.len() {
+            return Err(ArenaFull);
+        }
+        self.members[self.n_members] = value;
+        self.n_members += 1;
+        Ok(())
+    }
+    fn members_end(&self, start: u32) -> Span {
+        Span {
+            start,
+            len: self.n_members as u32 - start,
+        }
+    }
+    fn push_bytes(&mut self, bytes: &[u8]) -> Result<Span, ArenaFull> {
+        let start = self.n_bytes;
+        if start + bytes.len() > self.bytes.len() {
+            return Err(ArenaFull);
+        }
+        self.bytes[start..start + bytes.len()].copy_from_slice(bytes);
+        self.n_bytes += bytes.len();
+        Ok(Span {
+            start: start as u32,
+            len: bytes.len() as u32,
+        })
+    }
+    fn set_key_derivation(&mut self, id: KeyId, num1: u32, num2: u32) {
+        let k = &mut self.keys[id.0 as usize];
+        k.num1 = num1;
+        k.num2 = num2;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Cursors / views (backing-agnostic traversal)
 // ---------------------------------------------------------------------------
 
@@ -1067,6 +1192,77 @@ pub enum DescriptorNode<'a, A: ArenaRead> {
 pub trait LineSink: fmt::Write {
     /// Finish the current line and start a new one.
     fn flush_line(&mut self);
+}
+
+/// A `(offset, len)` slice of a cleartext line within a [`BufLineSink`]'s output
+/// buffer. The C layer turns `offset` into a pointer into the caller's buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct LineSpan {
+    pub offset: u32,
+    pub len: u32,
+}
+
+/// No-alloc [`LineSink`] writing line bytes into a caller `&mut [u8]` and
+/// recording each line's `(offset, len)` into a caller `&mut [LineSpan]`.
+/// `overflowed()` reports whether either buffer was exhausted. Used by the C
+/// build.
+pub struct BufLineSink<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+    line_start: usize,
+    lines: &'a mut [LineSpan],
+    n_lines: usize,
+    overflow: bool,
+}
+
+impl<'a> BufLineSink<'a> {
+    pub fn new(buf: &'a mut [u8], lines: &'a mut [LineSpan]) -> Self {
+        BufLineSink {
+            buf,
+            pos: 0,
+            line_start: 0,
+            lines,
+            n_lines: 0,
+            overflow: false,
+        }
+    }
+    /// Number of completed lines.
+    pub fn line_count(&self) -> usize {
+        self.n_lines
+    }
+    /// Whether the output buffer or the line array was exhausted.
+    pub fn overflowed(&self) -> bool {
+        self.overflow
+    }
+}
+
+impl<'a> fmt::Write for BufLineSink<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for &b in s.as_bytes() {
+            if self.pos < self.buf.len() {
+                self.buf[self.pos] = b;
+                self.pos += 1;
+            } else {
+                self.overflow = true;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> LineSink for BufLineSink<'a> {
+    fn flush_line(&mut self) {
+        if self.n_lines < self.lines.len() {
+            self.lines[self.n_lines] = LineSpan {
+                offset: self.line_start as u32,
+                len: (self.pos - self.line_start) as u32,
+            };
+            self.n_lines += 1;
+        } else {
+            self.overflow = true;
+        }
+        self.line_start = self.pos;
+    }
 }
 
 /// A `fmt::Write` adapter that upper-cases the first ASCII-lowercase character

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -293,7 +293,7 @@ mod vec_arena {
     use alloc::vec::Vec;
 
     /// Growable, `Vec`-backed arena. Allocation only fails on `u32` overflow.
-    #[derive(Clone, Debug, Default)]
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
     pub struct VecArena {
         nodes: Vec<Node>,
         keys: Vec<KeyExprRec>,

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -1,0 +1,924 @@
+//! Arena / index-based storage for BIP-388 descriptor templates.
+//!
+//! The descriptor AST is stored in a small set of flat, pointer-free pools and
+//! addressed by `u32` ids. This lets the *same* parser, classifier and renderer
+//! run against two backings:
+//!
+//! * [`VecArena`] — growable `Vec`-backed pools, used by the default `alloc`
+//!   build (behaves like the historical `Box`/`Vec` AST, but flat).
+//! * a future `SliceArena` — bump cursors over a caller-provided `&mut [u8]`,
+//!   used by the no-alloc / C build (no global allocator, no `Vec`/`Box`).
+//!
+//! All node records are fixed-size and `Copy`, and all cross-references are
+//! `u32` indices, so the layout is portable and there is no recursion through
+//! owned pointers.
+//!
+//! Computation is written once against borrowed [`Cursor`]s (see [`Cursor::view`]
+//! / [`DescriptorNode`]), so it is backing-agnostic.
+//!
+//! NOTE: this module is wired into the rest of the crate incrementally across
+//! the migration phases; until then several items are intentionally unused.
+#![allow(dead_code, unused_imports)]
+
+use core::fmt;
+
+/// Sentinel for "no node" / "no link" in a `u32` reference.
+pub const NONE: u32 = u32::MAX;
+
+/// Maximum tap-tree / traversal depth (mirrors `MAX_PARSE_DEPTH` in `lib.rs`).
+pub const MAX_TREE_DEPTH: usize = 64;
+
+/// Index into the arena's `nodes` pool (descriptor *and* tap-tree nodes).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub struct NodeId(pub u32);
+
+/// Index into the arena's `keys` pool.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub struct KeyId(pub u32);
+
+/// A contiguous `[start, start+len)` span into a typed pool.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Span {
+    pub start: u32,
+    pub len: u32,
+}
+
+impl Span {
+    pub const EMPTY: Span = Span { start: 0, len: 0 };
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+/// Discriminant for a [`Node`]. `repr(u8)` keeps the record compact and stable.
+///
+/// Covers every `DescriptorTemplate` variant plus the two tap-tree node kinds
+/// (`TapLeaf` / `TapBranch`), which share the `nodes` pool.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum NodeTag {
+    // top-level / script-context wrappers around a single child (a = child NodeId)
+    Sh,
+    Wsh,
+    // single-letter miniscript wrappers (a = child NodeId)
+    A,
+    S,
+    C,
+    T,
+    D,
+    V,
+    J,
+    N,
+    L,
+    U,
+    // key fragments (a = KeyId)
+    Pkh,
+    Wpkh,
+    Pk,
+    PkK,
+    PkH,
+    // taproot top level (a = KeyId, d = tap-tree root NodeId | NONE)
+    Tr,
+    // constants
+    Zero,
+    One,
+    // numeric locktimes (a = value)
+    Older,
+    After,
+    // hash fragments ((a,b) = bytes Span; len 32)
+    Sha256,
+    Hash256,
+    // hash fragments ((a,b) = bytes Span; len 20)
+    Ripemd160,
+    Hash160,
+    // combinators (a,b,c = child NodeIds)
+    Andor,
+    AndV,
+    AndB,
+    AndN,
+    OrB,
+    OrC,
+    OrD,
+    OrI,
+    // threshold over sub-scripts (a = k, b = head link, c = child count)
+    Thresh,
+    // multisig over keys (a = k, b = head link, c = key count)
+    Multi,
+    MultiA,
+    Sortedmulti,
+    SortedmultiA,
+    // tap-tree nodes
+    TapLeaf,   // a = script NodeId
+    TapBranch, // a = left NodeId, b = right NodeId
+}
+
+/// A fixed-size, `Copy` descriptor or tap-tree node. Fields `a..d` are
+/// interpreted per [`NodeTag`] (see the tag docs above).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Node {
+    pub tag: NodeTag,
+    pub a: u32,
+    pub b: u32,
+    pub c: u32,
+    pub d: u32,
+}
+
+impl Node {
+    pub fn new(tag: NodeTag) -> Node {
+        Node {
+            tag,
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+        }
+    }
+    pub fn with_a(tag: NodeTag, a: u32) -> Node {
+        Node { tag, a, b: 0, c: 0, d: 0 }
+    }
+}
+
+/// Plain vs. musig key expression.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum KeyKind {
+    Plain = 0,
+    Musig = 1,
+}
+
+/// A `Copy`, pointer-free key expression. For a plain key, `plain_index` is the
+/// key-information index and `musig_members` is empty; for a musig key,
+/// `musig_members` is a span of member indices in the `members` pool.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct KeyExprRec {
+    pub num1: u32,
+    pub num2: u32,
+    pub kind: KeyKind,
+    pub plain_index: u32,
+    pub musig_members: Span,
+}
+
+impl KeyExprRec {
+    pub fn plain(plain_index: u32, num1: u32, num2: u32) -> KeyExprRec {
+        KeyExprRec {
+            num1,
+            num2,
+            kind: KeyKind::Plain,
+            plain_index,
+            musig_members: Span::EMPTY,
+        }
+    }
+    pub fn musig(musig_members: Span, num1: u32, num2: u32) -> KeyExprRec {
+        KeyExprRec {
+            num1,
+            num2,
+            kind: KeyKind::Musig,
+            plain_index: 0,
+            musig_members,
+        }
+    }
+}
+
+/// A cons cell for the singly-linked lists used by `Thresh` (NodeIds) and
+/// `Multi*` (KeyIds). Cons cells make list building robust against the
+/// allocation interleaving that happens while parsing nested sub-fragments
+/// (e.g. a musig key inside a `multi_a`, or a `thresh` inside a `thresh`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Link {
+    pub val: u32,
+    pub next: u32,
+}
+
+/// Returned by allocation methods when a fixed-capacity backing is exhausted
+/// (or when a `u32` id space would overflow).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ArenaFull;
+
+// ---------------------------------------------------------------------------
+// Read / build abstractions
+// ---------------------------------------------------------------------------
+
+/// Read-only view of an arena. [`Cursor`]s are generic over this so traversal
+/// code is written once for every backing.
+pub trait ArenaRead {
+    fn node(&self, id: NodeId) -> Node;
+    fn key(&self, id: KeyId) -> KeyExprRec;
+    fn link(&self, idx: u32) -> Link;
+    fn members(&self, span: Span) -> &[u32];
+    fn bytes(&self, span: Span) -> &[u8];
+}
+
+/// Append-only builder API shared by all backings, so the parser is generic
+/// over it. Every method is fallible: `VecArena` only fails on `u32` overflow,
+/// while a fixed-capacity backing fails when exhausted.
+pub trait ArenaStore: ArenaRead {
+    fn push_node(&mut self, node: Node) -> Result<NodeId, ArenaFull>;
+    fn push_key(&mut self, key: KeyExprRec) -> Result<KeyId, ArenaFull>;
+    fn push_link(&mut self, link: Link) -> Result<u32, ArenaFull>;
+    /// Patch the `next` field of a previously pushed link (for in-order lists).
+    fn set_link_next(&mut self, idx: u32, next: u32);
+
+    /// Begin a contiguous span in the `members` pool. Returns the start index.
+    fn members_begin(&self) -> u32;
+    /// Append one value to the `members` pool (must not interleave with other
+    /// `members` pushes — see the musig parsing path).
+    fn members_push(&mut self, value: u32) -> Result<(), ArenaFull>;
+    /// Finish a span started at `start` (the current `members` length is the end).
+    fn members_end(&self, start: u32) -> Span;
+
+    /// Append a byte run (hash fragment) and return its span.
+    fn push_bytes(&mut self, bytes: &[u8]) -> Result<Span, ArenaFull>;
+
+    /// Mutate a stored key's derivation indices in place (used by the decode
+    /// path's canonicalization, addressed by id with no aliasing).
+    fn set_key_derivation(&mut self, id: KeyId, num1: u32, num2: u32);
+}
+
+/// In-order cons-list builder. Holds the head and tail link indices and the
+/// element count, so finished lists keep parse order with `O(1)` appends.
+#[derive(Clone, Copy, Debug)]
+pub struct ListBuilder {
+    head: u32,
+    tail: u32,
+    count: u32,
+}
+
+impl ListBuilder {
+    pub fn new() -> ListBuilder {
+        ListBuilder {
+            head: NONE,
+            tail: NONE,
+            count: 0,
+        }
+    }
+
+    /// Append `val` (a NodeId or KeyId) to the list.
+    pub fn push<A: ArenaStore>(&mut self, store: &mut A, val: u32) -> Result<(), ArenaFull> {
+        let idx = store.push_link(Link { val, next: NONE })?;
+        if self.head == NONE {
+            self.head = idx;
+        } else {
+            store.set_link_next(self.tail, idx);
+        }
+        self.tail = idx;
+        self.count += 1;
+        Ok(())
+    }
+
+    pub fn head(&self) -> u32 {
+        self.head
+    }
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+}
+
+impl Default for ListBuilder {
+    fn default() -> Self {
+        ListBuilder::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VecArena (alloc-backed)
+// ---------------------------------------------------------------------------
+
+// The default build currently always has `alloc`; the explicit `alloc` feature
+// gate (and the no-alloc `SliceArena`) are introduced in later phases.
+pub use vec_arena::VecArena;
+
+mod vec_arena {
+    use super::*;
+    use alloc::vec::Vec;
+
+    /// Growable, `Vec`-backed arena. Allocation only fails on `u32` overflow.
+    #[derive(Clone, Debug, Default)]
+    pub struct VecArena {
+        nodes: Vec<Node>,
+        keys: Vec<KeyExprRec>,
+        links: Vec<Link>,
+        members: Vec<u32>,
+        bytes: Vec<u8>,
+    }
+
+    impl VecArena {
+        pub fn new() -> VecArena {
+            VecArena::default()
+        }
+
+        pub fn node_count(&self) -> usize {
+            self.nodes.len()
+        }
+    }
+
+    impl ArenaRead for VecArena {
+        fn node(&self, id: NodeId) -> Node {
+            self.nodes[id.0 as usize]
+        }
+        fn key(&self, id: KeyId) -> KeyExprRec {
+            self.keys[id.0 as usize]
+        }
+        fn link(&self, idx: u32) -> Link {
+            self.links[idx as usize]
+        }
+        fn members(&self, span: Span) -> &[u32] {
+            &self.members[span.start as usize..(span.start + span.len) as usize]
+        }
+        fn bytes(&self, span: Span) -> &[u8] {
+            &self.bytes[span.start as usize..(span.start + span.len) as usize]
+        }
+    }
+
+    impl ArenaStore for VecArena {
+        fn push_node(&mut self, node: Node) -> Result<NodeId, ArenaFull> {
+            let id = u32::try_from(self.nodes.len()).map_err(|_| ArenaFull)?;
+            self.nodes.push(node);
+            Ok(NodeId(id))
+        }
+        fn push_key(&mut self, key: KeyExprRec) -> Result<KeyId, ArenaFull> {
+            let id = u32::try_from(self.keys.len()).map_err(|_| ArenaFull)?;
+            self.keys.push(key);
+            Ok(KeyId(id))
+        }
+        fn push_link(&mut self, link: Link) -> Result<u32, ArenaFull> {
+            let idx = u32::try_from(self.links.len()).map_err(|_| ArenaFull)?;
+            self.links.push(link);
+            Ok(idx)
+        }
+        fn set_link_next(&mut self, idx: u32, next: u32) {
+            self.links[idx as usize].next = next;
+        }
+        fn members_begin(&self) -> u32 {
+            self.members.len() as u32
+        }
+        fn members_push(&mut self, value: u32) -> Result<(), ArenaFull> {
+            if self.members.len() >= u32::MAX as usize {
+                return Err(ArenaFull);
+            }
+            self.members.push(value);
+            Ok(())
+        }
+        fn members_end(&self, start: u32) -> Span {
+            Span {
+                start,
+                len: self.members.len() as u32 - start,
+            }
+        }
+        fn push_bytes(&mut self, bytes: &[u8]) -> Result<Span, ArenaFull> {
+            let start = u32::try_from(self.bytes.len()).map_err(|_| ArenaFull)?;
+            let len = u32::try_from(bytes.len()).map_err(|_| ArenaFull)?;
+            self.bytes.extend_from_slice(bytes);
+            Ok(Span { start, len })
+        }
+        fn set_key_derivation(&mut self, id: KeyId, num1: u32, num2: u32) {
+            let k = &mut self.keys[id.0 as usize];
+            k.num1 = num1;
+            k.num2 = num2;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cursors / views (backing-agnostic traversal)
+// ---------------------------------------------------------------------------
+
+/// A borrowed reference to a descriptor node within an arena.
+pub struct Cursor<'a, A: ArenaRead> {
+    arena: &'a A,
+    id: NodeId,
+}
+
+// Manual Clone/Copy so the cursor types stay `Copy` regardless of whether the
+// backing arena `A` is `Copy` (it holds only a shared reference to `A`).
+impl<'a, A: ArenaRead> Clone for Cursor<'a, A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, A: ArenaRead> Copy for Cursor<'a, A> {}
+
+impl<'a, A: ArenaRead> Cursor<'a, A> {
+    pub fn new(arena: &'a A, id: NodeId) -> Self {
+        Cursor { arena, id }
+    }
+    pub fn arena(&self) -> &'a A {
+        self.arena
+    }
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+    pub fn tag(&self) -> NodeTag {
+        self.arena.node(self.id).tag
+    }
+    fn raw(&self) -> Node {
+        self.arena.node(self.id)
+    }
+    fn child(&self, slot_field: u32) -> Cursor<'a, A> {
+        Cursor::new(self.arena, NodeId(slot_field))
+    }
+    fn key_at(&self, id: u32) -> KeyView<'a, A> {
+        KeyView {
+            arena: self.arena,
+            rec: self.arena.key(KeyId(id)),
+        }
+    }
+
+    /// Resolve this node to a borrowed, matchable view.
+    pub fn view(&self) -> DescriptorNode<'a, A> {
+        let n = self.raw();
+        use NodeTag::*;
+        match n.tag {
+            Sh => DescriptorNode::Sh(self.child(n.a)),
+            Wsh => DescriptorNode::Wsh(self.child(n.a)),
+            A => DescriptorNode::A(self.child(n.a)),
+            S => DescriptorNode::S(self.child(n.a)),
+            C => DescriptorNode::C(self.child(n.a)),
+            T => DescriptorNode::T(self.child(n.a)),
+            D => DescriptorNode::D(self.child(n.a)),
+            V => DescriptorNode::V(self.child(n.a)),
+            J => DescriptorNode::J(self.child(n.a)),
+            N => DescriptorNode::N(self.child(n.a)),
+            L => DescriptorNode::L(self.child(n.a)),
+            U => DescriptorNode::U(self.child(n.a)),
+            Pkh => DescriptorNode::Pkh(self.key_at(n.a)),
+            Wpkh => DescriptorNode::Wpkh(self.key_at(n.a)),
+            Pk => DescriptorNode::Pk(self.key_at(n.a)),
+            PkK => DescriptorNode::PkK(self.key_at(n.a)),
+            PkH => DescriptorNode::PkH(self.key_at(n.a)),
+            Tr => {
+                let tree = if n.d == NONE {
+                    None
+                } else {
+                    Some(TapCursor::new(self.arena, NodeId(n.d)))
+                };
+                DescriptorNode::Tr(self.key_at(n.a), tree)
+            }
+            Zero => DescriptorNode::Zero,
+            One => DescriptorNode::One,
+            Older => DescriptorNode::Older(n.a),
+            After => DescriptorNode::After(n.a),
+            Sha256 => DescriptorNode::Sha256(self.arena.bytes(Span { start: n.a, len: n.b })),
+            Hash256 => DescriptorNode::Hash256(self.arena.bytes(Span { start: n.a, len: n.b })),
+            Ripemd160 => DescriptorNode::Ripemd160(self.arena.bytes(Span { start: n.a, len: n.b })),
+            Hash160 => DescriptorNode::Hash160(self.arena.bytes(Span { start: n.a, len: n.b })),
+            Andor => DescriptorNode::Andor(self.child(n.a), self.child(n.b), self.child(n.c)),
+            AndV => DescriptorNode::AndV(self.child(n.a), self.child(n.b)),
+            AndB => DescriptorNode::AndB(self.child(n.a), self.child(n.b)),
+            AndN => DescriptorNode::AndN(self.child(n.a), self.child(n.b)),
+            OrB => DescriptorNode::OrB(self.child(n.a), self.child(n.b)),
+            OrC => DescriptorNode::OrC(self.child(n.a), self.child(n.b)),
+            OrD => DescriptorNode::OrD(self.child(n.a), self.child(n.b)),
+            OrI => DescriptorNode::OrI(self.child(n.a), self.child(n.b)),
+            Thresh => DescriptorNode::Thresh(
+                n.a,
+                NodeList {
+                    arena: self.arena,
+                    cur: n.b,
+                    count: n.c,
+                },
+            ),
+            Multi => DescriptorNode::Multi(n.a, self.key_list(n.b, n.c)),
+            MultiA => DescriptorNode::MultiA(n.a, self.key_list(n.b, n.c)),
+            Sortedmulti => DescriptorNode::Sortedmulti(n.a, self.key_list(n.b, n.c)),
+            SortedmultiA => DescriptorNode::SortedmultiA(n.a, self.key_list(n.b, n.c)),
+            TapLeaf | TapBranch => DescriptorNode::TapNode(TapCursor::new(self.arena, self.id)),
+        }
+    }
+
+    fn key_list(&self, head: u32, count: u32) -> KeyListView<'a, A> {
+        KeyListView {
+            arena: self.arena,
+            head,
+            count,
+        }
+    }
+}
+
+/// A borrowed key expression.
+pub struct KeyView<'a, A: ArenaRead> {
+    arena: &'a A,
+    rec: KeyExprRec,
+}
+impl<'a, A: ArenaRead> Clone for KeyView<'a, A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, A: ArenaRead> Copy for KeyView<'a, A> {}
+
+impl<'a, A: ArenaRead> KeyView<'a, A> {
+    pub fn num1(&self) -> u32 {
+        self.rec.num1
+    }
+    pub fn num2(&self) -> u32 {
+        self.rec.num2
+    }
+    pub fn is_plain(&self) -> bool {
+        self.rec.kind == KeyKind::Plain
+    }
+    pub fn is_musig(&self) -> bool {
+        self.rec.kind == KeyKind::Musig
+    }
+    pub fn plain_key_index(&self) -> Option<u32> {
+        match self.rec.kind {
+            KeyKind::Plain => Some(self.rec.plain_index),
+            KeyKind::Musig => None,
+        }
+    }
+    pub fn musig_key_indices(&self) -> Option<&'a [u32]> {
+        match self.rec.kind {
+            KeyKind::Musig => Some(self.arena.members(self.rec.musig_members)),
+            KeyKind::Plain => None,
+        }
+    }
+}
+
+/// A borrowed list of key expressions (for `multi`/`sortedmulti`/`_a`).
+pub struct KeyListView<'a, A: ArenaRead> {
+    arena: &'a A,
+    head: u32,
+    count: u32,
+}
+impl<'a, A: ArenaRead> Clone for KeyListView<'a, A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, A: ArenaRead> Copy for KeyListView<'a, A> {}
+
+impl<'a, A: ArenaRead> KeyListView<'a, A> {
+    pub fn len(&self) -> usize {
+        self.count as usize
+    }
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+    pub fn iter(&self) -> KeyListIter<'a, A> {
+        KeyListIter {
+            arena: self.arena,
+            cur: self.head,
+        }
+    }
+}
+
+pub struct KeyListIter<'a, A: ArenaRead> {
+    arena: &'a A,
+    cur: u32,
+}
+
+impl<'a, A: ArenaRead> Iterator for KeyListIter<'a, A> {
+    type Item = KeyView<'a, A>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur == NONE {
+            return None;
+        }
+        let link = self.arena.link(self.cur);
+        self.cur = link.next;
+        Some(KeyView {
+            arena: self.arena,
+            rec: self.arena.key(KeyId(link.val)),
+        })
+    }
+}
+
+/// A borrowed list of sub-script nodes (for `thresh`).
+pub struct NodeList<'a, A: ArenaRead> {
+    arena: &'a A,
+    cur: u32,
+    count: u32,
+}
+impl<'a, A: ArenaRead> Clone for NodeList<'a, A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, A: ArenaRead> Copy for NodeList<'a, A> {}
+
+impl<'a, A: ArenaRead> NodeList<'a, A> {
+    pub fn len(&self) -> usize {
+        self.count as usize
+    }
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+    pub fn iter(&self) -> NodeListIter<'a, A> {
+        NodeListIter {
+            arena: self.arena,
+            cur: self.cur,
+        }
+    }
+}
+
+pub struct NodeListIter<'a, A: ArenaRead> {
+    arena: &'a A,
+    cur: u32,
+}
+
+impl<'a, A: ArenaRead> Iterator for NodeListIter<'a, A> {
+    type Item = Cursor<'a, A>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur == NONE {
+            return None;
+        }
+        let link = self.arena.link(self.cur);
+        self.cur = link.next;
+        Some(Cursor::new(self.arena, NodeId(link.val)))
+    }
+}
+
+/// A borrowed reference to a tap-tree node.
+pub struct TapCursor<'a, A: ArenaRead> {
+    arena: &'a A,
+    id: NodeId,
+}
+impl<'a, A: ArenaRead> Clone for TapCursor<'a, A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, A: ArenaRead> Copy for TapCursor<'a, A> {}
+
+impl<'a, A: ArenaRead> TapCursor<'a, A> {
+    pub fn new(arena: &'a A, id: NodeId) -> Self {
+        TapCursor { arena, id }
+    }
+    pub fn is_leaf(&self) -> bool {
+        self.arena.node(self.id).tag == NodeTag::TapLeaf
+    }
+    /// For a `TapLeaf`, the leaf script cursor.
+    pub fn leaf_script(&self) -> Option<Cursor<'a, A>> {
+        let n = self.arena.node(self.id);
+        if n.tag == NodeTag::TapLeaf {
+            Some(Cursor::new(self.arena, NodeId(n.a)))
+        } else {
+            None
+        }
+    }
+    /// For a `TapBranch`, the (left, right) child tap-cursors.
+    pub fn branch(&self) -> Option<(TapCursor<'a, A>, TapCursor<'a, A>)> {
+        let n = self.arena.node(self.id);
+        if n.tag == NodeTag::TapBranch {
+            Some((
+                TapCursor::new(self.arena, NodeId(n.a)),
+                TapCursor::new(self.arena, NodeId(n.b)),
+            ))
+        } else {
+            None
+        }
+    }
+    /// Iterate the leaf script cursors left-to-right (matching the historical
+    /// `TapleavesIter`), using a fixed-capacity stack (no allocation).
+    pub fn tapleaves(&self) -> TapleavesIter<'a, A> {
+        let mut stack = [NodeId(0); MAX_TREE_DEPTH + 1];
+        stack[0] = self.id;
+        TapleavesIter {
+            arena: self.arena,
+            stack,
+            depth: 1,
+        }
+    }
+}
+
+pub struct TapleavesIter<'a, A: ArenaRead> {
+    arena: &'a A,
+    stack: [NodeId; MAX_TREE_DEPTH + 1],
+    depth: usize,
+}
+
+impl<'a, A: ArenaRead> Iterator for TapleavesIter<'a, A> {
+    type Item = Cursor<'a, A>;
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.depth > 0 {
+            self.depth -= 1;
+            let id = self.stack[self.depth];
+            let n = self.arena.node(id);
+            match n.tag {
+                NodeTag::TapLeaf => return Some(Cursor::new(self.arena, NodeId(n.a))),
+                NodeTag::TapBranch => {
+                    // push right then left so left is popped first
+                    if self.depth + 2 <= self.stack.len() {
+                        self.stack[self.depth] = NodeId(n.b);
+                        self.stack[self.depth + 1] = NodeId(n.a);
+                        self.depth += 2;
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+/// A borrowed, matchable view of a descriptor node. Produced by [`Cursor::view`].
+pub enum DescriptorNode<'a, A: ArenaRead> {
+    Sh(Cursor<'a, A>),
+    Wsh(Cursor<'a, A>),
+    A(Cursor<'a, A>),
+    S(Cursor<'a, A>),
+    C(Cursor<'a, A>),
+    T(Cursor<'a, A>),
+    D(Cursor<'a, A>),
+    V(Cursor<'a, A>),
+    J(Cursor<'a, A>),
+    N(Cursor<'a, A>),
+    L(Cursor<'a, A>),
+    U(Cursor<'a, A>),
+    Pkh(KeyView<'a, A>),
+    Wpkh(KeyView<'a, A>),
+    Pk(KeyView<'a, A>),
+    PkK(KeyView<'a, A>),
+    PkH(KeyView<'a, A>),
+    Tr(KeyView<'a, A>, Option<TapCursor<'a, A>>),
+    Zero,
+    One,
+    Older(u32),
+    After(u32),
+    Sha256(&'a [u8]),
+    Hash256(&'a [u8]),
+    Ripemd160(&'a [u8]),
+    Hash160(&'a [u8]),
+    Andor(Cursor<'a, A>, Cursor<'a, A>, Cursor<'a, A>),
+    AndV(Cursor<'a, A>, Cursor<'a, A>),
+    AndB(Cursor<'a, A>, Cursor<'a, A>),
+    AndN(Cursor<'a, A>, Cursor<'a, A>),
+    OrB(Cursor<'a, A>, Cursor<'a, A>),
+    OrC(Cursor<'a, A>, Cursor<'a, A>),
+    OrD(Cursor<'a, A>, Cursor<'a, A>),
+    OrI(Cursor<'a, A>, Cursor<'a, A>),
+    Thresh(u32, NodeList<'a, A>),
+    Multi(u32, KeyListView<'a, A>),
+    MultiA(u32, KeyListView<'a, A>),
+    Sortedmulti(u32, KeyListView<'a, A>),
+    SortedmultiA(u32, KeyListView<'a, A>),
+    /// A tap-tree node encountered directly (only when a `Cursor` is aimed at a
+    /// `TapLeaf`/`TapBranch`); normal traversal reaches leaves via [`TapCursor`].
+    TapNode(TapCursor<'a, A>),
+}
+
+// ---------------------------------------------------------------------------
+// Cleartext output sink
+// ---------------------------------------------------------------------------
+
+/// A sink for cleartext output: a `core::fmt::Write` plus a line separator.
+/// The encoder writes one logical description per "line" and calls
+/// [`LineSink::flush_line`] between them.
+pub trait LineSink: fmt::Write {
+    /// Finish the current line and start a new one.
+    fn flush_line(&mut self);
+}
+
+pub use vec_sink::VecLineSink;
+
+mod vec_sink {
+    use super::*;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    /// Collects cleartext lines into `Vec<String>` (alloc build).
+    #[derive(Default)]
+    pub struct VecLineSink {
+        lines: Vec<String>,
+        cur: String,
+    }
+
+    impl VecLineSink {
+        pub fn new() -> VecLineSink {
+            VecLineSink::default()
+        }
+        /// Consume the sink, flushing any pending current line, into the lines.
+        pub fn into_lines(mut self) -> Vec<String> {
+            if !self.cur.is_empty() {
+                self.lines.push(core::mem::take(&mut self.cur));
+            }
+            self.lines
+        }
+    }
+
+    impl fmt::Write for VecLineSink {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            self.cur.push_str(s);
+            Ok(())
+        }
+    }
+
+    impl LineSink for VecLineSink {
+        fn flush_line(&mut self) {
+            self.lines.push(core::mem::take(&mut self.cur));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::fmt::Write;
+
+    // Build `pkh(@0/**)` and read it back through a cursor.
+    #[test]
+    fn build_and_read_pkh() {
+        let mut a = VecArena::new();
+        let k = a.push_key(KeyExprRec::plain(0, 0, 1)).unwrap();
+        let root = a.push_node(Node::with_a(NodeTag::Pkh, k.0)).unwrap();
+
+        let cur = Cursor::new(&a, root);
+        match cur.view() {
+            DescriptorNode::Pkh(kv) => {
+                assert!(kv.is_plain());
+                assert_eq!(kv.plain_key_index(), Some(0));
+                assert_eq!((kv.num1(), kv.num2()), (0, 1));
+                assert_eq!(kv.musig_key_indices(), None);
+            }
+            _ => panic!("expected Pkh"),
+        }
+    }
+
+    // Build `multi(2,@0,@1,@2)` via an in-order cons list.
+    #[test]
+    fn build_and_read_multi() {
+        let mut a = VecArena::new();
+        let mut list = ListBuilder::new();
+        for i in 0..3u32 {
+            let k = a.push_key(KeyExprRec::plain(i, 0, 1)).unwrap();
+            list.push(&mut a, k.0).unwrap();
+        }
+        let mut node = Node::new(NodeTag::Multi);
+        node.a = 2; // threshold
+        node.b = list.head();
+        node.c = list.count();
+        let root = a.push_node(node).unwrap();
+
+        match Cursor::new(&a, root).view() {
+            DescriptorNode::Multi(k, keys) => {
+                assert_eq!(k, 2);
+                assert_eq!(keys.len(), 3);
+                let indices: alloc::vec::Vec<u32> =
+                    keys.iter().map(|kv| kv.plain_key_index().unwrap()).collect();
+                assert_eq!(indices, alloc::vec![0, 1, 2]);
+            }
+            _ => panic!("expected Multi"),
+        }
+    }
+
+    // Build `musig(@3,@7)` and read its members as a contiguous slice.
+    #[test]
+    fn build_and_read_musig() {
+        let mut a = VecArena::new();
+        let start = a.members_begin();
+        a.members_push(3).unwrap();
+        a.members_push(7).unwrap();
+        let span = a.members_end(start);
+        let k = a.push_key(KeyExprRec::musig(span, 0, 1)).unwrap();
+        let root = a.push_node(Node::with_a(NodeTag::Pk, k.0)).unwrap();
+
+        match Cursor::new(&a, root).view() {
+            DescriptorNode::Pk(kv) => {
+                assert!(kv.is_musig());
+                assert_eq!(kv.musig_key_indices(), Some(&[3u32, 7u32][..]));
+                assert_eq!(kv.plain_key_index(), None);
+            }
+            _ => panic!("expected Pk(musig)"),
+        }
+    }
+
+    // Build a tap tree `{leaf(@0), {leaf(@1), leaf(@2)}}` and check left-to-right leaf order.
+    #[test]
+    fn build_and_iterate_tapleaves() {
+        let mut a = VecArena::new();
+        let mk_leaf = |a: &mut VecArena, idx: u32| {
+            let k = a.push_key(KeyExprRec::plain(idx, 0, 1)).unwrap();
+            let script = a.push_node(Node::with_a(NodeTag::Pk, k.0)).unwrap();
+            a.push_node(Node::with_a(NodeTag::TapLeaf, script.0)).unwrap()
+        };
+        let l0 = mk_leaf(&mut a, 0);
+        let l1 = mk_leaf(&mut a, 1);
+        let l2 = mk_leaf(&mut a, 2);
+        let mut inner = Node::new(NodeTag::TapBranch);
+        inner.a = l1.0;
+        inner.b = l2.0;
+        let inner = a.push_node(inner).unwrap();
+        let mut root = Node::new(NodeTag::TapBranch);
+        root.a = l0.0;
+        root.b = inner.0;
+        let root = a.push_node(root).unwrap();
+
+        let tc = TapCursor::new(&a, root);
+        let order: alloc::vec::Vec<u32> = tc
+            .tapleaves()
+            .map(|leaf| match leaf.view() {
+                DescriptorNode::Pk(kv) => kv.plain_key_index().unwrap(),
+                _ => panic!("expected Pk leaf"),
+            })
+            .collect();
+        assert_eq!(order, alloc::vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn line_sink_collects_lines() {
+        let mut sink = VecLineSink::new();
+        write!(sink, "first {}", 1).unwrap();
+        sink.flush_line();
+        write!(sink, "second").unwrap();
+        let lines = sink.into_lines();
+        assert_eq!(lines, alloc::vec!["first 1".to_string(), "second".to_string()]);
+    }
+}

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -1027,6 +1027,106 @@ mod vec_sink {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Cursor-based traversals shared by both builds (no allocation)
+// ---------------------------------------------------------------------------
+
+impl<'a, A: ArenaRead> KeyView<'a, A> {
+    /// Renders this key expression into `w` (mirrors `KeyExpression` `Display`).
+    pub fn write_to(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+        write_key(w, *self)
+    }
+}
+
+impl<'a, A: ArenaRead> Cursor<'a, A> {
+    /// Determines the segwit version of a *top-level* descriptor node, matching
+    /// the owned `WalletPolicy::get_segwit_version`.
+    pub fn segwit_version(&self) -> Result<crate::SegwitVersion, crate::ParseError> {
+        use crate::SegwitVersion as SV;
+        use NodeTag::*;
+        let n = self.arena.node(self.id);
+        match n.tag {
+            Tr => Ok(SV::Taproot),
+            Pkh => Ok(SV::Legacy),
+            Wpkh | Wsh => Ok(SV::SegwitV0),
+            Sh => match self.arena.node(NodeId(n.a)).tag {
+                Wpkh | Wsh => Ok(SV::SegwitV0),
+                _ => Ok(SV::Legacy),
+            },
+            _ => Err(crate::ParseError::InvalidTopLevelPolicy),
+        }
+    }
+
+    /// Visits every key placeholder in document order (left-to-right), passing
+    /// the enclosing tap-leaf script cursor (or `None` outside a tap leaf / for
+    /// the taproot internal key). Matches the order of the owned
+    /// `DescriptorTemplate::placeholders` iterator. Recursion is bounded by the
+    /// parser depth limit.
+    pub fn for_each_placeholder<F>(&self, f: &mut F)
+    where
+        F: FnMut(KeyView<'a, A>, Option<Cursor<'a, A>>),
+    {
+        self.visit_placeholders(None, f);
+    }
+
+    fn visit_placeholders<F>(&self, leaf: Option<Cursor<'a, A>>, f: &mut F)
+    where
+        F: FnMut(KeyView<'a, A>, Option<Cursor<'a, A>>),
+    {
+        use DescriptorNode as DN;
+        match self.view() {
+            DN::Pkh(kv) | DN::Wpkh(kv) | DN::Pk(kv) | DN::PkK(kv) | DN::PkH(kv) => f(kv, leaf),
+            DN::Multi(_, keys)
+            | DN::MultiA(_, keys)
+            | DN::Sortedmulti(_, keys)
+            | DN::SortedmultiA(_, keys) => {
+                for kv in keys.iter() {
+                    f(kv, leaf);
+                }
+            }
+            DN::Tr(kv, tree) => {
+                f(kv, None);
+                if let Some(t) = tree {
+                    for leaf_script in t.tapleaves() {
+                        leaf_script.visit_placeholders(Some(leaf_script), f);
+                    }
+                }
+            }
+            DN::Sh(c) | DN::Wsh(c) | DN::A(c) | DN::S(c) | DN::C(c) | DN::T(c) | DN::D(c)
+            | DN::V(c) | DN::J(c) | DN::N(c) | DN::L(c) | DN::U(c) => c.visit_placeholders(leaf, f),
+            DN::Andor(x, y, z) => {
+                x.visit_placeholders(leaf, f);
+                y.visit_placeholders(leaf, f);
+                z.visit_placeholders(leaf, f);
+            }
+            DN::AndV(x, y)
+            | DN::AndB(x, y)
+            | DN::AndN(x, y)
+            | DN::OrB(x, y)
+            | DN::OrC(x, y)
+            | DN::OrD(x, y)
+            | DN::OrI(x, y) => {
+                x.visit_placeholders(leaf, f);
+                y.visit_placeholders(leaf, f);
+            }
+            DN::Thresh(_, list) => {
+                for c in list.iter() {
+                    c.visit_placeholders(leaf, f);
+                }
+            }
+            DN::Zero
+            | DN::One
+            | DN::Older(_)
+            | DN::After(_)
+            | DN::Sha256(_)
+            | DN::Hash256(_)
+            | DN::Ripemd160(_)
+            | DN::Hash160(_)
+            | DN::TapNode(_) => {}
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -1230,6 +1230,10 @@ impl<'a> BufLineSink<'a> {
     pub fn line_count(&self) -> usize {
         self.n_lines
     }
+    /// The recorded line spans.
+    pub fn lines(&self) -> &[LineSpan] {
+        &self.lines[..self.n_lines]
+    }
     /// Whether the output buffer or the line array was exhausted.
     pub fn overflowed(&self) -> bool {
         self.overflow

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -494,6 +494,15 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
     }
 }
 
+/// Construct a [`KeyView`] for a key id (used when materializing an owned
+/// `KeyExpression` from a parsed `KeyId`).
+pub fn key_view<A: ArenaRead>(arena: &A, id: KeyId) -> KeyView<'_, A> {
+    KeyView {
+        arena,
+        rec: arena.key(id),
+    }
+}
+
 /// A borrowed key expression.
 pub struct KeyView<'a, A: ArenaRead> {
     arena: &'a A,

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -1611,6 +1611,130 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Placeholder iterator (alloc-only pull-style traversal)
+// ---------------------------------------------------------------------------
+//
+// The no-alloc computation paths use the recursive `for_each_placeholder`
+// callback above. Consumers that need a pull-style iterator (the PSBT/signing
+// handlers) use this `Vec`-backed iterator, which mirrors the owned
+// `DescriptorTemplateIter` arm-for-arm (same traversal order), but yields
+// `(KeyView, Option<Cursor>)` over the arena instead of borrowed owned nodes.
+
+#[cfg(feature = "alloc")]
+pub use placeholder_iter::PlaceholderIter;
+
+#[cfg(feature = "alloc")]
+mod placeholder_iter {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    /// Pull-style iterator over a descriptor's key placeholders, in the same
+    /// order as the historical owned `DescriptorTemplateIter`. Each item is the
+    /// key expression and the enclosing tap-leaf script cursor (`None` outside a
+    /// tap leaf / for the taproot internal key).
+    pub struct PlaceholderIter<'a, A: ArenaRead> {
+        fragments: Vec<(Cursor<'a, A>, Option<Cursor<'a, A>>)>,
+        placeholders: Vec<(KeyView<'a, A>, Option<Cursor<'a, A>>)>,
+    }
+
+    impl<'a, A: ArenaRead> PlaceholderIter<'a, A> {
+        pub fn new(root: Cursor<'a, A>) -> Self {
+            PlaceholderIter {
+                fragments: vec![(root, None)],
+                placeholders: Vec::new(),
+            }
+        }
+    }
+
+    impl<'a, A: ArenaRead> Iterator for PlaceholderIter<'a, A> {
+        type Item = (KeyView<'a, A>, Option<Cursor<'a, A>>);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            use DescriptorNode as DN;
+            while !self.placeholders.is_empty() || !self.fragments.is_empty() {
+                // If there are pending placeholders, pop and return one.
+                if let Some(item) = self.placeholders.pop() {
+                    return Some(item);
+                }
+
+                let (frag, leaf) = self.fragments.pop()?;
+                match frag.view() {
+                    DN::Sh(c) | DN::Wsh(c) | DN::A(c) | DN::S(c) | DN::C(c) | DN::T(c)
+                    | DN::D(c) | DN::V(c) | DN::J(c) | DN::N(c) | DN::L(c) | DN::U(c) => {
+                        self.fragments.push((c, leaf));
+                    }
+                    DN::Andor(x, y, z) => {
+                        self.fragments.push((z, leaf));
+                        self.fragments.push((y, leaf));
+                        self.fragments.push((x, leaf));
+                    }
+                    DN::OrB(x, y)
+                    | DN::OrC(x, y)
+                    | DN::OrD(x, y)
+                    | DN::OrI(x, y)
+                    | DN::AndV(x, y)
+                    | DN::AndB(x, y)
+                    | DN::AndN(x, y) => {
+                        self.fragments.push((y, leaf));
+                        self.fragments.push((x, leaf));
+                    }
+                    DN::Tr(key, tree) => {
+                        self.placeholders.push((key, None));
+                        if let Some(t) = tree {
+                            let mut leaves: Vec<Cursor<'a, A>> = t.tapleaves().collect();
+                            leaves.reverse();
+                            for leaf_script in leaves {
+                                self.fragments.push((leaf_script, Some(leaf_script)));
+                            }
+                        }
+                    }
+                    DN::Pkh(key) | DN::Wpkh(key) | DN::Pk(key) | DN::PkK(key) | DN::PkH(key) => {
+                        return Some((key, leaf));
+                    }
+                    DN::Sortedmulti(_, keys)
+                    | DN::SortedmultiA(_, keys)
+                    | DN::Multi(_, keys)
+                    | DN::MultiA(_, keys) => {
+                        // Push keys in reverse so the first key is yielded first.
+                        let kvs: Vec<KeyView<'a, A>> = keys.iter().collect();
+                        for kv in kvs.into_iter().rev() {
+                            self.placeholders.push((kv, leaf));
+                        }
+                    }
+                    DN::Thresh(_, list) => {
+                        let subs: Vec<Cursor<'a, A>> = list.iter().collect();
+                        for c in subs.into_iter().rev() {
+                            self.fragments.push((c, leaf));
+                        }
+                    }
+                    DN::Zero
+                    | DN::One
+                    | DN::Older(_)
+                    | DN::After(_)
+                    | DN::Sha256(_)
+                    | DN::Hash256(_)
+                    | DN::Ripemd160(_)
+                    | DN::Hash160(_)
+                    | DN::TapNode(_) => {
+                        // No placeholders for these.
+                    }
+                }
+            }
+            None
+        }
+    }
+
+    impl<'a, A: ArenaRead> Cursor<'a, A> {
+        /// Pull-style iterator over this node's key placeholders (see
+        /// [`PlaceholderIter`]). Matches the owned `placeholders()` order.
+        pub fn placeholders(&self) -> PlaceholderIter<'a, A> {
+            PlaceholderIter::new(*self)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/bitcoin/bip388/src/arena.rs
+++ b/apps/bitcoin/bip388/src/arena.rs
@@ -494,6 +494,216 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
     }
 }
 
+impl NodeTag {
+    /// Whether this is a single-letter miniscript wrapper (`a:`…`u:`).
+    pub fn is_wrapper(self) -> bool {
+        use NodeTag::*;
+        matches!(self, A | S | C | T | D | U | V | J | N | L)
+    }
+
+    /// The wrapper character for a wrapper tag, else `None`.
+    pub fn wrapper_char(self) -> Option<char> {
+        use NodeTag::*;
+        Some(match self {
+            A => 'a',
+            S => 's',
+            C => 'c',
+            T => 't',
+            D => 'd',
+            V => 'v',
+            J => 'j',
+            N => 'n',
+            L => 'l',
+            U => 'u',
+            _ => return None,
+        })
+    }
+}
+
+/// Writes `bytes` as lowercase hex into `w` (allocation-free; mirrors
+/// `hex::encode` used by the owned `Display`).
+fn write_hex(w: &mut dyn fmt::Write, bytes: &[u8]) -> fmt::Result {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    for &byte in bytes {
+        w.write_char(DIGITS[(byte >> 4) as usize] as char)?;
+        w.write_char(DIGITS[(byte & 0x0f) as usize] as char)?;
+    }
+    Ok(())
+}
+
+/// Writes a key expression in descriptor-template syntax (mirrors the owned
+/// `KeyExpression` `Display`): `@i/**`, `@i/<a;b>/*`, or `musig(@i,@j,…)/…`.
+fn write_key<A: ArenaRead>(w: &mut dyn fmt::Write, kv: KeyView<'_, A>) -> fmt::Result {
+    let (num1, num2) = (kv.num1(), kv.num2());
+    if let Some(idx) = kv.plain_key_index() {
+        if num1 == 0 && num2 == 1 {
+            write!(w, "@{}/**", idx)
+        } else {
+            write!(w, "@{}/<{};{}>/*", idx, num1, num2)
+        }
+    } else {
+        let members = kv.musig_key_indices().expect("musig key");
+        w.write_str("musig(")?;
+        for (i, idx) in members.iter().enumerate() {
+            if i > 0 {
+                w.write_char(',')?;
+            }
+            write!(w, "@{}", idx)?;
+        }
+        if num1 == 0 && num2 == 1 {
+            write!(w, ")/**")
+        } else {
+            write!(w, ")/<{};{}>/*", num1, num2)
+        }
+    }
+}
+
+impl<'a, A: ArenaRead> Cursor<'a, A> {
+    /// Renders this node as a descriptor-template string into `w`, byte-for-byte
+    /// identical to the owned `DescriptorTemplate` `Display`.
+    pub fn write_template(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+        use DescriptorNode as DN;
+        match self.view() {
+            DN::Sh(c) => bracket(w, "sh(", c),
+            DN::Wsh(c) => bracket(w, "wsh(", c),
+            DN::Pkh(kv) => kp(w, "pkh(", kv),
+            DN::Wpkh(kv) => kp(w, "wpkh(", kv),
+            DN::Pk(kv) => kp(w, "pk(", kv),
+            DN::PkK(kv) => kp(w, "pk_k(", kv),
+            DN::PkH(kv) => kp(w, "pk_h(", kv),
+            DN::Sortedmulti(k, keys) => multi(w, "sortedmulti(", k, keys),
+            DN::SortedmultiA(k, keys) => multi(w, "sortedmulti_a(", k, keys),
+            DN::Multi(k, keys) => multi(w, "multi(", k, keys),
+            DN::MultiA(k, keys) => multi(w, "multi_a(", k, keys),
+            DN::Tr(kv, None) => {
+                w.write_str("tr(")?;
+                write_key(w, kv)?;
+                w.write_char(')')
+            }
+            DN::Tr(kv, Some(tree)) => {
+                w.write_str("tr(")?;
+                write_key(w, kv)?;
+                w.write_char(',')?;
+                tree.write_template(w)?;
+                w.write_char(')')
+            }
+            DN::Zero => w.write_char('0'),
+            DN::One => w.write_char('1'),
+            DN::Older(n) => write!(w, "older({})", n),
+            DN::After(n) => write!(w, "after({})", n),
+            DN::Sha256(b) => hash(w, "sha256(", b),
+            DN::Hash256(b) => hash(w, "hash256(", b),
+            DN::Ripemd160(b) => hash(w, "ripemd160(", b),
+            DN::Hash160(b) => hash(w, "hash160(", b),
+            DN::Andor(x, y, z) => {
+                w.write_str("andor(")?;
+                x.write_template(w)?;
+                w.write_char(',')?;
+                y.write_template(w)?;
+                w.write_char(',')?;
+                z.write_template(w)?;
+                w.write_char(')')
+            }
+            DN::AndV(x, y) => binary(w, "and_v(", x, y),
+            DN::AndB(x, y) => binary(w, "and_b(", x, y),
+            DN::AndN(x, y) => binary(w, "and_n(", x, y),
+            DN::OrB(x, y) => binary(w, "or_b(", x, y),
+            DN::OrC(x, y) => binary(w, "or_c(", x, y),
+            DN::OrD(x, y) => binary(w, "or_d(", x, y),
+            DN::OrI(x, y) => binary(w, "or_i(", x, y),
+            DN::Thresh(k, list) => {
+                write!(w, "thresh({}", k)?;
+                for c in list.iter() {
+                    w.write_char(',')?;
+                    c.write_template(w)?;
+                }
+                w.write_char(')')
+            }
+            DN::A(c) => wrapper(w, 'a', c),
+            DN::S(c) => wrapper(w, 's', c),
+            DN::C(c) => wrapper(w, 'c', c),
+            DN::T(c) => wrapper(w, 't', c),
+            DN::D(c) => wrapper(w, 'd', c),
+            DN::V(c) => wrapper(w, 'v', c),
+            DN::J(c) => wrapper(w, 'j', c),
+            DN::N(c) => wrapper(w, 'n', c),
+            DN::L(c) => wrapper(w, 'l', c),
+            DN::U(c) => wrapper(w, 'u', c),
+            DN::TapNode(_) => unreachable!("tap-tree node reached via write_template"),
+        }
+    }
+}
+
+fn bracket<A: ArenaRead>(w: &mut dyn fmt::Write, open: &str, c: Cursor<'_, A>) -> fmt::Result {
+    w.write_str(open)?;
+    c.write_template(w)?;
+    w.write_char(')')
+}
+
+fn kp<A: ArenaRead>(w: &mut dyn fmt::Write, open: &str, kv: KeyView<'_, A>) -> fmt::Result {
+    w.write_str(open)?;
+    write_key(w, kv)?;
+    w.write_char(')')
+}
+
+fn multi<A: ArenaRead>(
+    w: &mut dyn fmt::Write,
+    open: &str,
+    k: u32,
+    keys: KeyListView<'_, A>,
+) -> fmt::Result {
+    write!(w, "{}{}", open, k)?;
+    for kv in keys.iter() {
+        w.write_char(',')?;
+        write_key(w, kv)?;
+    }
+    w.write_char(')')
+}
+
+fn binary<A: ArenaRead>(
+    w: &mut dyn fmt::Write,
+    open: &str,
+    x: Cursor<'_, A>,
+    y: Cursor<'_, A>,
+) -> fmt::Result {
+    w.write_str(open)?;
+    x.write_template(w)?;
+    w.write_char(',')?;
+    y.write_template(w)?;
+    w.write_char(')')
+}
+
+fn hash(w: &mut dyn fmt::Write, open: &str, bytes: &[u8]) -> fmt::Result {
+    w.write_str(open)?;
+    write_hex(w, bytes)?;
+    w.write_char(')')
+}
+
+fn wrapper<A: ArenaRead>(w: &mut dyn fmt::Write, ch: char, inner: Cursor<'_, A>) -> fmt::Result {
+    w.write_char(ch)?;
+    if !inner.tag().is_wrapper() {
+        w.write_char(':')?;
+    }
+    inner.write_template(w)
+}
+
+impl<'a, A: ArenaRead> TapCursor<'a, A> {
+    /// Renders this tap-tree node as `{left,right}` / leaf script, matching the
+    /// owned `TapTree` `Display`.
+    pub fn write_template(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+        if let Some(script) = self.leaf_script() {
+            script.write_template(w)
+        } else {
+            let (l, r) = self.branch().expect("tap node is leaf or branch");
+            w.write_char('{')?;
+            l.write_template(w)?;
+            w.write_char(',')?;
+            r.write_template(w)?;
+            w.write_char('}')
+        }
+    }
+}
+
 /// Construct a [`KeyView`] for a key id (used when materializing an owned
 /// `KeyExpression` from a parsed `KeyId`).
 pub fn key_view<A: ArenaRead>(arena: &A, id: KeyId) -> KeyView<'_, A> {

--- a/apps/bitcoin/bip388/src/cleartext/decode.rs
+++ b/apps/bitcoin/bip388/src/cleartext/decode.rs
@@ -99,7 +99,9 @@ fn parse_relative_time(s: &str) -> Option<u32> {
 fn parse_timelock(s: &str) -> Option<Timelock> {
     if let Some(num) = s.strip_suffix(" blocks after receiving") {
         let n: u32 = num.parse().ok()?;
-        return (1..RELATIVE_LOCK_LIMIT).contains(&n).then_some(Timelock::Relative(n));
+        return (1..RELATIVE_LOCK_LIMIT)
+            .contains(&n)
+            .then_some(Timelock::Relative(n));
     }
     if let Some(duration) = s.strip_suffix(" after receiving") {
         let n = parse_relative_time(duration)?;
@@ -110,7 +112,9 @@ fn parse_timelock(s: &str) -> Option<Timelock> {
     }
     if let Some(num) = s.strip_prefix("not before block ") {
         let n: u32 = num.parse().ok()?;
-        return (1..LOCKTIME_THRESHOLD).contains(&n).then_some(Timelock::Absolute(n));
+        return (1..LOCKTIME_THRESHOLD)
+            .contains(&n)
+            .then_some(Timelock::Absolute(n));
     }
     if let Some(rest) = s.strip_prefix("not before ") {
         let date = rest.strip_suffix(" utc")?;
@@ -192,7 +196,11 @@ impl CleartextValueCursor {
 /// to prevent nesting.
 fn parse_tapleaf_cleartext(s: &str) -> Option<alloc::boxed::Box<TapleafClass>> {
     for spec in TAPLEAF_SPECS {
-        if spec.parts.iter().any(|p| matches!(p, CleartextPart::Subpolicy)) {
+        if spec
+            .parts
+            .iter()
+            .any(|p| matches!(p, CleartextPart::Subpolicy))
+        {
             continue; // skip combinator specs to prevent nesting
         }
         for values in parse_with_spec(spec, s) {
@@ -211,9 +219,7 @@ fn parse_cleartext_value(part: CleartextPart, input: &str) -> Option<CleartextVa
         CleartextPart::KeyIndex => parse_key_index(input).map(CleartextValue::KeyIndex),
         CleartextPart::KeyIndices => parse_key_indices(input).map(CleartextValue::KeyIndices),
         CleartextPart::Timelock => parse_timelock(input).map(CleartextValue::Timelock),
-        CleartextPart::Subpolicy => {
-            parse_tapleaf_cleartext(input).map(CleartextValue::Subpolicy)
-        }
+        CleartextPart::Subpolicy => parse_tapleaf_cleartext(input).map(CleartextValue::Subpolicy),
     }
 }
 
@@ -634,7 +640,10 @@ pub(super) fn from_cleartext_impl(
     // `capitalize_first` (and any other case variation) is undone uniformly. The
     // patterns are unambiguous when lower-cased, which `test_spec_shape_uniqueness`
     // and the build-time uniqueness check both enforce.
-    let lowered: Vec<String> = descriptions.iter().map(|d| d.to_ascii_lowercase()).collect();
+    let lowered: Vec<String> = descriptions
+        .iter()
+        .map(|d| d.to_ascii_lowercase())
+        .collect();
     let lowered_refs: Vec<&str> = lowered.iter().map(|s| s.as_str()).collect();
     let classes = parse_top_level_candidates(&lowered_refs)?;
     // `top_level_variants` only fails for `DescriptorClass::Other`; surface that

--- a/apps/bitcoin/bip388/src/cleartext/mod.rs
+++ b/apps/bitcoin/bip388/src/cleartext/mod.rs
@@ -29,7 +29,7 @@
 
 use alloc::{format, string::String, string::ToString, vec, vec::Vec};
 
-use super::time::{format_seconds, format_utc_date};
+use super::time::{format_seconds, format_utc_date, write_seconds, write_utc_date};
 use super::{DescriptorTemplate, KeyExpression, KeyExpressionType};
 
 // Arena cursor types used by the generated cursor-based classifier
@@ -338,8 +338,8 @@ fn format_timelock_to(sink: &mut dyn core::fmt::Write, lock: Timelock) -> core::
     match lock {
         Timelock::Relative(n) => {
             if n & SEQUENCE_LOCKTIME_TYPE_FLAG != 0 {
-                // format_relative_time(n) followed by " after receiving"
-                sink.write_str(&format_relative_time(n))?;
+                // relative duration: same value as `format_relative_time`, streamed
+                write_seconds(sink, (n & !SEQUENCE_LOCKTIME_TYPE_FLAG) * 512)?;
                 sink.write_str(" after receiving")
             } else {
                 write!(sink, "{} blocks after receiving", n)
@@ -349,7 +349,9 @@ fn format_timelock_to(sink: &mut dyn core::fmt::Write, lock: Timelock) -> core::
             if n < LOCKTIME_THRESHOLD {
                 write!(sink, "not before block {}", n)
             } else {
-                write!(sink, "not before {} UTC", format_utc_date(n))
+                sink.write_str("not before ")?;
+                write_utc_date(sink, n)?;
+                sink.write_str(" UTC")
             }
         }
     }

--- a/apps/bitcoin/bip388/src/cleartext/mod.rs
+++ b/apps/bitcoin/bip388/src/cleartext/mod.rs
@@ -794,10 +794,13 @@ fn tapleaf_ref_display_cmp<A: ArenaRead>(
                 })
         }
         (TC::Other(c1), TC::Other(c2)) => {
-            let (mut s1, mut s2) = (String::new(), String::new());
-            let _ = c1.write_template(&mut s1);
-            let _ = c2.write_template(&mut s2);
-            s1.cmp(&s2)
+            // Lexicographic by rendered descriptor, allocation-free. Raw-policy
+            // leaves are short; capture a bounded prefix for the comparison.
+            let mut b1 = crate::arena::FixedBuf::<256>::new();
+            let mut b2 = crate::arena::FixedBuf::<256>::new();
+            let _ = c1.write_template(&mut b1);
+            let _ = c2.write_template(&mut b2);
+            b1.as_slice().cmp(b2.as_slice())
         }
         // Equal `order()` implies the same variant; other pairings are unreachable.
         _ => core::cmp::Ordering::Equal,

--- a/apps/bitcoin/bip388/src/cleartext/mod.rs
+++ b/apps/bitcoin/bip388/src/cleartext/mod.rs
@@ -32,6 +32,10 @@ use alloc::{format, string::String, string::ToString, vec, vec::Vec};
 use super::time::{format_seconds, format_utc_date};
 use super::{DescriptorTemplate, KeyExpression, KeyExpressionType};
 
+// Arena cursor types used by the generated cursor-based classifier
+// (`cleartext_generated.rs`).
+use crate::arena::{ArenaRead, ClassKeyList, Cursor, DescriptorNode, KeyView, TapCursor};
+
 #[cfg(any(test, feature = "cleartext-decode"))]
 mod decode;
 
@@ -611,6 +615,42 @@ impl ClearText for DescriptorTemplate {
     }
 }
 
+// Cursor-based confusion score (no allocation), using the generated cursor
+// classifier. This is the single source of truth for the no-alloc / C build;
+// it is differential-tested against the owned `ClearText::confusion_score`.
+#[allow(dead_code)] // wired into production in a later phase; used by the C build
+impl<'a, A: ArenaRead> Cursor<'a, A> {
+    /// Upper bound on the number of descriptor templates that map to the same
+    /// cleartext (see [`ClearText::confusion_score`]). `scratch` must hold at
+    /// least `expanded_key_occurrences()` entries (an over-small scratch yields
+    /// a safe over-count).
+    pub fn confusion_score(&self, scratch: &mut [u32]) -> u64 {
+        let class = classify_ref(*self);
+        let base = match &class {
+            DescriptorClassRef::Taproot { leaves, .. }
+            | DescriptorClassRef::TaprootMusig { leaves, .. } => {
+                let mut score = class.outer_score();
+                let mut n_leaves = 0usize;
+                if let Some(tree) = leaves {
+                    for leaf in tree.tapleaves() {
+                        score = score.saturating_mul(classify_as_tapleaf_ref(leaf).per_leaf_score());
+                        n_leaves += 1;
+                    }
+                }
+                // T(n) = (2n - 3)!! for n > 1, and T(1) = 1.
+                if n_leaves > 1 {
+                    for i in (1..=(2 * n_leaves - 3)).step_by(2) {
+                        score = score.saturating_mul(i as u64);
+                    }
+                }
+                score
+            }
+            _ => class.outer_score(),
+        };
+        base.saturating_mul(self.key_derivation_orderings_count(scratch))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{ClearText, DescriptorTemplate};
@@ -689,6 +729,19 @@ mod tests {
                 dt(&v.template).confusion_score(),
                 expected,
                 "confusion_score mismatch for {:?}",
+                v.template
+            );
+
+            // The cursor (no-alloc) confusion score must agree with the owned one
+            // across the whole corpus.
+            let mut a = crate::arena::VecArena::new();
+            let root = crate::parser::parse_descriptor_template(&v.template, &mut a).unwrap();
+            let cur = crate::arena::Cursor::new(&a, root);
+            let mut scratch = alloc::vec![0u32; cur.expanded_key_occurrences()];
+            assert_eq!(
+                cur.confusion_score(&mut scratch),
+                expected,
+                "cursor confusion_score mismatch for {:?}",
                 v.template
             );
         }

--- a/apps/bitcoin/bip388/src/cleartext/mod.rs
+++ b/apps/bitcoin/bip388/src/cleartext/mod.rs
@@ -34,7 +34,10 @@ use super::{DescriptorTemplate, KeyExpression, KeyExpressionType};
 
 // Arena cursor types used by the generated cursor-based classifier
 // (`cleartext_generated.rs`).
-use crate::arena::{ArenaRead, ClassKeyList, Cursor, DescriptorNode, KeyView, TapCursor};
+use crate::arena::{
+    ArenaRead, CapWrite, ClassKeyList, Cursor, DescriptorNode, KeyExprRec, KeyView, LineSink,
+    NodeId, TapCursor,
+};
 
 #[cfg(any(test, feature = "cleartext-decode"))]
 mod decode;
@@ -284,6 +287,72 @@ fn format_timelock(lock: Timelock) -> String {
 /// order. Used by the generated `classify` for `tr(...)` patterns.
 fn tree_to_leaves(t: &super::TapTree) -> Vec<TapleafClass> {
     t.tapleaves().map(|l| l.classify_as_tapleaf()).collect()
+}
+
+// ── Streaming (cursor, no-alloc) cleartext formatting ──────────────────────
+// These mirror `format_key` / `format_key_indices` / `format_timelock` exactly
+// but write into a `core::fmt::Write` sink and take arena views.
+
+fn format_key_to<A: ArenaRead>(
+    sink: &mut dyn core::fmt::Write,
+    kv: KeyView<'_, A>,
+    canonical: bool,
+) -> core::fmt::Result {
+    let write_musig = |sink: &mut dyn core::fmt::Write, members: &[u32]| -> core::fmt::Result {
+        sink.write_str("musig(")?;
+        for (i, idx) in members.iter().enumerate() {
+            if i > 0 {
+                sink.write_char(',')?;
+            }
+            write!(sink, "@{}", idx)?;
+        }
+        sink.write_char(')')
+    };
+    match (kv.plain_key_index(), canonical) {
+        (Some(i), true) => write!(sink, "@{}", i),
+        (Some(i), false) => write!(sink, "@{}/<{};{}>/*", i, kv.num1(), kv.num2()),
+        (None, true) => write_musig(sink, kv.musig_key_indices().expect("musig")),
+        (None, false) => {
+            write_musig(sink, kv.musig_key_indices().expect("musig"))?;
+            write!(sink, "/<{};{}>/*", kv.num1(), kv.num2())
+        }
+    }
+}
+
+fn format_key_indices_to<A: ArenaRead>(
+    sink: &mut dyn core::fmt::Write,
+    keys: ClassKeyList<'_, A>,
+    canonical: bool,
+) -> core::fmt::Result {
+    let n = keys.len();
+    for (i, kv) in keys.iter().enumerate() {
+        if i > 0 {
+            sink.write_str(if i + 1 == n { " and " } else { ", " })?;
+        }
+        format_key_to(sink, kv, canonical)?;
+    }
+    Ok(())
+}
+
+fn format_timelock_to(sink: &mut dyn core::fmt::Write, lock: Timelock) -> core::fmt::Result {
+    match lock {
+        Timelock::Relative(n) => {
+            if n & SEQUENCE_LOCKTIME_TYPE_FLAG != 0 {
+                // format_relative_time(n) followed by " after receiving"
+                sink.write_str(&format_relative_time(n))?;
+                sink.write_str(" after receiving")
+            } else {
+                write!(sink, "{} blocks after receiving", n)
+            }
+        }
+        Timelock::Absolute(n) => {
+            if n < LOCKTIME_THRESHOLD {
+                write!(sink, "not before block {}", n)
+            } else {
+                write!(sink, "not before {} UTC", format_utc_date(n))
+            }
+        }
+    }
 }
 
 fn cleartext_spec<K: Copy + Eq>(
@@ -651,6 +720,183 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
     }
 }
 
+// ── Cursor leaf display ordering (mirrors `cmp_key`/`cmp_keys`/`display_cmp`) ──
+
+fn cmp_key_view<A: ArenaRead>(a: &KeyView<'_, A>, b: &KeyView<'_, A>) -> core::cmp::Ordering {
+    use core::cmp::Ordering;
+    match (a.plain_key_index(), b.plain_key_index()) {
+        (Some(i1), Some(i2)) => i1.cmp(&i2),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => {
+            let m1 = a.musig_key_indices().expect("musig");
+            let m2 = b.musig_key_indices().expect("musig");
+            m1.len().cmp(&m2.len()).then_with(|| m1.cmp(m2))
+        }
+    }
+}
+
+fn cmp_keys_view<A: ArenaRead>(
+    a: &ClassKeyList<'_, A>,
+    b: &ClassKeyList<'_, A>,
+) -> core::cmp::Ordering {
+    for (x, y) in a.iter().zip(b.iter()) {
+        let ord = cmp_key_view(&x, &y);
+        if ord != core::cmp::Ordering::Equal {
+            return ord;
+        }
+    }
+    core::cmp::Ordering::Equal
+}
+
+/// Canonical display ordering of two classified tap leaves (mirrors the owned
+/// `TapleafClass::display_cmp`): by spec-table `order()`, then structurally.
+fn tapleaf_ref_display_cmp<A: ArenaRead>(
+    a: &TapleafClassRef<'_, A>,
+    b: &TapleafClassRef<'_, A>,
+) -> core::cmp::Ordering {
+    use core::cmp::Ordering;
+    use TapleafClassRef as TC;
+    let by_order = a.order().cmp(&b.order());
+    if by_order != Ordering::Equal {
+        return by_order;
+    }
+    match (a, b) {
+        (TC::SingleSig { key: k1 }, TC::SingleSig { key: k2 }) => cmp_key_view(k1, k2),
+        (TC::BothMustSign { key1: a1, key2: b1 }, TC::BothMustSign { key1: a2, key2: b2 }) => {
+            cmp_key_view(a1, a2).then_with(|| cmp_key_view(b1, b2))
+        }
+        (
+            TC::SortedMultisig { threshold: t1, keys: k1 },
+            TC::SortedMultisig { threshold: t2, keys: k2 },
+        )
+        | (TC::Multisig { threshold: t1, keys: k1 }, TC::Multisig { threshold: t2, keys: k2 }) => k1
+            .len()
+            .cmp(&k2.len())
+            .then(t1.cmp(t2))
+            .then_with(|| cmp_keys_view(k1, k2)),
+        (TC::Timelocked { sub: s1, timelock: t1 }, TC::Timelocked { sub: s2, timelock: t2 }) => {
+            tapleaf_ref_display_cmp(
+                &classify_as_tapleaf_ref(*s1),
+                &classify_as_tapleaf_ref(*s2),
+            )
+            .then(t1.cmp(t2))
+        }
+        (TC::AndV { sub1: a1, sub2: a2 }, TC::AndV { sub1: b1, sub2: b2 }) => {
+            tapleaf_ref_display_cmp(&classify_as_tapleaf_ref(*a1), &classify_as_tapleaf_ref(*b1))
+                .then_with(|| {
+                    tapleaf_ref_display_cmp(
+                        &classify_as_tapleaf_ref(*a2),
+                        &classify_as_tapleaf_ref(*b2),
+                    )
+                })
+        }
+        (TC::Other(c1), TC::Other(c2)) => {
+            let (mut s1, mut s2) = (String::new(), String::new());
+            let _ = c1.write_template(&mut s1);
+            let _ = c2.write_template(&mut s2);
+            s1.cmp(&s2)
+        }
+        // Equal `order()` implies the same variant; other pairings are unreachable.
+        _ => core::cmp::Ordering::Equal,
+    }
+}
+
+#[allow(dead_code)] // wired into production in a later phase; used by the C build
+impl<'a, A: ArenaRead> Cursor<'a, A> {
+    /// Number of tap leaves (for sizing the leaf scratch); 0 if not a taproot
+    /// descriptor with a tree.
+    pub fn tapleaf_count(&self) -> usize {
+        match self.view() {
+            DescriptorNode::Tr(_, Some(tree)) => tree.tapleaves().count(),
+            _ => 0,
+        }
+    }
+
+    /// Cursor analogue of [`ClearText::to_cleartext`]: writes one line per
+    /// description into `sink`, returning whether every part has a cleartext
+    /// form. `canon_scratch` must hold `placeholder_count()` records;
+    /// `leaf_scratch` must hold `tapleaf_count()` entries. The same canonical
+    /// leaf ordering as the owned implementation is applied.
+    pub fn to_cleartext<S: LineSink>(
+        &self,
+        sink: &mut S,
+        canon_scratch: &mut [KeyExprRec],
+        leaf_scratch: &mut [u32],
+    ) -> bool {
+        if !self.are_key_derivations_canonical(canon_scratch) {
+            let _ = self.write_template(sink);
+            sink.flush_line();
+            return false;
+        }
+        let class = classify_ref(*self);
+        match &class {
+            DescriptorClassRef::Other => {
+                let _ = self.write_template(sink);
+                sink.flush_line();
+                false
+            }
+            DescriptorClassRef::Taproot { leaves, .. }
+            | DescriptorClassRef::TaprootMusig { leaves, .. } => {
+                {
+                    let mut cw = CapWrite::new(sink);
+                    let _ = class.cleartext_render(&mut cw, true);
+                }
+                sink.flush_line();
+
+                let arena = self.arena();
+                let mut n = 0usize;
+                let mut overflow = false;
+                if let Some(tree) = leaves {
+                    for leaf in tree.tapleaves() {
+                        if n < leaf_scratch.len() {
+                            leaf_scratch[n] = leaf.id().0;
+                        } else {
+                            overflow = true;
+                        }
+                        n += 1;
+                    }
+                }
+                if overflow {
+                    let _ = self.write_template(sink);
+                    sink.flush_line();
+                    return false;
+                }
+                let s = &mut leaf_scratch[..n];
+                s.sort_by(|&x, &y| {
+                    tapleaf_ref_display_cmp(
+                        &classify_as_tapleaf_ref(Cursor::new(arena, NodeId(x))),
+                        &classify_as_tapleaf_ref(Cursor::new(arena, NodeId(y))),
+                    )
+                });
+                let mut all_recognized = true;
+                for &leaf_id in s.iter() {
+                    let leaf_cur = Cursor::new(arena, NodeId(leaf_id));
+                    let lc = classify_as_tapleaf_ref(leaf_cur);
+                    if let TapleafClassRef::Other(c) = &lc {
+                        let _ = sink.write_str(UNRECOGNIZED_LEAF_PREFIX);
+                        let _ = c.write_template(sink);
+                        all_recognized = false;
+                    } else {
+                        let mut cw = CapWrite::new(sink);
+                        let _ = lc.cleartext_render(&mut cw, true);
+                    }
+                    sink.flush_line();
+                }
+                all_recognized
+            }
+            _ => {
+                {
+                    let mut cw = CapWrite::new(sink);
+                    let _ = class.cleartext_render(&mut cw, true);
+                }
+                sink.flush_line();
+                true
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{ClearText, DescriptorTemplate};
@@ -762,6 +1008,27 @@ mod tests {
             assert_eq!(
                 actual_hct, expected_hct,
                 "has_cleartext flag mismatch for {:?}",
+                v.template
+            );
+
+            // The cursor (no-alloc) renderer must produce identical lines + flag.
+            let mut a = crate::arena::VecArena::new();
+            let root = crate::parser::parse_descriptor_template(&v.template, &mut a).unwrap();
+            let cur = crate::arena::Cursor::new(&a, root);
+            let mut canon =
+                alloc::vec![crate::arena::KeyExprRec::plain(0, 0, 1); cur.placeholder_count()];
+            let mut leaf = alloc::vec![0u32; cur.tapleaf_count()];
+            let mut sink = crate::arena::VecLineSink::new();
+            let cur_hct = cur.to_cleartext(&mut sink, &mut canon, &mut leaf);
+            assert_eq!(
+                sink.into_lines(),
+                *expected_ct,
+                "cursor cleartext mismatch for {:?}",
+                v.template
+            );
+            assert_eq!(
+                cur_hct, expected_hct,
+                "cursor has_cleartext mismatch for {:?}",
                 v.template
             );
         }

--- a/apps/bitcoin/bip388/src/cleartext/mod.rs
+++ b/apps/bitcoin/bip388/src/cleartext/mod.rs
@@ -27,9 +27,13 @@
 //!    so the cleartext output is deterministic regardless of the original tree shape. The number
 //!    of structurally distinct trees is taken into account in the confusion score.
 
+#[cfg(feature = "alloc")]
 use alloc::{format, string::String, string::ToString, vec, vec::Vec};
 
-use super::time::{format_seconds, format_utc_date, write_seconds, write_utc_date};
+use super::time::{write_seconds, write_utc_date};
+#[cfg(feature = "alloc")]
+use super::time::{format_seconds, format_utc_date};
+#[cfg(feature = "alloc")]
 use super::{DescriptorTemplate, KeyExpression, KeyExpressionType};
 
 // Arena cursor types used by the generated cursor-based classifier
@@ -110,6 +114,7 @@ include!(concat!(env!("OUT_DIR"), "/cleartext_generated.rs"));
 // Represents a part of a clear-text representation of a descriptor template or tapleaf. A sequence of cleartext parts
 // fully defines the structure of the cleartext representation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(feature = "alloc")]
 pub(super) enum CleartextPart {
     Literal(&'static str),
     Threshold,
@@ -119,12 +124,14 @@ pub(super) enum CleartextPart {
     Subpolicy,
 }
 
+#[cfg(feature = "alloc")]
 pub(super) struct CleartextSpec<K> {
     pub(super) kind: K,
     pub(super) parts: &'static [CleartextPart],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg(feature = "alloc")]
 enum CleartextValue {
     Threshold(u32),
     KeyIndex(KeyExpression),
@@ -137,6 +144,7 @@ enum CleartextValue {
 /// - plain key vs plain key: ordered by key index
 /// - plain key vs musig: plain key comes first
 /// - musig vs musig: ordered by number of keys, then left-to-right by key index
+#[cfg(feature = "alloc")]
 fn cmp_key(a: &KeyExpression, b: &KeyExpression) -> core::cmp::Ordering {
     match (&a.key_type, &b.key_type) {
         (KeyExpressionType::PlainKey(i1), KeyExpressionType::PlainKey(i2)) => i1.cmp(i2),
@@ -158,6 +166,7 @@ fn cmp_key(a: &KeyExpression, b: &KeyExpression) -> core::cmp::Ordering {
 /// that differ only in their keys would compare equal, leaving their cleartext
 /// order to depend on tap-tree position — which is unstable across descriptors
 /// that share a cleartext rendering.
+#[cfg(feature = "alloc")]
 fn cmp_keys(a: &[KeyExpression], b: &[KeyExpression]) -> core::cmp::Ordering {
     for (x, y) in a.iter().zip(b.iter()) {
         let ord = cmp_key(x, y);
@@ -168,6 +177,7 @@ fn cmp_keys(a: &[KeyExpression], b: &[KeyExpression]) -> core::cmp::Ordering {
     core::cmp::Ordering::Equal
 }
 
+#[cfg(feature = "alloc")]
 impl TapleafClass {
     /// Full canonical display order. Categories come from `order()` (generated);
     /// within a category, ties are broken by:
@@ -216,6 +226,7 @@ impl TapleafClass {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn format_key(kp: &KeyExpression, canonical: bool) -> String {
     if canonical {
         match &kp.key_type {
@@ -241,6 +252,7 @@ fn format_key(kp: &KeyExpression, canonical: bool) -> String {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn format_key_indices(keys: &[KeyExpression], canonical: bool) -> String {
     match keys {
         [] => String::new(),
@@ -252,6 +264,7 @@ fn format_key_indices(keys: &[KeyExpression], canonical: bool) -> String {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn format_relative_time(time: u32) -> String {
     format_seconds((time & !SEQUENCE_LOCKTIME_TYPE_FLAG) * 512)
 }
@@ -264,6 +277,7 @@ fn format_relative_time(time: u32) -> String {
 ///   relative duration     -> "<duration> after receiving"
 ///   absolute block height -> "not before block <n>"
 ///   absolute date         -> "not before <date> UTC"
+#[cfg(feature = "alloc")]
 fn format_timelock(lock: Timelock) -> String {
     match lock {
         Timelock::Relative(n) => {
@@ -285,6 +299,7 @@ fn format_timelock(lock: Timelock) -> String {
 
 /// Classify every leaf of a tap-tree and collect the results in tree-traversal
 /// order. Used by the generated `classify` for `tr(...)` patterns.
+#[cfg(feature = "alloc")]
 fn tree_to_leaves(t: &super::TapTree) -> Vec<TapleafClass> {
     t.tapleaves().map(|l| l.classify_as_tapleaf()).collect()
 }
@@ -357,6 +372,7 @@ fn format_timelock_to(sink: &mut dyn core::fmt::Write, lock: Timelock) -> core::
     }
 }
 
+#[cfg(feature = "alloc")]
 fn cleartext_spec<K: Copy + Eq>(
     specs: &'static [CleartextSpec<K>],
     kind: K,
@@ -369,6 +385,7 @@ fn cleartext_spec<K: Copy + Eq>(
 /// (part, value) pairing represents a codegen-side bug since the two are
 /// produced in lockstep; we return `None` and let the caller fall back to a
 /// safe default rather than panic on the VM.
+#[cfg(feature = "alloc")]
 fn format_cleartext_value(
     part: CleartextPart,
     value: &CleartextValue,
@@ -395,6 +412,7 @@ fn format_cleartext_value(
     })
 }
 
+#[cfg(feature = "alloc")]
 fn format_with_spec<K>(
     spec: &CleartextSpec<K>,
     values: &[CleartextValue],
@@ -427,6 +445,7 @@ pub(super) const UNRECOGNIZED_LEAF_PREFIX: &str = "Raw policy: ";
 /// of an `AndV`); this fixes up only the leading character once the whole
 /// element has been assembled, leaving any composed sub-policies lowercase. The
 /// reverse parser undoes this per leaf (see `decode::parse_leaf_candidates`).
+#[cfg(feature = "alloc")]
 fn capitalize_first(s: &str) -> String {
     let mut chars = s.chars();
     match chars.next() {
@@ -440,6 +459,7 @@ fn capitalize_first(s: &str) -> String {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl DescriptorClass {
     fn to_cleartext_string(&self, canonical: bool) -> Option<String> {
         let (kind, values) = self.cleartext_pattern()?;
@@ -447,6 +467,7 @@ impl DescriptorClass {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl TapleafClass {
     fn to_cleartext_string(&self, canonical: bool) -> Option<String> {
         let (kind, values) = self.cleartext_pattern()?;
@@ -454,6 +475,7 @@ impl TapleafClass {
     }
 }
 
+#[cfg(feature = "alloc")]
 pub trait ClearText {
     /// Returns an upper bound on the number of different descriptor templates
     /// that would be mapped to the same cleartext description. u64::MAX is returned
@@ -478,6 +500,7 @@ pub trait ClearText {
         Self: Sized;
 }
 
+#[cfg(feature = "alloc")]
 impl DescriptorTemplate {
     // Verify that, for each distinct key expression in placeholders, its k occurrences carry derivations
     // (in some order) equal to <0;1>/*, <2;3>/*, ..., <2k-2;2k-1>/*. That is, after sorting the (num1, num2)
@@ -577,6 +600,7 @@ impl DescriptorTemplate {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ClearText for DescriptorTemplate {
     fn confusion_score(&self) -> u64 {
         let class = self.classify();
@@ -868,7 +892,7 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
                     return false;
                 }
                 let s = &mut leaf_scratch[..n];
-                s.sort_by(|&x, &y| {
+                s.sort_unstable_by(|&x, &y| {
                     tapleaf_ref_display_cmp(
                         &classify_as_tapleaf_ref(Cursor::new(arena, NodeId(x))),
                         &classify_as_tapleaf_ref(Cursor::new(arena, NodeId(y))),

--- a/apps/bitcoin/bip388/src/cleartext/mod.rs
+++ b/apps/bitcoin/bip388/src/cleartext/mod.rs
@@ -30,9 +30,9 @@
 #[cfg(feature = "alloc")]
 use alloc::{format, string::String, string::ToString, vec, vec::Vec};
 
-use super::time::{write_seconds, write_utc_date};
 #[cfg(feature = "alloc")]
 use super::time::{format_seconds, format_utc_date};
+use super::time::{write_seconds, write_utc_date};
 #[cfg(feature = "alloc")]
 use super::{DescriptorTemplate, KeyExpression, KeyExpressionType};
 
@@ -728,7 +728,8 @@ impl<'a, A: ArenaRead> Cursor<'a, A> {
                 let mut n_leaves = 0usize;
                 if let Some(tree) = leaves {
                     for leaf in tree.tapleaves() {
-                        score = score.saturating_mul(classify_as_tapleaf_ref(leaf).per_leaf_score());
+                        score =
+                            score.saturating_mul(classify_as_tapleaf_ref(leaf).per_leaf_score());
                         n_leaves += 1;
                     }
                 }
@@ -793,21 +794,40 @@ fn tapleaf_ref_display_cmp<A: ArenaRead>(
             cmp_key_view(a1, a2).then_with(|| cmp_key_view(b1, b2))
         }
         (
-            TC::SortedMultisig { threshold: t1, keys: k1 },
-            TC::SortedMultisig { threshold: t2, keys: k2 },
+            TC::SortedMultisig {
+                threshold: t1,
+                keys: k1,
+            },
+            TC::SortedMultisig {
+                threshold: t2,
+                keys: k2,
+            },
         )
-        | (TC::Multisig { threshold: t1, keys: k1 }, TC::Multisig { threshold: t2, keys: k2 }) => k1
+        | (
+            TC::Multisig {
+                threshold: t1,
+                keys: k1,
+            },
+            TC::Multisig {
+                threshold: t2,
+                keys: k2,
+            },
+        ) => k1
             .len()
             .cmp(&k2.len())
             .then(t1.cmp(t2))
             .then_with(|| cmp_keys_view(k1, k2)),
-        (TC::Timelocked { sub: s1, timelock: t1 }, TC::Timelocked { sub: s2, timelock: t2 }) => {
-            tapleaf_ref_display_cmp(
-                &classify_as_tapleaf_ref(*s1),
-                &classify_as_tapleaf_ref(*s2),
-            )
-            .then(t1.cmp(t2))
-        }
+        (
+            TC::Timelocked {
+                sub: s1,
+                timelock: t1,
+            },
+            TC::Timelocked {
+                sub: s2,
+                timelock: t2,
+            },
+        ) => tapleaf_ref_display_cmp(&classify_as_tapleaf_ref(*s1), &classify_as_tapleaf_ref(*s2))
+            .then(t1.cmp(t2)),
         (TC::AndV { sub1: a1, sub2: a2 }, TC::AndV { sub1: b1, sub2: b2 }) => {
             tapleaf_ref_display_cmp(&classify_as_tapleaf_ref(*a1), &classify_as_tapleaf_ref(*b1))
                 .then_with(|| {

--- a/apps/bitcoin/bip388/src/embedded.rs
+++ b/apps/bitcoin/bip388/src/embedded.rs
@@ -15,7 +15,7 @@
 use crate::arena::{ArenaFull, ArenaRead, ArenaStore, KeyId, NodeTag, Span};
 use crate::ParseError;
 
-pub use crate::arena::{BufLineSink, Cursor, KeyExprRec, Link, LineSpan, Node, NodeId, SliceArena};
+pub use crate::arena::{BufLineSink, Cursor, KeyExprRec, LineSpan, Link, Node, NodeId, SliceArena};
 
 /// Number of records each arena pool must hold to parse a given template.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -28,10 +28,8 @@ pub struct ArenaCounts {
 }
 
 /// An [`ArenaStore`] that records pool sizes without storing anything, used by
-/// [`measure`]. Reads return harmless defaults: the parser only reads back the
-/// `members` pool (for the musig-distinctness check), and an empty slice there
-/// just skips the early-reject — the real parse still validates, and for valid
-/// templates the counts are identical.
+/// [`measure`]. Reads return harmless defaults; measurement only needs parser
+/// validation and final pool counts.
 struct CountingArena {
     counts: ArenaCounts,
 }
@@ -108,9 +106,6 @@ pub fn measure(template: &str) -> Result<ArenaCounts, ParseError> {
 /// Parse `template` into `arena`, returning the root node id. Build a
 /// [`Cursor`] with `Cursor::new(&arena, root)` afterwards to compute the
 /// confusion score / cleartext.
-pub fn parse<'a>(
-    template: &str,
-    arena: &mut SliceArena<'a>,
-) -> Result<NodeId, ParseError> {
+pub fn parse<'a>(template: &str, arena: &mut SliceArena<'a>) -> Result<NodeId, ParseError> {
     crate::parser::parse_descriptor_template(template, arena)
 }

--- a/apps/bitcoin/bip388/src/embedded.rs
+++ b/apps/bitcoin/bip388/src/embedded.rs
@@ -1,0 +1,116 @@
+//! Public, allocation-free API for embedded / C consumers.
+//!
+//! Everything here works with caller-provided memory and never allocates, so it
+//! is available in every build (including `--no-default-features`). The intended
+//! flow is:
+//!
+//! 1. [`measure`] the template to get the per-pool record counts;
+//! 2. carve caller memory into the typed pools and build a [`SliceArena`];
+//! 3. [`parse`] the template into the arena to get the root [`NodeId`];
+//! 4. build a [`Cursor`] and call [`Cursor::confusion_score`] /
+//!    [`Cursor::to_cleartext`] (rendering into a [`BufLineSink`]).
+//!
+//! `bip388-c` is a thin `extern "C"` shim over exactly this.
+
+use crate::arena::{ArenaFull, ArenaRead, ArenaStore, KeyId, NodeTag, Span};
+use crate::ParseError;
+
+pub use crate::arena::{BufLineSink, Cursor, KeyExprRec, Link, LineSpan, Node, NodeId, SliceArena};
+
+/// Number of records each arena pool must hold to parse a given template.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ArenaCounts {
+    pub nodes: u32,
+    pub keys: u32,
+    pub links: u32,
+    pub members: u32,
+    pub bytes: u32,
+}
+
+/// An [`ArenaStore`] that records pool sizes without storing anything, used by
+/// [`measure`]. Reads return harmless defaults: the parser only reads back the
+/// `members` pool (for the musig-distinctness check), and an empty slice there
+/// just skips the early-reject — the real parse still validates, and for valid
+/// templates the counts are identical.
+struct CountingArena {
+    counts: ArenaCounts,
+}
+
+impl ArenaRead for CountingArena {
+    fn node(&self, _: NodeId) -> Node {
+        Node::new(NodeTag::Zero)
+    }
+    fn key(&self, _: KeyId) -> KeyExprRec {
+        KeyExprRec::plain(0, 0, 1)
+    }
+    fn link(&self, _: u32) -> Link {
+        Link { val: 0, next: 0 }
+    }
+    fn members(&self, _: Span) -> &[u32] {
+        &[]
+    }
+    fn bytes(&self, _: Span) -> &[u8] {
+        &[]
+    }
+}
+
+impl ArenaStore for CountingArena {
+    fn push_node(&mut self, _: Node) -> Result<NodeId, ArenaFull> {
+        let i = self.counts.nodes;
+        self.counts.nodes += 1;
+        Ok(NodeId(i))
+    }
+    fn push_key(&mut self, _: KeyExprRec) -> Result<KeyId, ArenaFull> {
+        let i = self.counts.keys;
+        self.counts.keys += 1;
+        Ok(KeyId(i))
+    }
+    fn push_link(&mut self, _: Link) -> Result<u32, ArenaFull> {
+        let i = self.counts.links;
+        self.counts.links += 1;
+        Ok(i)
+    }
+    fn set_link_next(&mut self, _: u32, _: u32) {}
+    fn members_begin(&self) -> u32 {
+        self.counts.members
+    }
+    fn members_push(&mut self, _: u32) -> Result<(), ArenaFull> {
+        self.counts.members += 1;
+        Ok(())
+    }
+    fn members_end(&self, start: u32) -> Span {
+        Span {
+            start,
+            len: self.counts.members - start,
+        }
+    }
+    fn push_bytes(&mut self, bytes: &[u8]) -> Result<Span, ArenaFull> {
+        let start = self.counts.bytes;
+        self.counts.bytes += bytes.len() as u32;
+        Ok(Span {
+            start,
+            len: bytes.len() as u32,
+        })
+    }
+    fn set_key_derivation(&mut self, _: KeyId, _: u32, _: u32) {}
+}
+
+/// Measure the per-pool record counts required to parse `template`. These are
+/// an upper bound sufficient to size a [`SliceArena`] for a successful parse.
+pub fn measure(template: &str) -> Result<ArenaCounts, ParseError> {
+    let mut a = CountingArena {
+        counts: ArenaCounts::default(),
+    };
+    crate::parser::parse_descriptor_template(template, &mut a)?;
+    Ok(a.counts)
+}
+
+/// Parse `template` into `arena`, returning the root node id. Build a
+/// [`Cursor`] with `Cursor::new(&arena, root)` afterwards to compute the
+/// confusion score / cleartext.
+pub fn parse<'a>(
+    template: &str,
+    arena: &mut SliceArena<'a>,
+) -> Result<NodeId, ParseError> {
+    crate::parser::parse_descriptor_template(template, arena)
+}

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -1031,12 +1031,11 @@ impl core::fmt::Display for DescriptorTemplate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg(feature = "wallet-policy")]
 pub struct WalletPolicy {
-    // Flat arena form of the parsed template + its root, used by the cursor
-    // (no-alloc-shaped) computation path. The owned `descriptor_template` is
-    // kept during the migration of consumers to cursors.
+    // Flat arena form of the parsed template + its root. All computation
+    // (script derivation, taproot hashing, placeholders, cleartext/confusion
+    // score) runs over this via cursors; there is no owned AST representation.
     arena: arena::VecArena,
     root: arena::NodeId,
-    descriptor_template: DescriptorTemplate,
     key_information: Vec<KeyInformation>,
     descriptor_template_raw: String,
 }
@@ -1062,25 +1061,18 @@ impl WalletPolicy {
     ) -> Result<Self, ParseError> {
         let mut arena = arena::VecArena::new();
         let root = parser::parse_descriptor_template(descriptor_template_str, &mut arena)?;
-        let descriptor_template = arena_to_owned(&arena, root);
 
         Ok(Self {
             arena,
             root,
-            descriptor_template,
             key_information,
             descriptor_template_raw: String::from(descriptor_template_str),
         })
     }
 
-    /// The parsed descriptor template AST.
-    pub fn descriptor_template(&self) -> &DescriptorTemplate {
-        &self.descriptor_template
-    }
-
-    /// A cursor over the flat (arena) form of the parsed template — the
-    /// representation the cursor-based computation (and eventually the
-    /// consensus consumers) operate on.
+    /// A cursor over the flat (arena) form of the parsed template — the single
+    /// representation that all computation (script derivation, taproot hashing,
+    /// placeholders, cleartext/confusion score) operates on.
     pub fn descriptor_cursor(&self) -> arena::Cursor<'_, arena::VecArena> {
         arena::Cursor::new(&self.arena, self.root)
     }
@@ -1235,18 +1227,7 @@ impl WalletPolicy {
     }
 
     pub fn get_segwit_version(&self) -> Result<SegwitVersion, ParseError> {
-        match &self.descriptor_template {
-            DescriptorTemplate::Tr(_, _) => Ok(SegwitVersion::Taproot),
-            DescriptorTemplate::Pkh(_) => Ok(SegwitVersion::Legacy),
-            DescriptorTemplate::Wpkh(_) | DescriptorTemplate::Wsh(_) => Ok(SegwitVersion::SegwitV0),
-            DescriptorTemplate::Sh(inner) => match inner.as_ref() {
-                DescriptorTemplate::Wpkh(_) | DescriptorTemplate::Wsh(_) => {
-                    Ok(SegwitVersion::SegwitV0)
-                }
-                _ => Ok(SegwitVersion::Legacy),
-            },
-            _ => Err(ParseError::InvalidTopLevelPolicy),
-        }
+        self.descriptor_cursor().segwit_version()
     }
 }
 

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -822,8 +822,11 @@ fn build_owned<A: arena::ArenaRead>(view: arena::DescriptorNode<'_, A>) -> Descr
     }
 }
 
+/// Materializes an owned [`KeyExpression`] from a borrowed arena [`KeyView`].
+/// Used at API boundaries where an owned key value is required (e.g. collecting
+/// a wallet policy's placeholders for PSBT filling).
 #[cfg(feature = "alloc")]
-fn keyview_to_owned<A: arena::ArenaRead>(kv: arena::KeyView<'_, A>) -> KeyExpression {
+pub fn keyview_to_owned<A: arena::ArenaRead>(kv: arena::KeyView<'_, A>) -> KeyExpression {
     if let Some(idx) = kv.plain_key_index() {
         KeyExpression::plain(idx, kv.num1(), kv.num2())
     } else {
@@ -2587,5 +2590,70 @@ mod tests {
         let out = dt.to_descriptor(&keys, true, 3).unwrap();
         let expected = format!("wsh(thresh(1,pk({}/1/3),s:pk({}/1/3)))", xpub_str, xpub_str);
         assert_eq!(out, expected);
+    }
+
+    /// The cursor-based `placeholders()` iterator must visit placeholders in the
+    /// exact same order as the owned `DescriptorTemplateIter`, with the same
+    /// per-placeholder tap-leaf context. Compared via the key/leaf `Display`
+    /// (cursor side uses the byte-identical `write_to` / `write_template`).
+    #[test]
+    fn cursor_placeholders_match_owned_order() {
+        use core::fmt::Write;
+
+        let corpus = [
+            "pkh(@0/**)",
+            "wsh(multi(2,@0/**,@1/**,@2/**))",
+            "wsh(sortedmulti(2,@0/**,@1/**))",
+            "tr(@0/**)",
+            "tr(@0/**,pk(@1/**))",
+            "tr(@0/**,{pk(@1/**),{pk(@2/**),pk(@3/**)}})",
+            "tr(@0/**,multi_a(2,@1/**,@2/**))",
+            "wsh(or_d(pk(@0/**),and_v(v:pk(@1/**),older(65535))))",
+            "wsh(andor(pk(@0/**),older(144),pk(@1/**)))",
+            "wsh(thresh(2,pk(@0/**),s:pk(@1/**),s:pk(@2/**)))",
+            "tr(musig(@0,@1)/**)",
+            "tr(@0/**,pk(musig(@1,@2)/**))",
+            "tr(@0/**,{multi_a(2,@1/**,@2/**),pk(@3/**)})",
+        ];
+
+        let render_cursor_key = |kv: arena::KeyView<'_, arena::VecArena>| -> alloc::string::String {
+            let mut s = alloc::string::String::new();
+            kv.write_to(&mut s).unwrap();
+            s
+        };
+        let render_cursor_leaf =
+            |leaf: Option<arena::Cursor<'_, arena::VecArena>>| -> Option<alloc::string::String> {
+                leaf.map(|c| {
+                    let mut s = alloc::string::String::new();
+                    c.write_template(&mut s).unwrap();
+                    s
+                })
+            };
+
+        for template in corpus {
+            let mut a = arena::VecArena::new();
+            let root = parser::parse_descriptor_template(template, &mut a).unwrap();
+            let owned = arena_to_owned(&a, root);
+            let cursor = arena::Cursor::new(&a, root);
+
+            let owned_seq: Vec<(String, Option<String>)> = owned
+                .placeholders()
+                .map(|(kp, leaf)| {
+                    let mut k = String::new();
+                    write!(k, "{}", kp).unwrap();
+                    (k, leaf.map(|d| format!("{}", d)))
+                })
+                .collect();
+
+            let cursor_seq: Vec<(String, Option<String>)> = cursor
+                .placeholders()
+                .map(|(kv, leaf)| (render_cursor_key(kv), render_cursor_leaf(leaf)))
+                .collect();
+
+            assert_eq!(
+                owned_seq, cursor_seq,
+                "placeholder order/context mismatch for {template}"
+            );
+        }
     }
 }

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -841,10 +841,7 @@ fn taptree_to_owned<A: arena::ArenaRead>(tc: arena::TapCursor<'_, A>) -> TapTree
         TapTree::Script(Box::new(node_to_owned(script)))
     } else {
         let (l, r) = tc.branch().expect("tap node is leaf or branch");
-        TapTree::Branch(
-            Box::new(taptree_to_owned(l)),
-            Box::new(taptree_to_owned(r)),
-        )
+        TapTree::Branch(Box::new(taptree_to_owned(l)), Box::new(taptree_to_owned(r)))
     }
 }
 
@@ -928,7 +925,6 @@ fn parse_sortedmulti(input: &str) -> Result<(&str, DescriptorTemplate), ParseErr
     )?;
     Ok((rest, arena_to_owned(&a, id)))
 }
-
 
 #[cfg(feature = "alloc")]
 fn write_display_wrapper(
@@ -1939,7 +1935,11 @@ mod tests {
                 }));
             });
 
-            assert_eq!(cur_keys, owned_keys, "placeholder keys mismatch for {:?}", s);
+            assert_eq!(
+                cur_keys, owned_keys,
+                "placeholder keys mismatch for {:?}",
+                s
+            );
             assert_eq!(
                 cur_ctx, owned_ctx,
                 "placeholder leaf-context mismatch for {:?}",
@@ -1952,7 +1952,8 @@ mod tests {
     // helpers, computed from the public `placeholders()` iterator.
     #[cfg(test)]
     fn ref_orderings_count(dt: &DescriptorTemplate) -> u64 {
-        let mut counts: alloc::collections::BTreeMap<u32, u32> = alloc::collections::BTreeMap::new();
+        let mut counts: alloc::collections::BTreeMap<u32, u32> =
+            alloc::collections::BTreeMap::new();
         for (kp, _) in dt.placeholders() {
             match &kp.key_type {
                 KeyExpressionType::PlainKey(i) => *counts.entry(*i).or_insert(0) += 1,
@@ -2021,8 +2022,7 @@ mod tests {
                 s
             );
 
-            let mut can_scratch =
-                vec![arena::KeyExprRec::plain(0, 0, 1); cur.placeholder_count()];
+            let mut can_scratch = vec![arena::KeyExprRec::plain(0, 0, 1); cur.placeholder_count()];
             assert_eq!(
                 cur.are_key_derivations_canonical(&mut can_scratch),
                 ref_canonical(&owned),
@@ -2113,8 +2113,16 @@ mod tests {
             let s_hct = sc.to_cleartext(&mut ssink, &mut scanon, &mut sleaf);
             let s_lines = ssink.into_lines();
 
-            assert_eq!(v_score, s_score, "confusion score backing mismatch for {:?}", s);
-            assert_eq!(v_lines, s_lines, "cleartext lines backing mismatch for {:?}", s);
+            assert_eq!(
+                v_score, s_score,
+                "confusion score backing mismatch for {:?}",
+                s
+            );
+            assert_eq!(
+                v_lines, s_lines,
+                "cleartext lines backing mismatch for {:?}",
+                s
+            );
             assert_eq!(v_hct, s_hct, "has_cleartext backing mismatch for {:?}", s);
         }
     }
@@ -2123,6 +2131,11 @@ mod tests {
     fn test_embedded_public_api() {
         // Drive the public no-alloc API: measure -> size pools -> parse ->
         // confusion_score, and check it matches the owned implementation.
+        assert_eq!(
+            crate::embedded::measure("tr(musig(@0,@0)/**)"),
+            Err(ParseError::InvalidKey)
+        );
+
         let cases = vec![
             "wsh(multi(2,@0/**,@1/**,@2/**))",
             "tr(musig(@0,@1)/**,{pk(@2/**),multi_a(2,@3/**,@4/**)})",

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -1098,6 +1098,27 @@ impl WalletPolicy {
         &self.descriptor_template_raw
     }
 
+    /// Upper bound on how many descriptor templates map to the same cleartext
+    /// (see the `cleartext` module). Computed over the arena via the cursor
+    /// path; mirrors the historical `descriptor_template().confusion_score()`.
+    pub fn confusion_score(&self) -> u64 {
+        let cur = self.descriptor_cursor();
+        let mut scratch = alloc::vec![0u32; cur.expanded_key_occurrences()];
+        cur.confusion_score(&mut scratch)
+    }
+
+    /// Human-readable description lines for this policy, plus whether every
+    /// part has a cleartext form. Computed over the arena via the cursor path;
+    /// mirrors the historical `descriptor_template().to_cleartext()`.
+    pub fn to_cleartext(&self) -> (Vec<String>, bool) {
+        let cur = self.descriptor_cursor();
+        let mut canon = alloc::vec![arena::KeyExprRec::plain(0, 0, 0); cur.placeholder_count()];
+        let mut leaf = alloc::vec![0u32; cur.tapleaf_count()];
+        let mut sink = arena::VecLineSink::new();
+        let all_have_cleartext = cur.to_cleartext(&mut sink, &mut canon, &mut leaf);
+        (sink.into_lines(), all_have_cleartext)
+    }
+
     pub fn serialize(&self) -> Vec<u8> {
         // `consensus_encode` only fails when its writer fails. Writing to a `Vec`
         // is infallible, so all `expect`s below are unreachable in practice.

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -1833,6 +1833,80 @@ mod tests {
     }
 
     #[test]
+    fn test_cursor_placeholders_match_owned() {
+        let cases = vec![
+            "pkh(@0/**)",
+            "wsh(multi(2,@0/**,@1/**,@2/**))",
+            "wsh(or_d(pk(@0/**),pkh(@1/**)))",
+            "tr(@0/**)",
+            "tr(@0/**,pkh(@1/**))",
+            "tr(@0/<2;1>/*,{pkh(@1/<2;7>/*),pk(@2/**)})",
+            "tr(musig(@0,@1)/**,{multi_a(1,@2/**,@3/**),pk(@4/**)})",
+            "wsh(or_i(and_v(v:pkh(@4/<3;7>/*),older(65535)),or_d(multi(2,@0/**,@3/**),and_v(v:thresh(1,pkh(@5/<99;101>/*),a:pkh(@1/**)),older(64231)))))",
+        ];
+
+        for s in cases {
+            let owned = DescriptorTemplate::from_str(s).unwrap();
+            let mut owned_keys: Vec<String> = Vec::new();
+            let mut owned_ctx: Vec<Option<String>> = Vec::new();
+            for (kp, ctx) in owned.placeholders() {
+                owned_keys.push(kp.to_string());
+                owned_ctx.push(ctx.map(|c| c.to_string()));
+            }
+
+            let mut a = arena::VecArena::new();
+            let root = parser::parse_descriptor_template(s, &mut a).unwrap();
+            let mut cur_keys: Vec<String> = Vec::new();
+            let mut cur_ctx: Vec<Option<String>> = Vec::new();
+            arena::Cursor::new(&a, root).for_each_placeholder(&mut |kv, leaf| {
+                let mut ks = String::new();
+                kv.write_to(&mut ks).unwrap();
+                cur_keys.push(ks);
+                cur_ctx.push(leaf.map(|c| {
+                    let mut s = String::new();
+                    c.write_template(&mut s).unwrap();
+                    s
+                }));
+            });
+
+            assert_eq!(cur_keys, owned_keys, "placeholder keys mismatch for {:?}", s);
+            assert_eq!(
+                cur_ctx, owned_ctx,
+                "placeholder leaf-context mismatch for {:?}",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn test_cursor_segwit_version_matches_owned() {
+        // get_segwit_version only inspects the top-level template, so an empty
+        // key-information list is fine here.
+        let cases = vec![
+            ("pkh(@0/**)", SegwitVersion::Legacy),
+            ("wpkh(@0/**)", SegwitVersion::SegwitV0),
+            ("wsh(multi(2,@0/**,@1/**))", SegwitVersion::SegwitV0),
+            ("sh(wpkh(@0/**))", SegwitVersion::SegwitV0),
+            ("sh(wsh(multi(2,@0/**,@1/**)))", SegwitVersion::SegwitV0),
+            ("tr(@0/**)", SegwitVersion::Taproot),
+        ];
+        for (s, expected) in cases {
+            let wp_version = WalletPolicy::new(s, vec![]).unwrap().get_segwit_version();
+            assert_eq!(wp_version, Ok(expected));
+
+            let mut a = arena::VecArena::new();
+            let root = parser::parse_descriptor_template(s, &mut a).unwrap();
+            let got = arena::Cursor::new(&a, root).segwit_version();
+            assert_eq!(got, Ok(expected), "segwit version mismatch for {:?}", s);
+            assert_eq!(
+                got, wp_version,
+                "cursor vs WalletPolicy segwit version for {:?}",
+                s
+            );
+        }
+    }
+
+    #[test]
     fn test_musig_inside_tr_parses() {
         // musig() as the internal key of tr()
         let result = DescriptorTemplate::from_str("tr(musig(@0,@1)/**)");

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -1878,6 +1878,90 @@ mod tests {
         }
     }
 
+    // Reference implementations mirroring the owned (private) confusion-score
+    // helpers, computed from the public `placeholders()` iterator.
+    #[cfg(test)]
+    fn ref_orderings_count(dt: &DescriptorTemplate) -> u64 {
+        let mut counts: alloc::collections::BTreeMap<u32, u32> = alloc::collections::BTreeMap::new();
+        for (kp, _) in dt.placeholders() {
+            match &kp.key_type {
+                KeyExpressionType::PlainKey(i) => *counts.entry(*i).or_insert(0) += 1,
+                KeyExpressionType::Musig(g) => {
+                    for &m in g {
+                        *counts.entry(m).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+        let mut product = 1u64;
+        for &k in counts.values() {
+            let mut f = 1u64;
+            for i in 1..=k as u64 {
+                f = f.saturating_mul(i);
+            }
+            product = product.saturating_mul(f);
+        }
+        product
+    }
+
+    #[cfg(test)]
+    fn ref_canonical(dt: &DescriptorTemplate) -> bool {
+        let mut pairs: alloc::collections::BTreeMap<KeyExpressionType, Vec<(u32, u32)>> =
+            alloc::collections::BTreeMap::new();
+        for (kp, _) in dt.placeholders() {
+            pairs
+                .entry(kp.key_type.clone())
+                .or_default()
+                .push((kp.num1, kp.num2));
+        }
+        for v in pairs.values_mut() {
+            v.sort();
+            for (i, &(n1, n2)) in v.iter().enumerate() {
+                if (n1, n2) != (2 * i as u32, 2 * i as u32 + 1) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    #[test]
+    fn test_cursor_confusion_helpers_match_owned() {
+        let cases = vec![
+            "wsh(multi(2,@0/**,@1/**))",
+            // index 0 repeated 3x across key path + two leaves -> 3! = 6
+            "tr(@0/**,{pk(@0/<2;3>/*),pk(@0/<4;5>/*)})",
+            // non-canonical: a single key with pair (2,3) instead of (0,1)
+            "wpkh(@0/<2;3>/*)",
+            // canonical musig + repeated members
+            "tr(musig(@0,@1)/**,{multi_a(1,@0/<2;3>/*,@1/<2;3>/*),pk(@2/**)})",
+            "wsh(or_i(and_v(v:pkh(@4/<3;7>/*),older(65535)),or_d(multi(2,@0/**,@3/**),and_v(v:thresh(1,pkh(@5/<99;101>/*),a:pkh(@1/**)),older(64231)))))",
+        ];
+        for s in cases {
+            let owned = DescriptorTemplate::from_str(s).unwrap();
+            let mut a = arena::VecArena::new();
+            let root = parser::parse_descriptor_template(s, &mut a).unwrap();
+            let cur = arena::Cursor::new(&a, root);
+
+            let mut ord_scratch = vec![0u32; cur.expanded_key_occurrences()];
+            assert_eq!(
+                cur.key_derivation_orderings_count(&mut ord_scratch),
+                ref_orderings_count(&owned),
+                "orderings count mismatch for {:?}",
+                s
+            );
+
+            let mut can_scratch =
+                vec![arena::KeyExprRec::plain(0, 0, 1); cur.placeholder_count()];
+            assert_eq!(
+                cur.are_key_derivations_canonical(&mut can_scratch),
+                ref_canonical(&owned),
+                "canonical mismatch for {:?}",
+                s
+            );
+        }
+    }
+
     #[test]
     fn test_cursor_segwit_version_matches_owned() {
         // get_segwit_version only inspects the top-level template, so an empty

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -1791,6 +1791,48 @@ mod tests {
     }
 
     #[test]
+    fn test_cursor_render_matches_owned_display() {
+        // The arena cursor renderer (used by the no-alloc build) must produce
+        // byte-identical output to the owned `Display` for every shape.
+        let cases = vec![
+            "0",
+            "1",
+            "pkh(@0/**)",
+            "wpkh(@0/<11;67>/*)",
+            "sh(wsh(sortedmulti(2,@0/**,@1/**)))",
+            "wsh(c:pk_k(@0/**))",
+            "wsh(or_d(pk(@0/**),pkh(@1/**)))",
+            "wsh(thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@2/**),sln:older(12960)))",
+            "tr(@0/**)",
+            "tr(@0/<2;1>/*,{pkh(@1/<2;7>/*),pk(@2/**)})",
+            "tr(musig(@0,@1)/**)",
+            "tr(@0/**,pk(musig(@1,@2,@3)/<5;6>/*))",
+            "sha256(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)",
+            "ripemd160(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)",
+            "wsh(andor(pk(@0/**),older(1),pk(@1/**)))",
+            "wsh(or_i(and_v(v:pkh(@4/<3;7>/*),older(65535)),or_d(multi(2,@0/**,@3/**),and_v(v:thresh(1,pkh(@5/<99;101>/*),a:pkh(@1/**)),older(64231)))))",
+            "tr(@0/**,{sortedmulti_a(1,@1/**,@2/**),or_b(pk(@3/**),s:pk(@4/**))})",
+        ];
+
+        for s in cases {
+            let mut a = arena::VecArena::new();
+            let root = parser::parse_descriptor_template(s, &mut a)
+                .unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", s, e));
+            let mut rendered = String::new();
+            arena::Cursor::new(&a, root)
+                .write_template(&mut rendered)
+                .expect("render");
+            assert_eq!(rendered, s, "cursor render mismatch for {:?}", s);
+            assert_eq!(
+                rendered,
+                DescriptorTemplate::from_str(s).unwrap().to_string(),
+                "cursor render disagrees with owned Display for {:?}",
+                s
+            );
+        }
+    }
+
+    #[test]
     fn test_musig_inside_tr_parses() {
         // musig() as the internal key of tr()
         let result = DescriptorTemplate::from_str("tr(musig(@0,@1)/**)");

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 
 mod arena;
 mod cleartext;
+mod parser;
 mod time;
 
 pub use cleartext::*;
@@ -20,8 +21,6 @@ use alloc::{format, string::ToString};
 
 use core::str::FromStr;
 
-use hex::{self, FromHex};
-
 use bitcoin::{
     bip32::{ChildNumber, Xpub},
     consensus::{encode, Decodable, Encodable},
@@ -29,17 +28,17 @@ use bitcoin::{
     VarInt,
 };
 
-const HARDENED_INDEX: u32 = 0x80000000u32;
-const MAX_OLDER_AFTER: u32 = 2147483647; // maximum allowed in older/after
+pub(crate) const HARDENED_INDEX: u32 = 0x80000000u32;
+pub(crate) const MAX_OLDER_AFTER: u32 = 2147483647; // maximum allowed in older/after
 
 // Maximum key count for `multi`/`sortedmulti` (OP_CHECKMULTISIG consensus limit).
-const MAX_KEYS_MULTI: usize = 20;
+pub(crate) const MAX_KEYS_MULTI: usize = 20;
 // Maximum key count for the Taproot `multi_a`/`sortedmulti_a` variants.
-const MAX_KEYS_MULTI_A: usize = 999;
+pub(crate) const MAX_KEYS_MULTI_A: usize = 999;
 // Maximum recursion depth for descriptor parsing. Bounds host-provided nesting
 // (e.g. `andor(...andor(...))` or `{{{...}}}`) to keep stack usage finite on
 // the constrained VM. Well above any realistic policy depth.
-const MAX_PARSE_DEPTH: usize = 64;
+pub(crate) const MAX_PARSE_DEPTH: usize = 64;
 // Maximum byte length of a serialized descriptor template accepted by
 // `WalletPolicy::deserialize`. Practical policies are far below this.
 const MAX_SERIALIZED_DESCRIPTORTEMPLATE_LEN: usize = 4096;
@@ -86,12 +85,16 @@ pub enum ParseError {
     InvalidMultisigQuorum,
     /// Descriptor template nesting exceeds [`MAX_PARSE_DEPTH`].
     NestingTooDeep,
+    /// The arena backing ran out of space while building the parsed template
+    /// (only reachable with a fixed-capacity, no-alloc backing; the `Vec`-backed
+    /// arena used in the default build effectively never returns this).
+    ArenaFull,
 }
 
 /// The parsing context, tracking which top-level descriptor we are inside.
 /// This determines which fragments and key expression forms are valid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ParseContext {
+pub(crate) enum ParseContext {
     /// Top-level: no enclosing descriptor yet.
     TopLevel,
     /// Inside a `sh()` descriptor (legacy P2SH).
@@ -105,27 +108,27 @@ enum ParseContext {
 }
 
 impl ParseContext {
-    fn musig_allowed(self) -> bool {
+    pub(crate) fn musig_allowed(self) -> bool {
         matches!(self, ParseContext::Taproot)
     }
 
     /// `sh()` is only allowed at the top level.
-    fn sh_allowed(self) -> bool {
+    pub(crate) fn sh_allowed(self) -> bool {
         matches!(self, ParseContext::TopLevel)
     }
 
     /// `wpkh()` is only allowed at the top level or inside `sh()`.
-    fn wpkh_allowed(self) -> bool {
+    pub(crate) fn wpkh_allowed(self) -> bool {
         matches!(self, ParseContext::TopLevel | ParseContext::Legacy)
     }
 
     /// `wsh()` is only allowed at the top level or inside `sh()`.
-    fn wsh_allowed(self) -> bool {
+    pub(crate) fn wsh_allowed(self) -> bool {
         matches!(self, ParseContext::TopLevel | ParseContext::Legacy)
     }
 
     /// `tr()` is only allowed at the top level.
-    fn tr_allowed(self) -> bool {
+    pub(crate) fn tr_allowed(self) -> bool {
         matches!(self, ParseContext::TopLevel)
     }
 }
@@ -678,573 +681,213 @@ pub trait ToDescriptor {
     ) -> Result<String, ParseError>;
 }
 
-// Return type for all hand-rolled parser functions: (remaining_input, parsed_value)
-type ParseResult<'a, T> = Result<(&'a str, T), ParseError>;
-
-// Parses a decimal u32 (no leading zeros unless "0"), value <= max.
-fn parse_number_up_to(input: &str, max: u32) -> ParseResult<'_, u32> {
-    if input.is_empty() || !input.starts_with(|c: char| c.is_ascii_digit()) {
-        return Err(ParseError::InvalidSyntax);
-    }
-    // reject leading zeros on multi-digit numbers
-    if input.starts_with('0') && input.len() > 1 && input.as_bytes()[1].is_ascii_digit() {
-        return Err(ParseError::NumberOutOfRange);
-    }
-    let end = input
-        .bytes()
-        .position(|b| !b.is_ascii_digit())
-        .unwrap_or(input.len());
-    let num: u32 = input[..end]
-        .parse()
-        .map_err(|_| ParseError::NumberOutOfRange)?;
-    if num > max {
-        return Err(ParseError::NumberOutOfRange);
-    }
-    Ok((&input[end..], num))
-}
-
-// Entry-point: parse a complete descriptor template string.
-fn parse_descriptor_template(input: &str) -> Result<DescriptorTemplate, ParseError> {
-    let (rest, descriptor) = parse_descriptor(input, ParseContext::TopLevel, 0)?;
-    if rest.is_empty() {
-        Ok(descriptor)
-    } else {
-        Err(ParseError::TrailingInput)
-    }
-}
-
-// Parses a derivation-step number like "44" or "44'".
-fn parse_derivation_step_number(input: &str) -> ParseResult<'_, u32> {
-    let (rest, num) = parse_number_up_to(input, HARDENED_INDEX - 1)?;
-    if rest.starts_with('\'') {
-        Ok((&rest[1..], num + HARDENED_INDEX))
-    } else {
-        Ok((rest, num))
-    }
-}
-
-// Parses the derivation suffix: /** or /<num1;num2>/*
-fn parse_derivation_suffix(input: &str) -> ParseResult<'_, (u32, u32)> {
-    if !input.starts_with('/') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    let rest = &input[1..];
-
-    if rest.starts_with("**") {
-        Ok((&rest[2..], (0u32, 1u32)))
-    } else if rest.starts_with('<') {
-        let rest = &rest[1..];
-        let (rest, num1) = parse_derivation_step_number(rest)?;
-        if !rest.starts_with(';') {
-            return Err(ParseError::InvalidSyntax);
-        }
-        let (rest, num2) = parse_derivation_step_number(&rest[1..])?;
-        if !rest.starts_with(">/*") {
-            return Err(ParseError::InvalidSyntax);
-        }
-        Ok((&rest[3..], (num1, num2)))
-    } else {
-        Err(ParseError::InvalidSyntax)
-    }
-}
-
-// Parses a key expression: @N/** or @N/<num1;num2>/*
-// When the context allows musig, also accepts: musig(@N1,@N2,...)/** or musig(@N1,@N2,...)/<num1;num2>/*
-// musig() is only valid inside tr() (BIP-390).
-fn parse_key_expression(input: &str, ctx: ParseContext) -> ParseResult<'_, KeyExpression> {
-    if input.starts_with("musig(") {
-        if !ctx.musig_allowed() {
-            return Err(ParseError::InvalidScriptContext);
-        }
-        return parse_musig_key_expression(input);
-    }
-    if !input.starts_with('@') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    let (rest, key_index) = parse_number_up_to(&input[1..], u32::MAX)?;
-    let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
-
-    Ok((rest, KeyExpression::plain(key_index, num1, num2)))
-}
-
-// Parses a musig key expression: musig(@N1,@N2,...)/** or musig(@N1,@N2,...)/<num1;num2>/*
-// Per BIP-390, all participant key indices must be distinct.
-fn parse_musig_key_expression(input: &str) -> ParseResult<'_, KeyExpression> {
-    let mut rest = &input[6..]; // skip "musig("
-    let mut key_indices = Vec::new();
-    loop {
-        if !rest.starts_with('@') {
-            return Err(ParseError::InvalidSyntax);
-        }
-        let (r, idx) = parse_number_up_to(&rest[1..], u32::MAX)?;
-        if key_indices.contains(&idx) {
-            return Err(ParseError::InvalidKey);
-        }
-        key_indices.push(idx);
-        rest = r;
-        if rest.starts_with(',') {
-            rest = &rest[1..];
-        } else {
-            break;
-        }
-    }
-    if key_indices.len() < 2 {
-        return Err(ParseError::TooFewKeyExpressions);
-    }
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    rest = &rest[1..]; // skip ')'
-    let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
-
-    Ok((rest, KeyExpression::musig(key_indices, num1, num2)))
-}
-
-// Parses a descriptor, optionally preceded by a wrapper prefix like "asc:".
-//
-// `depth` is the current recursion depth; it is incremented on every call and
-// rejected if it exceeds [`MAX_PARSE_DEPTH`]. This bounds stack usage on
-// untrusted input that nests descriptors arbitrarily deeply (e.g.
-// `andor(0,0,andor(0,0,...))` or `tr(@0,{{{{...}}}})`). A chain of wrapper
-// letters like `aaaa:0` does not grow recursion depth because wrappers are
-// applied iteratively in this function, not by re-entry.
-fn parse_descriptor(
-    input: &str,
-    ctx: ParseContext,
-    depth: usize,
-) -> ParseResult<'_, DescriptorTemplate> {
-    if depth >= MAX_PARSE_DEPTH {
-        return Err(ParseError::NestingTooDeep);
-    }
-    let depth = depth + 1;
-
-    // A wrapper prefix is a run of ASCII alphabetic chars followed by ':'.
-    // Fragment keywords are always followed by '(' instead, so no ambiguity.
-    let alpha_end = input
-        .bytes()
-        .position(|b| !b.is_ascii_alphabetic())
-        .unwrap_or(input.len());
-    let (input, wrappers) = if alpha_end > 0 && input.as_bytes().get(alpha_end) == Some(&b':') {
-        let wrappers = &input[..alpha_end];
-        (&input[alpha_end + 1..], wrappers)
-    } else {
-        (input, "")
-    };
-
-    let (input, inner) = parse_inner_descriptor(input, ctx, depth)?;
-
-    // Apply wrappers in reverse character order (rightmost char = outermost wrapper)
-    let mut result = inner;
-    for wrapper in wrappers.chars().rev() {
-        result = match wrapper {
-            'a' => DescriptorTemplate::A(Box::new(result)),
-            's' => DescriptorTemplate::S(Box::new(result)),
-            'c' => DescriptorTemplate::C(Box::new(result)),
-            't' => DescriptorTemplate::T(Box::new(result)),
-            'd' => DescriptorTemplate::D(Box::new(result)),
-            'v' => DescriptorTemplate::V(Box::new(result)),
-            'j' => DescriptorTemplate::J(Box::new(result)),
-            'n' => DescriptorTemplate::N(Box::new(result)),
-            'l' => DescriptorTemplate::L(Box::new(result)),
-            'u' => DescriptorTemplate::U(Box::new(result)),
-            _ => return Err(ParseError::InvalidSyntax),
-        };
-    }
-    Ok((input, result))
-}
-
-fn parse_inner_descriptor(
-    input: &str,
-    ctx: ParseContext,
-    depth: usize,
-) -> ParseResult<'_, DescriptorTemplate> {
-    // Longer names checked before shorter to avoid premature prefix matches.
-    if input.starts_with("sortedmulti_a(") {
-        return parse_threshold_kp_fragment(
-            input,
-            "sortedmulti_a",
-            DescriptorTemplate::Sortedmulti_a,
-            ctx,
-            MAX_KEYS_MULTI_A,
-        );
-    }
-    if input.starts_with("sortedmulti(") {
-        return parse_threshold_kp_fragment(
-            input,
-            "sortedmulti",
-            DescriptorTemplate::Sortedmulti,
-            ctx,
-            MAX_KEYS_MULTI,
-        );
-    }
-    if input.starts_with("multi_a(") {
-        return parse_threshold_kp_fragment(
-            input,
-            "multi_a",
-            DescriptorTemplate::Multi_a,
-            ctx,
-            MAX_KEYS_MULTI_A,
-        );
-    }
-    if input.starts_with("multi(") {
-        return parse_threshold_kp_fragment(
-            input,
-            "multi",
-            DescriptorTemplate::Multi,
-            ctx,
-            MAX_KEYS_MULTI,
-        );
-    }
-    if input.starts_with("thresh(") {
-        return parse_thresh(input, ctx, depth);
-    }
-    if input.starts_with("wsh(") {
-        if !ctx.wsh_allowed() {
-            return Err(ParseError::InvalidScriptContext);
-        }
-        let inner_ctx = match ctx {
-            ParseContext::TopLevel => ParseContext::Segwit,
-            ParseContext::Legacy => ParseContext::WrappedSegwit,
-            // `wsh_allowed` returns true only for `TopLevel`/`Legacy`; if a new
-            // `ParseContext` variant is added in the future, default to rejecting
-            // rather than panicking on hostile input.
-            _ => return Err(ParseError::InvalidScriptContext),
-        };
-
-        let (rest, [script]) = parse_n_subscripts(&input[4..], inner_ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::Wsh(Box::new(script))));
-    }
-    if input.starts_with("sh(") {
-        if !ctx.sh_allowed() {
-            return Err(ParseError::InvalidScriptContext);
-        }
-        let (rest, [script]) = parse_n_subscripts(&input[3..], ParseContext::Legacy, depth)?;
-        return Ok((rest, DescriptorTemplate::Sh(Box::new(script))));
-    }
-    if input.starts_with("wpkh(") {
-        if !ctx.wpkh_allowed() {
-            return Err(ParseError::InvalidScriptContext);
-        }
-        return parse_kp_fragment(input, "wpkh", DescriptorTemplate::Wpkh, ctx);
-    }
-    if input.starts_with("pkh(") {
-        return parse_kp_fragment(input, "pkh", DescriptorTemplate::Pkh, ctx);
-    }
-    if input.starts_with("tr(") {
-        if !ctx.tr_allowed() {
-            return Err(ParseError::InvalidScriptContext);
-        }
-        return parse_tr(input, depth);
-    }
-    if input.starts_with("pk_k(") {
-        return parse_kp_fragment(input, "pk_k", DescriptorTemplate::Pk_k, ctx);
-    }
-    if input.starts_with("pk_h(") {
-        return parse_kp_fragment(input, "pk_h", DescriptorTemplate::Pk_h, ctx);
-    }
-    if input.starts_with("pk(") {
-        return parse_kp_fragment(input, "pk", DescriptorTemplate::Pk, ctx);
-    }
-    if input.starts_with("older(") {
-        return parse_num_fragment(input, "older", MAX_OLDER_AFTER, DescriptorTemplate::Older);
-    }
-    if input.starts_with("after(") {
-        return parse_num_fragment(input, "after", MAX_OLDER_AFTER, DescriptorTemplate::After);
-    }
-    if input.starts_with("sha256(") {
-        return parse_hex32_fragment(input, "sha256", DescriptorTemplate::Sha256);
-    }
-    if input.starts_with("hash256(") {
-        return parse_hex32_fragment(input, "hash256", DescriptorTemplate::Hash256);
-    }
-    if input.starts_with("ripemd160(") {
-        return parse_hex20_fragment(input, "ripemd160", DescriptorTemplate::Ripemd160);
-    }
-    if input.starts_with("hash160(") {
-        return parse_hex20_fragment(input, "hash160", DescriptorTemplate::Hash160);
-    }
-    if input.starts_with("andor(") {
-        let (rest, [x, y, z]) = parse_n_subscripts(&input[6..], ctx, depth)?;
-        return Ok((
-            rest,
-            DescriptorTemplate::Andor(Box::new(x), Box::new(y), Box::new(z)),
-        ));
-    }
-    if input.starts_with("and_b(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[6..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::And_b(Box::new(x), Box::new(y))));
-    }
-    if input.starts_with("and_v(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[6..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::And_v(Box::new(x), Box::new(y))));
-    }
-    if input.starts_with("and_n(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[6..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::And_n(Box::new(x), Box::new(y))));
-    }
-    if input.starts_with("or_b(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[5..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::Or_b(Box::new(x), Box::new(y))));
-    }
-    if input.starts_with("or_c(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[5..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::Or_c(Box::new(x), Box::new(y))));
-    }
-    if input.starts_with("or_d(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[5..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::Or_d(Box::new(x), Box::new(y))));
-    }
-    if input.starts_with("or_i(") {
-        let (rest, [x, y]) = parse_n_subscripts(&input[5..], ctx, depth)?;
-        return Ok((rest, DescriptorTemplate::Or_i(Box::new(x), Box::new(y))));
-    }
-    // Simple terminals: bare "0" and "1"
-    if input.starts_with('0') {
-        return Ok((&input[1..], DescriptorTemplate::Zero));
-    }
-    if input.starts_with('1') {
-        return Ok((&input[1..], DescriptorTemplate::One));
-    }
-    Err(ParseError::UnrecognizedFragment)
-}
-
-// Parses a named fragment that wraps a single key expression: name(@...)
-fn parse_kp_fragment<'a>(
-    input: &'a str,
-    name: &str,
-    constructor: fn(KeyExpression) -> DescriptorTemplate,
-    ctx: ParseContext,
-) -> ParseResult<'a, DescriptorTemplate> {
-    let rest = &input[name.len()..]; // caller already checked starts_with(name)
-    let (rest, kp) = parse_key_expression(&rest[1..], ctx)?; // skip '('
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], constructor(kp)))
-}
-
-// Parses "name(n)" where n is a number <= max.
-fn parse_num_fragment<'a>(
-    input: &'a str,
-    name: &str,
-    max: u32,
-    constructor: fn(u32) -> DescriptorTemplate,
-) -> ParseResult<'a, DescriptorTemplate> {
-    let rest = &input[name.len()..]; // caller already checked starts_with(name)
-    let (rest, num) = parse_number_up_to(&rest[1..], max)?; // skip '('
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], constructor(num)))
-}
-
-// Parses "name(<40 hex chars>)".
-fn parse_hex20_fragment<'a>(
-    input: &'a str,
-    name: &str,
-    constructor: fn([u8; 20]) -> DescriptorTemplate,
-) -> ParseResult<'a, DescriptorTemplate> {
-    let rest = &input[name.len() + 1..]; // skip name and '('
-    if rest.len() < 40 {
-        return Err(ParseError::InvalidLength);
-    }
-    let bytes = <[u8; 20]>::from_hex(&rest[..40]).map_err(|_| ParseError::InvalidHex)?;
-    let rest = &rest[40..];
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], constructor(bytes)))
-}
-
-// Parses "name(<64 hex chars>)".
-fn parse_hex32_fragment<'a>(
-    input: &'a str,
-    name: &str,
-    constructor: fn([u8; 32]) -> DescriptorTemplate,
-) -> ParseResult<'a, DescriptorTemplate> {
-    let rest = &input[name.len() + 1..]; // skip name and '('
-    if rest.len() < 64 {
-        return Err(ParseError::InvalidLength);
-    }
-    let bytes = <[u8; 32]>::from_hex(&rest[..64]).map_err(|_| ParseError::InvalidHex)?;
-    let rest = &rest[64..];
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], constructor(bytes)))
-}
-
-// Parses "name(threshold,<key1>,<key1>,...)".
-fn parse_threshold_kp_fragment<'a>(
-    input: &'a str,
-    name: &str,
-    constructor: fn(u32, Vec<KeyExpression>) -> DescriptorTemplate,
-    ctx: ParseContext,
-    max_keys: usize,
-) -> ParseResult<'a, DescriptorTemplate> {
-    let rest = &input[name.len() + 1..]; // skip name and '('
-    let (mut rest, threshold) = parse_number_up_to(rest, u32::MAX)?;
-    let mut keys: Vec<KeyExpression> = Vec::new();
-    loop {
-        if !rest.starts_with(',') {
-            break;
-        }
-        if keys.len() >= max_keys {
-            return Err(ParseError::TooManyKeys);
-        }
-        match parse_key_expression(&rest[1..], ctx) {
-            Ok((r, kp)) => {
-                keys.push(kp);
-                rest = r;
-            }
-            Err(ParseError::InvalidScriptContext) => return Err(ParseError::InvalidScriptContext),
-            Err(_) => break,
-        }
-    }
-    if keys.len() < 2 {
-        return Err(ParseError::TooFewKeyExpressions);
-    }
-    if threshold == 0 || (threshold as usize) > keys.len() {
-        return Err(ParseError::InvalidMultisigQuorum);
-    }
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], constructor(threshold, keys)))
-}
-
-// Parses exactly `N` comma-separated sub-descriptors followed by ')'.
-// Called after the opening '(' of the enclosing fragment has been consumed.
-fn parse_n_subscripts<const N: usize>(
-    input: &str,
-    ctx: ParseContext,
-    depth: usize,
-) -> ParseResult<'_, [DescriptorTemplate; N]> {
-    let mut rest = input;
-    let mut scripts: Vec<DescriptorTemplate> = Vec::with_capacity(N);
-    for i in 0..N {
-        let (r, desc) = parse_descriptor(rest, ctx, depth)?;
-        scripts.push(desc);
-        rest = r;
-        if i + 1 < N {
-            if !rest.starts_with(',') {
-                return Err(ParseError::InvalidSyntax);
-            }
-            rest = &rest[1..];
-        }
-    }
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    let array: [DescriptorTemplate; N] = scripts
-        .try_into()
-        .ok()
-        .expect("loop pushed exactly N elements");
-    Ok((&rest[1..], array))
-}
-
-#[cfg(test)]
-fn parse_wsh(input: &str) -> ParseResult<'_, DescriptorTemplate> {
-    if !input.starts_with("wsh(") {
-        return Err(ParseError::InvalidSyntax);
-    }
-    let (rest, [script]) = parse_n_subscripts(&input[4..], ParseContext::Segwit, 0)?;
-    Ok((rest, DescriptorTemplate::Wsh(Box::new(script))))
-}
-
-#[cfg(test)]
-fn parse_sortedmulti(input: &str) -> ParseResult<'_, DescriptorTemplate> {
-    parse_threshold_kp_fragment(
-        input,
-        "sortedmulti",
-        DescriptorTemplate::Sortedmulti,
-        ParseContext::TopLevel,
-        MAX_KEYS_MULTI,
-    )
-}
-
-fn parse_thresh(
-    input: &str,
-    ctx: ParseContext,
-    depth: usize,
-) -> ParseResult<'_, DescriptorTemplate> {
-    // input starts with "thresh("
-    let (rest, k) = parse_number_up_to(&input[7..], u32::MAX)?;
-    if !rest.starts_with(',') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    // parse first script (mandatory)
-    let (rest, first) = parse_descriptor(&rest[1..], ctx, depth)?;
-    let mut scripts = vec![first];
-    let mut rest = rest;
-    loop {
-        if !rest.starts_with(',') {
-            break;
-        }
-        match parse_descriptor(&rest[1..], ctx, depth) {
-            Ok((r, desc)) => {
-                scripts.push(desc);
-                rest = r;
-            }
-            Err(ParseError::NestingTooDeep) => return Err(ParseError::NestingTooDeep),
-            Err(_) => break,
-        }
-    }
-    if k == 0 {
-        return Err(ParseError::InvalidMultisigQuorum);
-    }
-    if (k as usize) > scripts.len() {
-        return Err(ParseError::ThreshExceedsScripts);
-    }
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], DescriptorTemplate::Thresh(k, scripts)))
-}
-
-fn parse_tr(input: &str, depth: usize) -> ParseResult<'_, DescriptorTemplate> {
-    // input starts with "tr("
-    let (rest, key_placeholder) = parse_key_expression(&input[3..], ParseContext::Taproot)?;
-    let (rest, tree) = if rest.starts_with(',') {
-        let (rest, tree) = parse_tap_tree(&rest[1..], depth)?;
-        (rest, Some(tree))
-    } else {
-        (rest, None)
-    };
-    if !rest.starts_with(')') {
-        return Err(ParseError::InvalidSyntax);
-    }
-    Ok((&rest[1..], DescriptorTemplate::Tr(key_placeholder, tree)))
-}
-
-fn parse_tap_tree(input: &str, depth: usize) -> ParseResult<'_, TapTree> {
-    if depth >= MAX_PARSE_DEPTH {
-        return Err(ParseError::NestingTooDeep);
-    }
-    let depth = depth + 1;
-    if input.starts_with('{') {
-        let (rest, left) = parse_tap_tree(&input[1..], depth)?;
-        if !rest.starts_with(',') {
-            return Err(ParseError::InvalidSyntax);
-        }
-        let (rest, right) = parse_tap_tree(&rest[1..], depth)?;
-        if !rest.starts_with('}') {
-            return Err(ParseError::InvalidSyntax);
-        }
-        Ok((&rest[1..], TapTree::Branch(Box::new(left), Box::new(right))))
-    } else {
-        let (rest, desc) = parse_descriptor(input, ParseContext::Taproot, depth)?;
-        Ok((rest, TapTree::Script(Box::new(desc))))
-    }
-}
-
 impl FromStr for DescriptorTemplate {
     type Err = ParseError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        parse_descriptor_template(input)
+        let mut a = arena::VecArena::new();
+        let root = parser::parse_descriptor_template(input, &mut a)?;
+        Ok(arena_to_owned(&a, root))
     }
 }
+
+/// Materialize the owned [`DescriptorTemplate`] enum from a parsed arena.
+///
+/// This bridge keeps the historical owned-AST consumers working while the
+/// parser builds the flat arena representation. It is removed once all
+/// consumers operate directly on arena cursors.
+fn arena_to_owned(arena: &arena::VecArena, root: arena::NodeId) -> DescriptorTemplate {
+    node_to_owned(arena::Cursor::new(arena, root))
+}
+
+fn node_to_owned<A: arena::ArenaRead>(cur: arena::Cursor<'_, A>) -> DescriptorTemplate {
+    use arena::DescriptorNode as DN;
+    // Peel a linear wrapper spine iteratively so a long wrapper chain (e.g.
+    // `jjjj…:0`) doesn't recurse once per wrapper. Combinator/tap nesting is
+    // bounded by the parser depth limit, so `build_owned`'s recursion is bounded.
+    let mut wraps: Vec<fn(Box<DescriptorTemplate>) -> DescriptorTemplate> = Vec::new();
+    let mut cur = cur;
+    loop {
+        let (ctor, child): (fn(Box<DescriptorTemplate>) -> DescriptorTemplate, _) = match cur.view()
+        {
+            DN::A(c) => (DescriptorTemplate::A, c),
+            DN::S(c) => (DescriptorTemplate::S, c),
+            DN::C(c) => (DescriptorTemplate::C, c),
+            DN::T(c) => (DescriptorTemplate::T, c),
+            DN::D(c) => (DescriptorTemplate::D, c),
+            DN::V(c) => (DescriptorTemplate::V, c),
+            DN::J(c) => (DescriptorTemplate::J, c),
+            DN::N(c) => (DescriptorTemplate::N, c),
+            DN::L(c) => (DescriptorTemplate::L, c),
+            DN::U(c) => (DescriptorTemplate::U, c),
+            view => {
+                let mut result = build_owned(view);
+                while let Some(w) = wraps.pop() {
+                    result = w(Box::new(result));
+                }
+                return result;
+            }
+        };
+        wraps.push(ctor);
+        cur = child;
+    }
+}
+
+fn build_owned<A: arena::ArenaRead>(view: arena::DescriptorNode<'_, A>) -> DescriptorTemplate {
+    use arena::DescriptorNode as DN;
+    use DescriptorTemplate as DT;
+    match view {
+        DN::Sh(c) => DT::Sh(Box::new(node_to_owned(c))),
+        DN::Wsh(c) => DT::Wsh(Box::new(node_to_owned(c))),
+        DN::A(c) => DT::A(Box::new(node_to_owned(c))),
+        DN::S(c) => DT::S(Box::new(node_to_owned(c))),
+        DN::C(c) => DT::C(Box::new(node_to_owned(c))),
+        DN::T(c) => DT::T(Box::new(node_to_owned(c))),
+        DN::D(c) => DT::D(Box::new(node_to_owned(c))),
+        DN::V(c) => DT::V(Box::new(node_to_owned(c))),
+        DN::J(c) => DT::J(Box::new(node_to_owned(c))),
+        DN::N(c) => DT::N(Box::new(node_to_owned(c))),
+        DN::L(c) => DT::L(Box::new(node_to_owned(c))),
+        DN::U(c) => DT::U(Box::new(node_to_owned(c))),
+        DN::Pkh(kv) => DT::Pkh(keyview_to_owned(kv)),
+        DN::Wpkh(kv) => DT::Wpkh(keyview_to_owned(kv)),
+        DN::Pk(kv) => DT::Pk(keyview_to_owned(kv)),
+        DN::PkK(kv) => DT::Pk_k(keyview_to_owned(kv)),
+        DN::PkH(kv) => DT::Pk_h(keyview_to_owned(kv)),
+        DN::Tr(kv, tree) => DT::Tr(keyview_to_owned(kv), tree.map(taptree_to_owned)),
+        DN::Zero => DT::Zero,
+        DN::One => DT::One,
+        DN::Older(n) => DT::Older(n),
+        DN::After(n) => DT::After(n),
+        DN::Sha256(b) => DT::Sha256(b.try_into().expect("sha256 fragment is 32 bytes")),
+        DN::Hash256(b) => DT::Hash256(b.try_into().expect("hash256 fragment is 32 bytes")),
+        DN::Ripemd160(b) => DT::Ripemd160(b.try_into().expect("ripemd160 fragment is 20 bytes")),
+        DN::Hash160(b) => DT::Hash160(b.try_into().expect("hash160 fragment is 20 bytes")),
+        DN::Andor(x, y, z) => DT::Andor(
+            Box::new(node_to_owned(x)),
+            Box::new(node_to_owned(y)),
+            Box::new(node_to_owned(z)),
+        ),
+        DN::AndV(x, y) => DT::And_v(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::AndB(x, y) => DT::And_b(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::AndN(x, y) => DT::And_n(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::OrB(x, y) => DT::Or_b(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::OrC(x, y) => DT::Or_c(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::OrD(x, y) => DT::Or_d(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::OrI(x, y) => DT::Or_i(Box::new(node_to_owned(x)), Box::new(node_to_owned(y))),
+        DN::Thresh(k, list) => DT::Thresh(k, list.iter().map(node_to_owned).collect()),
+        DN::Multi(k, keys) => DT::Multi(k, keys.iter().map(keyview_to_owned).collect()),
+        DN::MultiA(k, keys) => DT::Multi_a(k, keys.iter().map(keyview_to_owned).collect()),
+        DN::Sortedmulti(k, keys) => DT::Sortedmulti(k, keys.iter().map(keyview_to_owned).collect()),
+        DN::SortedmultiA(k, keys) => {
+            DT::Sortedmulti_a(k, keys.iter().map(keyview_to_owned).collect())
+        }
+        DN::TapNode(_) => unreachable!("tap-tree node reached via node_to_owned"),
+    }
+}
+
+fn keyview_to_owned<A: arena::ArenaRead>(kv: arena::KeyView<'_, A>) -> KeyExpression {
+    if let Some(idx) = kv.plain_key_index() {
+        KeyExpression::plain(idx, kv.num1(), kv.num2())
+    } else {
+        let members = kv.musig_key_indices().expect("musig key").to_vec();
+        KeyExpression::musig(members, kv.num1(), kv.num2())
+    }
+}
+
+fn taptree_to_owned<A: arena::ArenaRead>(tc: arena::TapCursor<'_, A>) -> TapTree {
+    if let Some(script) = tc.leaf_script() {
+        TapTree::Script(Box::new(node_to_owned(script)))
+    } else {
+        let (l, r) = tc.branch().expect("tap node is leaf or branch");
+        TapTree::Branch(
+            Box::new(taptree_to_owned(l)),
+            Box::new(taptree_to_owned(r)),
+        )
+    }
+}
+
+// Test-only thin wrappers exposing the historical owned-returning parser API,
+// backed by the arena parser + `arena_to_owned`, so the existing unit tests
+// keep exercising the same surface.
+#[cfg(test)]
+pub(crate) use parser::parse_derivation_step_number;
+
+#[cfg(test)]
+fn parse_descriptor_template(input: &str) -> Result<DescriptorTemplate, ParseError> {
+    let mut a = arena::VecArena::new();
+    let root = parser::parse_descriptor_template(input, &mut a)?;
+    Ok(arena_to_owned(&a, root))
+}
+
+#[cfg(test)]
+fn parse_descriptor(
+    input: &str,
+    ctx: ParseContext,
+    depth: usize,
+) -> Result<(&str, DescriptorTemplate), ParseError> {
+    let mut a = arena::VecArena::new();
+    let (rest, id) = parser::parse_descriptor(input, ctx, depth, &mut a)?;
+    Ok((rest, arena_to_owned(&a, id)))
+}
+
+#[cfg(test)]
+fn parse_thresh(
+    input: &str,
+    ctx: ParseContext,
+    depth: usize,
+) -> Result<(&str, DescriptorTemplate), ParseError> {
+    let mut a = arena::VecArena::new();
+    let (rest, id) = parser::parse_thresh(input, ctx, depth, &mut a)?;
+    Ok((rest, arena_to_owned(&a, id)))
+}
+
+#[cfg(test)]
+fn parse_tr(input: &str, depth: usize) -> Result<(&str, DescriptorTemplate), ParseError> {
+    let mut a = arena::VecArena::new();
+    let (rest, id) = parser::parse_tr(input, depth, &mut a)?;
+    Ok((rest, arena_to_owned(&a, id)))
+}
+
+#[cfg(test)]
+fn parse_key_expression(
+    input: &str,
+    ctx: ParseContext,
+) -> Result<(&str, KeyExpression), ParseError> {
+    let mut a = arena::VecArena::new();
+    let (rest, kid) = parser::parse_key_expression(input, ctx, &mut a)?;
+    Ok((rest, keyview_to_owned(arena::key_view(&a, kid))))
+}
+
+#[cfg(test)]
+fn parse_wsh(input: &str) -> Result<(&str, DescriptorTemplate), ParseError> {
+    use arena::ArenaStore;
+    if !input.starts_with("wsh(") {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let mut a = arena::VecArena::new();
+    let (rest, [script]) =
+        parser::parse_n_subscripts::<1, _>(&input[4..], ParseContext::Segwit, 0, &mut a)?;
+    let wsh = a
+        .push_node(arena::Node::with_a(arena::NodeTag::Wsh, script.0))
+        .map_err(|_| ParseError::ArenaFull)?;
+    Ok((rest, arena_to_owned(&a, wsh)))
+}
+
+#[cfg(test)]
+fn parse_sortedmulti(input: &str) -> Result<(&str, DescriptorTemplate), ParseError> {
+    let mut a = arena::VecArena::new();
+    let (rest, id) = parser::parse_threshold_kp_fragment(
+        input,
+        "sortedmulti",
+        arena::NodeTag::Sortedmulti,
+        ParseContext::TopLevel,
+        MAX_KEYS_MULTI,
+        &mut a,
+    )?;
+    Ok((rest, arena_to_owned(&a, id)))
+}
+
 
 fn write_display_wrapper(
     f: &mut core::fmt::Formatter<'_>,

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -2043,6 +2043,91 @@ mod tests {
     }
 
     #[test]
+    fn test_slice_arena_matches_vec_arena() {
+        // The no-alloc SliceArena backing must produce identical confusion
+        // scores and cleartext to the alloc VecArena backing.
+        let cases = vec![
+            "pkh(@0/**)",
+            "wsh(multi(2,@0/**,@1/**,@2/**))",
+            "wsh(multi(3,@0/**,@1/**,@2/**))",
+            "sh(wsh(sortedmulti(2,@0/**,@1/**)))",
+            "tr(@0/**)",
+            "tr(@0/**,{pk(@1/**),{pk(@2/**),pk(@3/**)}})",
+            "tr(musig(@0,@1)/**,{pk(@2/**),multi_a(2,@3/**,@4/**)})",
+            "tr(@0/**,and_v(v:pk(@1/**),older(144)))",
+            "wsh(or_i(and_v(v:pkh(@4/<3;7>/*),older(65535)),or_d(multi(2,@0/**,@3/**),and_v(v:thresh(1,pkh(@5/<99;101>/*),a:pkh(@1/**)),older(64231)))))",
+        ];
+        for s in cases {
+            // VecArena (alloc) reference.
+            let mut va = arena::VecArena::new();
+            let vroot = parser::parse_descriptor_template(s, &mut va).unwrap();
+            let vc = arena::Cursor::new(&va, vroot);
+            let mut vsc = vec![0u32; vc.expanded_key_occurrences()];
+            let v_score = vc.confusion_score(&mut vsc);
+            let mut vcanon = vec![arena::KeyExprRec::plain(0, 0, 1); vc.placeholder_count()];
+            let mut vleaf = vec![0u32; vc.tapleaf_count()];
+            let mut vsink = arena::VecLineSink::new();
+            let v_hct = vc.to_cleartext(&mut vsink, &mut vcanon, &mut vleaf);
+            let v_lines = vsink.into_lines();
+
+            // SliceArena (no-alloc backing) over caller-provided slices.
+            let mut nodes = vec![arena::Node::new(arena::NodeTag::Zero); 1024];
+            let mut keys = vec![arena::KeyExprRec::plain(0, 0, 1); 1024];
+            let mut links = vec![arena::Link { val: 0, next: 0 }; 1024];
+            let mut members = vec![0u32; 1024];
+            let mut bytes = vec![0u8; 1024];
+            let mut sa =
+                arena::SliceArena::new(&mut nodes, &mut keys, &mut links, &mut members, &mut bytes);
+            let sroot = parser::parse_descriptor_template(s, &mut sa).unwrap();
+            let sc = arena::Cursor::new(&sa, sroot);
+            let mut ssc = vec![0u32; sc.expanded_key_occurrences()];
+            let s_score = sc.confusion_score(&mut ssc);
+            let mut scanon = vec![arena::KeyExprRec::plain(0, 0, 1); sc.placeholder_count()];
+            let mut sleaf = vec![0u32; sc.tapleaf_count()];
+            let mut ssink = arena::VecLineSink::new();
+            let s_hct = sc.to_cleartext(&mut ssink, &mut scanon, &mut sleaf);
+            let s_lines = ssink.into_lines();
+
+            assert_eq!(v_score, s_score, "confusion score backing mismatch for {:?}", s);
+            assert_eq!(v_lines, s_lines, "cleartext lines backing mismatch for {:?}", s);
+            assert_eq!(v_hct, s_hct, "has_cleartext backing mismatch for {:?}", s);
+        }
+    }
+
+    #[test]
+    fn test_buf_line_sink_matches_vec_sink() {
+        let s = "tr(@0/**,{pk(@1/**),and_v(v:pk(@2/**),older(144))})";
+        let mut a = arena::VecArena::new();
+        let root = parser::parse_descriptor_template(s, &mut a).unwrap();
+        let cur = arena::Cursor::new(&a, root);
+
+        let mut canon = vec![arena::KeyExprRec::plain(0, 0, 1); cur.placeholder_count()];
+        let mut leaf = vec![0u32; cur.tapleaf_count()];
+        let mut vsink = arena::VecLineSink::new();
+        cur.to_cleartext(&mut vsink, &mut canon, &mut leaf);
+        let v_lines = vsink.into_lines();
+
+        let mut buf = vec![0u8; 4096];
+        let mut spans = vec![arena::LineSpan::default(); 64];
+        let mut canon2 = vec![arena::KeyExprRec::plain(0, 0, 1); cur.placeholder_count()];
+        let mut leaf2 = vec![0u32; cur.tapleaf_count()];
+        let n = {
+            let mut bsink = arena::BufLineSink::new(&mut buf, &mut spans);
+            cur.to_cleartext(&mut bsink, &mut canon2, &mut leaf2);
+            assert!(!bsink.overflowed());
+            bsink.line_count()
+        };
+        let buf_lines: Vec<String> = (0..n)
+            .map(|i| {
+                let sp = spans[i];
+                String::from_utf8(buf[sp.offset as usize..(sp.offset + sp.len) as usize].to_vec())
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(buf_lines, v_lines);
+    }
+
+    #[test]
     fn test_cursor_segwit_version_matches_owned() {
         // get_segwit_version only inspects the top-level template, so an empty
         // key-information list is fine here.

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -137,24 +137,28 @@ impl ParseContext {
     }
 }
 
+#[cfg(feature = "wallet-policy")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct KeyOrigin {
     pub fingerprint: u32,
     pub derivation_path: Vec<ChildNumber>,
 }
 
+#[cfg(feature = "wallet-policy")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct KeyInformation {
     pub pubkey: Xpub,
     pub origin_info: Option<KeyOrigin>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum KeyExpressionType {
     PlainKey(u32),
     Musig(Vec<u32>),
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct KeyExpression {
     pub key_type: KeyExpressionType,
@@ -162,6 +166,7 @@ pub struct KeyExpression {
     pub num2: u32,
 }
 
+#[cfg(feature = "alloc")]
 impl KeyExpression {
     pub fn plain(key_index: u32, num1: u32, num2: u32) -> Self {
         KeyExpression {
@@ -206,6 +211,7 @@ impl KeyExpression {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum DescriptorTemplate {

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 mod arena;
 mod cleartext;
+pub mod embedded;
 mod parser;
 mod time;
 
@@ -45,11 +46,14 @@ pub(crate) const MAX_KEYS_MULTI_A: usize = 999;
 pub(crate) const MAX_PARSE_DEPTH: usize = 64;
 // Maximum byte length of a serialized descriptor template accepted by
 // `WalletPolicy::deserialize`. Practical policies are far below this.
+#[cfg(feature = "wallet-policy")]
 const MAX_SERIALIZED_DESCRIPTORTEMPLATE_LEN: usize = 4096;
 // Maximum number of key information entries accepted by `WalletPolicy::deserialize`.
 // Matches the largest multi-key fragment we can produce (`multi_a`/`sortedmulti_a`).
+#[cfg(feature = "wallet-policy")]
 const MAX_SERIALIZED_KEY_COUNT: usize = MAX_KEYS_MULTI_A;
 // Maximum length of a serialized BIP-32 derivation path.
+#[cfg(feature = "wallet-policy")]
 const MAX_BIP32_DERIVATION_PATH_LEN: usize = 32;
 
 /// Error type for descriptor template / wallet policy parsing and serialization.
@@ -2091,6 +2095,37 @@ mod tests {
             assert_eq!(v_score, s_score, "confusion score backing mismatch for {:?}", s);
             assert_eq!(v_lines, s_lines, "cleartext lines backing mismatch for {:?}", s);
             assert_eq!(v_hct, s_hct, "has_cleartext backing mismatch for {:?}", s);
+        }
+    }
+
+    #[test]
+    fn test_embedded_public_api() {
+        // Drive the public no-alloc API: measure -> size pools -> parse ->
+        // confusion_score, and check it matches the owned implementation.
+        let cases = vec![
+            "wsh(multi(2,@0/**,@1/**,@2/**))",
+            "tr(musig(@0,@1)/**,{pk(@2/**),multi_a(2,@3/**,@4/**)})",
+            "tr(@0/**,and_v(v:pk(@1/**),older(144)))",
+            "wsh(thresh(2,pk(@0/**),s:pk(@1/**),sln:older(10)))",
+        ];
+        for s in cases {
+            let c = crate::embedded::measure(s).unwrap();
+            let mut nodes = vec![arena::Node::new(arena::NodeTag::Zero); c.nodes as usize];
+            let mut keys = vec![arena::KeyExprRec::plain(0, 0, 1); c.keys as usize];
+            let mut links = vec![arena::Link { val: 0, next: 0 }; c.links as usize];
+            let mut members = vec![0u32; c.members as usize];
+            let mut bytes = vec![0u8; c.bytes as usize];
+            let mut sa =
+                arena::SliceArena::new(&mut nodes, &mut keys, &mut links, &mut members, &mut bytes);
+            let root = crate::embedded::parse(s, &mut sa).unwrap();
+            let cur = arena::Cursor::new(&sa, root);
+            let mut scratch = vec![0u32; cur.expanded_key_occurrences()];
+            assert_eq!(
+                cur.confusion_score(&mut scratch),
+                DescriptorTemplate::from_str(s).unwrap().confusion_score(),
+                "embedded confusion score mismatch for {:?}",
+                s
+            );
         }
     }
 

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 // - add malleability checks
 // - add stack limits and other safety checks
 
+mod arena;
 mod cleartext;
 mod time;
 

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 // - add malleability checks
 // - add stack limits and other safety checks
 
-mod arena;
+pub mod arena;
 mod cleartext;
 pub mod embedded;
 mod parser;
@@ -1028,6 +1028,11 @@ impl core::fmt::Display for DescriptorTemplate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg(feature = "wallet-policy")]
 pub struct WalletPolicy {
+    // Flat arena form of the parsed template + its root, used by the cursor
+    // (no-alloc-shaped) computation path. The owned `descriptor_template` is
+    // kept during the migration of consumers to cursors.
+    arena: arena::VecArena,
+    root: arena::NodeId,
     descriptor_template: DescriptorTemplate,
     key_information: Vec<KeyInformation>,
     descriptor_template_raw: String,
@@ -1052,9 +1057,13 @@ impl WalletPolicy {
         descriptor_template_str: &str,
         key_information: Vec<KeyInformation>,
     ) -> Result<Self, ParseError> {
-        let descriptor_template = DescriptorTemplate::from_str(descriptor_template_str)?;
+        let mut arena = arena::VecArena::new();
+        let root = parser::parse_descriptor_template(descriptor_template_str, &mut arena)?;
+        let descriptor_template = arena_to_owned(&arena, root);
 
         Ok(Self {
+            arena,
+            root,
             descriptor_template,
             key_information,
             descriptor_template_raw: String::from(descriptor_template_str),
@@ -1064,6 +1073,13 @@ impl WalletPolicy {
     /// The parsed descriptor template AST.
     pub fn descriptor_template(&self) -> &DescriptorTemplate {
         &self.descriptor_template
+    }
+
+    /// A cursor over the flat (arena) form of the parsed template — the
+    /// representation the cursor-based computation (and eventually the
+    /// consensus consumers) operate on.
+    pub fn descriptor_cursor(&self) -> arena::Cursor<'_, arena::VecArena> {
+        arena::Cursor::new(&self.arena, self.root)
     }
 
     /// The list of key information entries referenced by the template's

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -263,11 +263,13 @@ pub enum DescriptorTemplate {
     U(Box<DescriptorTemplate>),
 }
 
+#[cfg(feature = "alloc")]
 pub struct DescriptorTemplateIter<'a> {
     fragments: Vec<(&'a DescriptorTemplate, Option<&'a DescriptorTemplate>)>, // Store DescriptorTemplate and its associated leaf context
     placeholders: Vec<(&'a KeyExpression, Option<&'a DescriptorTemplate>)>, // Placeholders also carry the leaf context
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<&'a DescriptorTemplate> for DescriptorTemplateIter<'a> {
     fn from(desc: &'a DescriptorTemplate) -> Self {
         DescriptorTemplateIter {
@@ -277,6 +279,7 @@ impl<'a> From<&'a DescriptorTemplate> for DescriptorTemplateIter<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> Iterator for DescriptorTemplateIter<'a> {
     type Item = (&'a KeyExpression, Option<&'a DescriptorTemplate>);
 
@@ -386,12 +389,14 @@ impl<'a> Iterator for DescriptorTemplateIter<'a> {
 ///
 /// Uses raw pointers internally to satisfy Rust's aliasing rules while still
 /// providing a safe interface through the `placeholders_mut` method.
+#[cfg(feature = "alloc")]
 pub struct DescriptorTemplateIterMut<'a> {
     fragments: Vec<*mut DescriptorTemplate>,
     placeholders: Vec<*mut KeyExpression>,
     _marker: core::marker::PhantomData<&'a mut DescriptorTemplate>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> Iterator for DescriptorTemplateIterMut<'a> {
     type Item = &'a mut KeyExpression;
 
@@ -512,6 +517,7 @@ impl<'a> Iterator for DescriptorTemplateIterMut<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl DescriptorTemplate {
     /// Determines if root fragment is a wrapper.
     fn is_wrapper(&self) -> bool {
@@ -542,27 +548,32 @@ impl DescriptorTemplate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "alloc")]
 pub enum TapTree {
     Script(Box<DescriptorTemplate>),
     Branch(Box<TapTree>, Box<TapTree>),
 }
 
+#[cfg(feature = "alloc")]
 impl TapTree {
     pub fn tapleaves(&self) -> TapleavesIter<'_> {
         TapleavesIter::new(self)
     }
 }
 
+#[cfg(feature = "alloc")]
 pub struct TapleavesIter<'a> {
     stack: Vec<&'a TapTree>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> TapleavesIter<'a> {
     fn new(root: &'a TapTree) -> Self {
         TapleavesIter { stack: vec![root] }
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> Iterator for TapleavesIter<'a> {
     type Item = &'a DescriptorTemplate;
 
@@ -580,6 +591,7 @@ impl<'a> Iterator for TapleavesIter<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl core::fmt::Display for TapTree {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -589,6 +601,7 @@ impl core::fmt::Display for TapTree {
     }
 }
 
+#[cfg(feature = "wallet-policy")]
 impl core::fmt::Display for KeyOrigin {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:08x}", self.fingerprint)?;
@@ -599,6 +612,7 @@ impl core::fmt::Display for KeyOrigin {
     }
 }
 
+#[cfg(feature = "wallet-policy")]
 impl core::convert::TryFrom<&str> for KeyOrigin {
     type Error = ParseError;
 
@@ -624,6 +638,7 @@ impl core::convert::TryFrom<&str> for KeyOrigin {
     }
 }
 
+#[cfg(feature = "wallet-policy")]
 impl core::fmt::Display for KeyInformation {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self.origin_info {
@@ -633,6 +648,7 @@ impl core::fmt::Display for KeyInformation {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl core::fmt::Display for KeyExpression {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self.key_type {
@@ -661,6 +677,7 @@ impl core::fmt::Display for KeyExpression {
     }
 }
 
+#[cfg(feature = "wallet-policy")]
 impl TryFrom<&str> for KeyInformation {
     type Error = ParseError;
 
@@ -682,6 +699,7 @@ impl TryFrom<&str> for KeyInformation {
     }
 }
 
+#[cfg(feature = "alloc")]
 pub trait ToDescriptor {
     fn to_descriptor(
         &self,
@@ -691,6 +709,7 @@ pub trait ToDescriptor {
     ) -> Result<String, ParseError>;
 }
 
+#[cfg(feature = "alloc")]
 impl FromStr for DescriptorTemplate {
     type Err = ParseError;
 
@@ -706,10 +725,12 @@ impl FromStr for DescriptorTemplate {
 /// This bridge keeps the historical owned-AST consumers working while the
 /// parser builds the flat arena representation. It is removed once all
 /// consumers operate directly on arena cursors.
+#[cfg(feature = "alloc")]
 fn arena_to_owned(arena: &arena::VecArena, root: arena::NodeId) -> DescriptorTemplate {
     node_to_owned(arena::Cursor::new(arena, root))
 }
 
+#[cfg(feature = "alloc")]
 fn node_to_owned<A: arena::ArenaRead>(cur: arena::Cursor<'_, A>) -> DescriptorTemplate {
     use arena::DescriptorNode as DN;
     // Peel a linear wrapper spine iteratively so a long wrapper chain (e.g.
@@ -743,6 +764,7 @@ fn node_to_owned<A: arena::ArenaRead>(cur: arena::Cursor<'_, A>) -> DescriptorTe
     }
 }
 
+#[cfg(feature = "alloc")]
 fn build_owned<A: arena::ArenaRead>(view: arena::DescriptorNode<'_, A>) -> DescriptorTemplate {
     use arena::DescriptorNode as DN;
     use DescriptorTemplate as DT;
@@ -796,6 +818,7 @@ fn build_owned<A: arena::ArenaRead>(view: arena::DescriptorNode<'_, A>) -> Descr
     }
 }
 
+#[cfg(feature = "alloc")]
 fn keyview_to_owned<A: arena::ArenaRead>(kv: arena::KeyView<'_, A>) -> KeyExpression {
     if let Some(idx) = kv.plain_key_index() {
         KeyExpression::plain(idx, kv.num1(), kv.num2())
@@ -805,6 +828,7 @@ fn keyview_to_owned<A: arena::ArenaRead>(kv: arena::KeyView<'_, A>) -> KeyExpres
     }
 }
 
+#[cfg(feature = "alloc")]
 fn taptree_to_owned<A: arena::ArenaRead>(tc: arena::TapCursor<'_, A>) -> TapTree {
     if let Some(script) = tc.leaf_script() {
         TapTree::Script(Box::new(node_to_owned(script)))
@@ -899,6 +923,7 @@ fn parse_sortedmulti(input: &str) -> Result<(&str, DescriptorTemplate), ParseErr
 }
 
 
+#[cfg(feature = "alloc")]
 fn write_display_wrapper(
     f: &mut core::fmt::Formatter<'_>,
     ch: char,
@@ -911,6 +936,7 @@ fn write_display_wrapper(
     write!(f, "{}", inner)
 }
 
+#[cfg(feature = "alloc")]
 impl core::fmt::Display for DescriptorTemplate {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -996,6 +1022,7 @@ impl core::fmt::Display for DescriptorTemplate {
 /// parsed template cannot drift from the raw string used to compute the
 /// registration HMAC.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "wallet-policy")]
 pub struct WalletPolicy {
     descriptor_template: DescriptorTemplate,
     key_information: Vec<KeyInformation>,
@@ -1015,6 +1042,7 @@ impl SegwitVersion {
     }
 }
 
+#[cfg(feature = "wallet-policy")]
 impl WalletPolicy {
     pub fn new(
         descriptor_template_str: &str,
@@ -1178,6 +1206,7 @@ impl WalletPolicy {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn write_key_expression(
     w: &mut String,
     key_information: &[KeyInformation],
@@ -1212,6 +1241,7 @@ fn write_key_expression(
 }
 
 // Writes a comma-separated list of key expressions to a buffer.
+#[cfg(feature = "alloc")]
 fn write_key_expressions(
     w: &mut String,
     key_information: &[KeyInformation],
@@ -1229,6 +1259,7 @@ fn write_key_expressions(
 }
 
 // Writes a wrapper fragment to a buffer.
+#[cfg(feature = "alloc")]
 fn write_wrapper(
     w: &mut String,
     name: &str,
@@ -1244,6 +1275,7 @@ fn write_wrapper(
     inner.write_to(w, key_information, is_change, address_index)
 }
 
+#[cfg(feature = "alloc")]
 impl TapTree {
     fn write_to(
         &self,
@@ -1266,6 +1298,7 @@ impl TapTree {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl DescriptorTemplate {
     fn write_to(
         &self,
@@ -1470,6 +1503,7 @@ impl DescriptorTemplate {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToDescriptor for TapTree {
     fn to_descriptor(
         &self,
@@ -1483,6 +1517,7 @@ impl ToDescriptor for TapTree {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToDescriptor for DescriptorTemplate {
     fn to_descriptor(
         &self,

--- a/apps/bitcoin/bip388/src/lib.rs
+++ b/apps/bitcoin/bip388/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), no_std)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 // TODO:
@@ -14,13 +15,16 @@ mod time;
 
 pub use cleartext::*;
 
+#[cfg(feature = "alloc")]
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 #[cfg(test)]
 use alloc::{format, string::ToString};
 
+#[cfg(feature = "alloc")]
 use core::str::FromStr;
 
+#[cfg(feature = "wallet-policy")]
 use bitcoin::{
     bip32::{ChildNumber, Xpub},
     consensus::{encode, Decodable, Encodable},
@@ -1959,6 +1963,41 @@ mod tests {
                 "canonical mismatch for {:?}",
                 s
             );
+        }
+    }
+
+    #[test]
+    fn test_cursor_confusion_score_matches_owned() {
+        let cases = vec![
+            "pkh(@0/**)",
+            "wpkh(@0/**)",
+            "sh(wpkh(@0/**))",
+            "wsh(multi(2,@0/**,@1/**,@2/**))",
+            "wsh(multi(3,@0/**,@1/**,@2/**))",
+            "sh(wsh(sortedmulti(2,@0/**,@1/**)))",
+            "tr(@0/**)",
+            "tr(@0/**,pk(@1/**))",
+            "tr(@0/**,{pk(@1/**),pk(@2/**)})",
+            "tr(@0/**,{pk(@1/**),{pk(@2/**),pk(@3/**)}})",
+            "tr(musig(@0,@1)/**)",
+            "tr(musig(@0,@1)/**,{pk(@2/**),multi_a(2,@3/**,@4/**)})",
+            "tr(@0/**,{pk(@0/<2;3>/*),pk(@0/<4;5>/*)})",
+            "tr(@0/**,and_v(v:pk(@1/**),older(144)))",
+            "tr(@0/**,multi_a(2,@1/**,@2/**))",
+            "tr(@0/**,sortedmulti_a(1,@1/**,@2/**))",
+            "wsh(or_i(and_v(v:pkh(@4/<3;7>/*),older(65535)),or_d(multi(2,@0/**,@3/**),and_v(v:thresh(1,pkh(@5/<99;101>/*),a:pkh(@1/**)),older(64231)))))",
+        ];
+        for s in cases {
+            let owned = DescriptorTemplate::from_str(s).unwrap();
+            let expected = owned.confusion_score();
+
+            let mut a = arena::VecArena::new();
+            let root = parser::parse_descriptor_template(s, &mut a).unwrap();
+            let cur = arena::Cursor::new(&a, root);
+            let mut scratch = vec![0u32; cur.expanded_key_occurrences()];
+            let got = cur.confusion_score(&mut scratch);
+
+            assert_eq!(got, expected, "confusion score mismatch for {:?}", s);
         }
     }
 

--- a/apps/bitcoin/bip388/src/parser.rs
+++ b/apps/bitcoin/bip388/src/parser.rs
@@ -1,0 +1,611 @@
+//! Hand-rolled recursive-descent parser for BIP-388 descriptor *templates*.
+//!
+//! The parser builds directly into an [`ArenaStore`], returning arena ids, so
+//! the *same* parser serves both the `alloc` (`VecArena`) and the future
+//! no-alloc (`SliceArena`) backings. No `Box`/`Vec`/`String` is used here.
+
+use hex::FromHex;
+
+use crate::arena::{ArenaFull, ArenaStore, KeyExprRec, ListBuilder, Node, NodeId, NodeTag, NONE};
+use crate::{
+    ParseContext, ParseError, HARDENED_INDEX, MAX_KEYS_MULTI_A, MAX_OLDER_AFTER, MAX_PARSE_DEPTH,
+};
+
+/// Return type for all hand-rolled parser functions: (remaining_input, parsed_value)
+pub(crate) type ParseResult<'a, T> = Result<(&'a str, T), ParseError>;
+
+#[inline]
+fn full(_: ArenaFull) -> ParseError {
+    ParseError::ArenaFull
+}
+
+// ── Pure (allocation-free) scalar helpers ──────────────────────────────────
+
+/// Parses a decimal u32 (no leading zeros unless "0"), value <= max.
+pub(crate) fn parse_number_up_to(input: &str, max: u32) -> ParseResult<'_, u32> {
+    if input.is_empty() || !input.starts_with(|c: char| c.is_ascii_digit()) {
+        return Err(ParseError::InvalidSyntax);
+    }
+    // reject leading zeros on multi-digit numbers
+    if input.starts_with('0') && input.len() > 1 && input.as_bytes()[1].is_ascii_digit() {
+        return Err(ParseError::NumberOutOfRange);
+    }
+    let end = input
+        .bytes()
+        .position(|b| !b.is_ascii_digit())
+        .unwrap_or(input.len());
+    let num: u32 = input[..end]
+        .parse()
+        .map_err(|_| ParseError::NumberOutOfRange)?;
+    if num > max {
+        return Err(ParseError::NumberOutOfRange);
+    }
+    Ok((&input[end..], num))
+}
+
+/// Parses a derivation-step number like "44" or "44'".
+pub(crate) fn parse_derivation_step_number(input: &str) -> ParseResult<'_, u32> {
+    let (rest, num) = parse_number_up_to(input, HARDENED_INDEX - 1)?;
+    if rest.starts_with('\'') {
+        Ok((&rest[1..], num + HARDENED_INDEX))
+    } else {
+        Ok((rest, num))
+    }
+}
+
+/// Parses the derivation suffix: /** or /<num1;num2>/*
+pub(crate) fn parse_derivation_suffix(input: &str) -> ParseResult<'_, (u32, u32)> {
+    if !input.starts_with('/') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let rest = &input[1..];
+
+    if rest.starts_with("**") {
+        Ok((&rest[2..], (0u32, 1u32)))
+    } else if rest.starts_with('<') {
+        let rest = &rest[1..];
+        let (rest, num1) = parse_derivation_step_number(rest)?;
+        if !rest.starts_with(';') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        let (rest, num2) = parse_derivation_step_number(&rest[1..])?;
+        if !rest.starts_with(">/*") {
+            return Err(ParseError::InvalidSyntax);
+        }
+        Ok((&rest[3..], (num1, num2)))
+    } else {
+        Err(ParseError::InvalidSyntax)
+    }
+}
+
+// ── Key expressions ────────────────────────────────────────────────────────
+
+/// Parses a key expression `@N/...` or (in taproot context) `musig(@N1,@N2,...)/...`,
+/// allocating a [`KeyExprRec`] in the arena and returning its [`crate::arena::KeyId`].
+pub(crate) fn parse_key_expression<'a, A: ArenaStore>(
+    input: &'a str,
+    ctx: ParseContext,
+    arena: &mut A,
+) -> ParseResult<'a, crate::arena::KeyId> {
+    if input.starts_with("musig(") {
+        if !ctx.musig_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        return parse_musig_key_expression(input, arena);
+    }
+    if !input.starts_with('@') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let (rest, key_index) = parse_number_up_to(&input[1..], u32::MAX)?;
+    let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
+    let id = arena
+        .push_key(KeyExprRec::plain(key_index, num1, num2))
+        .map_err(full)?;
+    Ok((rest, id))
+}
+
+/// Parses `musig(@N1,@N2,...)/...`. Members are stored as a contiguous span in
+/// the `members` pool (no nested allocations interleave during the member loop).
+/// Per BIP-390, all participant key indices must be distinct.
+fn parse_musig_key_expression<'a, A: ArenaStore>(
+    input: &'a str,
+    arena: &mut A,
+) -> ParseResult<'a, crate::arena::KeyId> {
+    let mut rest = &input[6..]; // skip "musig("
+    let start = arena.members_begin();
+    let mut count = 0u32;
+    loop {
+        if !rest.starts_with('@') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        let (r, idx) = parse_number_up_to(&rest[1..], u32::MAX)?;
+        // distinctness against the members collected so far
+        let partial = arena.members_end(start);
+        if arena.members(partial).contains(&idx) {
+            return Err(ParseError::InvalidKey);
+        }
+        arena.members_push(idx).map_err(full)?;
+        count += 1;
+        rest = r;
+        if rest.starts_with(',') {
+            rest = &rest[1..];
+        } else {
+            break;
+        }
+    }
+    if count < 2 {
+        return Err(ParseError::TooFewKeyExpressions);
+    }
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    rest = &rest[1..]; // skip ')'
+    let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
+    let span = arena.members_end(start);
+    let id = arena.push_key(KeyExprRec::musig(span, num1, num2)).map_err(full)?;
+    Ok((rest, id))
+}
+
+// ── Descriptor fragments ───────────────────────────────────────────────────
+
+/// Entry point: parse a complete descriptor template string.
+pub(crate) fn parse_descriptor_template<A: ArenaStore>(
+    input: &str,
+    arena: &mut A,
+) -> Result<NodeId, ParseError> {
+    let (rest, root) = parse_descriptor(input, ParseContext::TopLevel, 0, arena)?;
+    if rest.is_empty() {
+        Ok(root)
+    } else {
+        Err(ParseError::TrailingInput)
+    }
+}
+
+/// Parses a descriptor, optionally preceded by a wrapper prefix like "asc:".
+pub(crate) fn parse_descriptor<'a, A: ArenaStore>(
+    input: &'a str,
+    ctx: ParseContext,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    if depth >= MAX_PARSE_DEPTH {
+        return Err(ParseError::NestingTooDeep);
+    }
+    let depth = depth + 1;
+
+    // A wrapper prefix is a run of ASCII alphabetic chars followed by ':'.
+    let alpha_end = input
+        .bytes()
+        .position(|b| !b.is_ascii_alphabetic())
+        .unwrap_or(input.len());
+    let (input, wrappers) = if alpha_end > 0 && input.as_bytes().get(alpha_end) == Some(&b':') {
+        let wrappers = &input[..alpha_end];
+        (&input[alpha_end + 1..], wrappers)
+    } else {
+        (input, "")
+    };
+
+    let (input, inner) = parse_inner_descriptor(input, ctx, depth, arena)?;
+
+    // Apply wrappers in reverse character order (rightmost char = outermost wrapper)
+    let mut result = inner;
+    for wrapper in wrappers.chars().rev() {
+        let tag = match wrapper {
+            'a' => NodeTag::A,
+            's' => NodeTag::S,
+            'c' => NodeTag::C,
+            't' => NodeTag::T,
+            'd' => NodeTag::D,
+            'v' => NodeTag::V,
+            'j' => NodeTag::J,
+            'n' => NodeTag::N,
+            'l' => NodeTag::L,
+            'u' => NodeTag::U,
+            _ => return Err(ParseError::InvalidSyntax),
+        };
+        result = arena.push_node(Node::with_a(tag, result.0)).map_err(full)?;
+    }
+    Ok((input, result))
+}
+
+fn parse_inner_descriptor<'a, A: ArenaStore>(
+    input: &'a str,
+    ctx: ParseContext,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    // Longer names checked before shorter to avoid premature prefix matches.
+    if input.starts_with("sortedmulti_a(") {
+        return parse_threshold_kp_fragment(input, "sortedmulti_a", NodeTag::SortedmultiA, ctx, MAX_KEYS_MULTI_A, arena);
+    }
+    if input.starts_with("sortedmulti(") {
+        return parse_threshold_kp_fragment(input, "sortedmulti", NodeTag::Sortedmulti, ctx, crate::MAX_KEYS_MULTI, arena);
+    }
+    if input.starts_with("multi_a(") {
+        return parse_threshold_kp_fragment(input, "multi_a", NodeTag::MultiA, ctx, MAX_KEYS_MULTI_A, arena);
+    }
+    if input.starts_with("multi(") {
+        return parse_threshold_kp_fragment(input, "multi", NodeTag::Multi, ctx, crate::MAX_KEYS_MULTI, arena);
+    }
+    if input.starts_with("thresh(") {
+        return parse_thresh(input, ctx, depth, arena);
+    }
+    if input.starts_with("wsh(") {
+        if !ctx.wsh_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        let inner_ctx = match ctx {
+            ParseContext::TopLevel => ParseContext::Segwit,
+            ParseContext::Legacy => ParseContext::WrappedSegwit,
+            _ => return Err(ParseError::InvalidScriptContext),
+        };
+        let (rest, [script]) = parse_n_subscripts::<1, A>(&input[4..], inner_ctx, depth, arena)?;
+        let id = arena.push_node(Node::with_a(NodeTag::Wsh, script.0)).map_err(full)?;
+        return Ok((rest, id));
+    }
+    if input.starts_with("sh(") {
+        if !ctx.sh_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        let (rest, [script]) = parse_n_subscripts::<1, A>(&input[3..], ParseContext::Legacy, depth, arena)?;
+        let id = arena.push_node(Node::with_a(NodeTag::Sh, script.0)).map_err(full)?;
+        return Ok((rest, id));
+    }
+    if input.starts_with("wpkh(") {
+        if !ctx.wpkh_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        return parse_kp_fragment(input, "wpkh", NodeTag::Wpkh, ctx, arena);
+    }
+    if input.starts_with("pkh(") {
+        return parse_kp_fragment(input, "pkh", NodeTag::Pkh, ctx, arena);
+    }
+    if input.starts_with("tr(") {
+        if !ctx.tr_allowed() {
+            return Err(ParseError::InvalidScriptContext);
+        }
+        return parse_tr(input, depth, arena);
+    }
+    if input.starts_with("pk_k(") {
+        return parse_kp_fragment(input, "pk_k", NodeTag::PkK, ctx, arena);
+    }
+    if input.starts_with("pk_h(") {
+        return parse_kp_fragment(input, "pk_h", NodeTag::PkH, ctx, arena);
+    }
+    if input.starts_with("pk(") {
+        return parse_kp_fragment(input, "pk", NodeTag::Pk, ctx, arena);
+    }
+    if input.starts_with("older(") {
+        return parse_num_fragment(input, "older", MAX_OLDER_AFTER, NodeTag::Older, arena);
+    }
+    if input.starts_with("after(") {
+        return parse_num_fragment(input, "after", MAX_OLDER_AFTER, NodeTag::After, arena);
+    }
+    if input.starts_with("sha256(") {
+        return parse_hex32_fragment(input, "sha256", NodeTag::Sha256, arena);
+    }
+    if input.starts_with("hash256(") {
+        return parse_hex32_fragment(input, "hash256", NodeTag::Hash256, arena);
+    }
+    if input.starts_with("ripemd160(") {
+        return parse_hex20_fragment(input, "ripemd160", NodeTag::Ripemd160, arena);
+    }
+    if input.starts_with("hash160(") {
+        return parse_hex20_fragment(input, "hash160", NodeTag::Hash160, arena);
+    }
+    if input.starts_with("andor(") {
+        let (rest, [x, y, z]) = parse_n_subscripts::<3, A>(&input[6..], ctx, depth, arena)?;
+        let mut node = Node::new(NodeTag::Andor);
+        node.a = x.0;
+        node.b = y.0;
+        node.c = z.0;
+        let id = arena.push_node(node).map_err(full)?;
+        return Ok((rest, id));
+    }
+    if input.starts_with("and_b(") {
+        return parse_binary(&input[6..], NodeTag::AndB, ctx, depth, arena);
+    }
+    if input.starts_with("and_v(") {
+        return parse_binary(&input[6..], NodeTag::AndV, ctx, depth, arena);
+    }
+    if input.starts_with("and_n(") {
+        return parse_binary(&input[6..], NodeTag::AndN, ctx, depth, arena);
+    }
+    if input.starts_with("or_b(") {
+        return parse_binary(&input[5..], NodeTag::OrB, ctx, depth, arena);
+    }
+    if input.starts_with("or_c(") {
+        return parse_binary(&input[5..], NodeTag::OrC, ctx, depth, arena);
+    }
+    if input.starts_with("or_d(") {
+        return parse_binary(&input[5..], NodeTag::OrD, ctx, depth, arena);
+    }
+    if input.starts_with("or_i(") {
+        return parse_binary(&input[5..], NodeTag::OrI, ctx, depth, arena);
+    }
+    // Simple terminals: bare "0" and "1"
+    if input.starts_with('0') {
+        let id = arena.push_node(Node::new(NodeTag::Zero)).map_err(full)?;
+        return Ok((&input[1..], id));
+    }
+    if input.starts_with('1') {
+        let id = arena.push_node(Node::new(NodeTag::One)).map_err(full)?;
+        return Ok((&input[1..], id));
+    }
+    Err(ParseError::UnrecognizedFragment)
+}
+
+/// Parses two comma-separated sub-scripts (the opening `(` already consumed by
+/// the caller) and builds a binary combinator node `(a, b)`.
+fn parse_binary<'a, A: ArenaStore>(
+    input: &'a str,
+    tag: NodeTag,
+    ctx: ParseContext,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    let (rest, [x, y]) = parse_n_subscripts::<2, A>(input, ctx, depth, arena)?;
+    let mut node = Node::new(tag);
+    node.a = x.0;
+    node.b = y.0;
+    let id = arena.push_node(node).map_err(full)?;
+    Ok((rest, id))
+}
+
+/// Parses a named fragment that wraps a single key expression: name(@...)
+fn parse_kp_fragment<'a, A: ArenaStore>(
+    input: &'a str,
+    name: &str,
+    tag: NodeTag,
+    ctx: ParseContext,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    let rest = &input[name.len()..]; // caller already checked starts_with(name)
+    let (rest, kp) = parse_key_expression(&rest[1..], ctx, arena)?; // skip '('
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let id = arena.push_node(Node::with_a(tag, kp.0)).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+/// Parses "name(n)" where n is a number <= max.
+fn parse_num_fragment<'a, A: ArenaStore>(
+    input: &'a str,
+    name: &str,
+    max: u32,
+    tag: NodeTag,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    let rest = &input[name.len()..]; // caller already checked starts_with(name)
+    let (rest, num) = parse_number_up_to(&rest[1..], max)?; // skip '('
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let id = arena.push_node(Node::with_a(tag, num)).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+/// Parses "name(<40 hex chars>)".
+fn parse_hex20_fragment<'a, A: ArenaStore>(
+    input: &'a str,
+    name: &str,
+    tag: NodeTag,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    let rest = &input[name.len() + 1..]; // skip name and '('
+    if rest.len() < 40 {
+        return Err(ParseError::InvalidLength);
+    }
+    let bytes = <[u8; 20]>::from_hex(&rest[..40]).map_err(|_| ParseError::InvalidHex)?;
+    let rest = &rest[40..];
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let span = arena.push_bytes(&bytes).map_err(full)?;
+    let id = arena.push_node(hash_node(tag, span)).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+/// Parses "name(<64 hex chars>)".
+fn parse_hex32_fragment<'a, A: ArenaStore>(
+    input: &'a str,
+    name: &str,
+    tag: NodeTag,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    let rest = &input[name.len() + 1..]; // skip name and '('
+    if rest.len() < 64 {
+        return Err(ParseError::InvalidLength);
+    }
+    let bytes = <[u8; 32]>::from_hex(&rest[..64]).map_err(|_| ParseError::InvalidHex)?;
+    let rest = &rest[64..];
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let span = arena.push_bytes(&bytes).map_err(full)?;
+    let id = arena.push_node(hash_node(tag, span)).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+fn hash_node(tag: NodeTag, span: crate::arena::Span) -> Node {
+    let mut node = Node::new(tag);
+    node.a = span.start;
+    node.b = span.len;
+    node
+}
+
+/// Parses "name(threshold,<key1>,<key2>,...)", building a `Multi*` node whose
+/// key list is an in-order cons list of [`crate::arena::KeyId`]s.
+pub(crate) fn parse_threshold_kp_fragment<'a, A: ArenaStore>(
+    input: &'a str,
+    name: &str,
+    tag: NodeTag,
+    ctx: ParseContext,
+    max_keys: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    let rest = &input[name.len() + 1..]; // skip name and '('
+    let (mut rest, threshold) = parse_number_up_to(rest, u32::MAX)?;
+    let mut list = ListBuilder::new();
+    let mut n_keys = 0usize;
+    loop {
+        if !rest.starts_with(',') {
+            break;
+        }
+        if n_keys >= max_keys {
+            return Err(ParseError::TooManyKeys);
+        }
+        match parse_key_expression(&rest[1..], ctx, arena) {
+            Ok((r, kp)) => {
+                list.push(arena, kp.0).map_err(full)?;
+                n_keys += 1;
+                rest = r;
+            }
+            Err(ParseError::InvalidScriptContext) => return Err(ParseError::InvalidScriptContext),
+            Err(_) => break,
+        }
+    }
+    if n_keys < 2 {
+        return Err(ParseError::TooFewKeyExpressions);
+    }
+    if threshold == 0 || (threshold as usize) > n_keys {
+        return Err(ParseError::InvalidMultisigQuorum);
+    }
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let mut node = Node::new(tag);
+    node.a = threshold;
+    node.b = list.head();
+    node.c = list.count();
+    let id = arena.push_node(node).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+/// Parses exactly `N` comma-separated sub-descriptors followed by ')'.
+pub(crate) fn parse_n_subscripts<'a, const N: usize, A: ArenaStore>(
+    input: &'a str,
+    ctx: ParseContext,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, [NodeId; N]> {
+    let mut rest = input;
+    let mut ids = [NodeId(0); N];
+    for (i, slot) in ids.iter_mut().enumerate() {
+        let (r, id) = parse_descriptor(rest, ctx, depth, arena)?;
+        *slot = id;
+        rest = r;
+        if i + 1 < N {
+            if !rest.starts_with(',') {
+                return Err(ParseError::InvalidSyntax);
+            }
+            rest = &rest[1..];
+        }
+    }
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    Ok((&rest[1..], ids))
+}
+
+pub(crate) fn parse_thresh<'a, A: ArenaStore>(
+    input: &'a str,
+    ctx: ParseContext,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    // input starts with "thresh("
+    let (rest, k) = parse_number_up_to(&input[7..], u32::MAX)?;
+    if !rest.starts_with(',') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    // parse first script (mandatory)
+    let (rest, first) = parse_descriptor(&rest[1..], ctx, depth, arena)?;
+    let mut list = ListBuilder::new();
+    list.push(arena, first.0).map_err(full)?;
+    let mut count = 1usize;
+    let mut rest = rest;
+    loop {
+        if !rest.starts_with(',') {
+            break;
+        }
+        match parse_descriptor(&rest[1..], ctx, depth, arena) {
+            Ok((r, desc)) => {
+                list.push(arena, desc.0).map_err(full)?;
+                count += 1;
+                rest = r;
+            }
+            Err(ParseError::NestingTooDeep) => return Err(ParseError::NestingTooDeep),
+            Err(_) => break,
+        }
+    }
+    if k == 0 {
+        return Err(ParseError::InvalidMultisigQuorum);
+    }
+    if (k as usize) > count {
+        return Err(ParseError::ThreshExceedsScripts);
+    }
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let mut node = Node::new(NodeTag::Thresh);
+    node.a = k;
+    node.b = list.head();
+    node.c = list.count();
+    let id = arena.push_node(node).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+pub(crate) fn parse_tr<'a, A: ArenaStore>(
+    input: &'a str,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    // input starts with "tr("
+    let (rest, key) = parse_key_expression(&input[3..], ParseContext::Taproot, arena)?;
+    let (rest, tree) = if rest.starts_with(',') {
+        let (rest, t) = parse_tap_tree(&rest[1..], depth, arena)?;
+        (rest, t.0)
+    } else {
+        (rest, NONE)
+    };
+    if !rest.starts_with(')') {
+        return Err(ParseError::InvalidSyntax);
+    }
+    let mut node = Node::new(NodeTag::Tr);
+    node.a = key.0;
+    node.d = tree;
+    let id = arena.push_node(node).map_err(full)?;
+    Ok((&rest[1..], id))
+}
+
+fn parse_tap_tree<'a, A: ArenaStore>(
+    input: &'a str,
+    depth: usize,
+    arena: &mut A,
+) -> ParseResult<'a, NodeId> {
+    if depth >= MAX_PARSE_DEPTH {
+        return Err(ParseError::NestingTooDeep);
+    }
+    let depth = depth + 1;
+    if input.starts_with('{') {
+        let (rest, left) = parse_tap_tree(&input[1..], depth, arena)?;
+        if !rest.starts_with(',') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        let (rest, right) = parse_tap_tree(&rest[1..], depth, arena)?;
+        if !rest.starts_with('}') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        let mut node = Node::new(NodeTag::TapBranch);
+        node.a = left.0;
+        node.b = right.0;
+        let id = arena.push_node(node).map_err(full)?;
+        Ok((&rest[1..], id))
+    } else {
+        let (rest, desc) = parse_descriptor(input, ParseContext::Taproot, depth, arena)?;
+        let id = arena.push_node(Node::with_a(NodeTag::TapLeaf, desc.0)).map_err(full)?;
+        Ok((rest, id))
+    }
+}

--- a/apps/bitcoin/bip388/src/parser.rs
+++ b/apps/bitcoin/bip388/src/parser.rs
@@ -125,14 +125,35 @@ pub(crate) fn parse_key_expression<'a, A: ArenaStore>(
     Ok((rest, id))
 }
 
+fn musig_previous_members_contains(mut previous: &str, idx: u32) -> Result<bool, ParseError> {
+    while !previous.is_empty() {
+        if !previous.starts_with('@') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        let (rest, prev_idx) = parse_number_up_to(&previous[1..], u32::MAX)?;
+        if prev_idx == idx {
+            return Ok(true);
+        }
+        if rest.is_empty() {
+            return Ok(false);
+        }
+        if !rest.starts_with(',') {
+            return Err(ParseError::InvalidSyntax);
+        }
+        previous = &rest[1..];
+    }
+    Ok(false)
+}
+
 /// Parses `musig(@N1,@N2,...)/...`. Members are stored as a contiguous span in
 /// the `members` pool (no nested allocations interleave during the member loop).
-/// Per BIP-390, all participant key indices must be distinct.
+/// Per BIP-388, all participant key indices must be distinct.
 fn parse_musig_key_expression<'a, A: ArenaStore>(
     input: &'a str,
     arena: &mut A,
 ) -> ParseResult<'a, crate::arena::KeyId> {
-    let mut rest = &input[6..]; // skip "musig("
+    let members_input = &input[6..]; // skip "musig("
+    let mut rest = members_input;
     let start = arena.members_begin();
     let mut count = 0u32;
     loop {
@@ -140,9 +161,8 @@ fn parse_musig_key_expression<'a, A: ArenaStore>(
             return Err(ParseError::InvalidSyntax);
         }
         let (r, idx) = parse_number_up_to(&rest[1..], u32::MAX)?;
-        // distinctness against the members collected so far
-        let partial = arena.members_end(start);
-        if arena.members(partial).contains(&idx) {
+        let previous_len = members_input.len() - rest.len();
+        if musig_previous_members_contains(&members_input[..previous_len], idx)? {
             return Err(ParseError::InvalidKey);
         }
         arena.members_push(idx).map_err(full)?;
@@ -163,7 +183,9 @@ fn parse_musig_key_expression<'a, A: ArenaStore>(
     rest = &rest[1..]; // skip ')'
     let (rest, (num1, num2)) = parse_derivation_suffix(rest)?;
     let span = arena.members_end(start);
-    let id = arena.push_key(KeyExprRec::musig(span, num1, num2)).map_err(full)?;
+    let id = arena
+        .push_key(KeyExprRec::musig(span, num1, num2))
+        .map_err(full)?;
     Ok((rest, id))
 }
 
@@ -237,16 +259,44 @@ fn parse_inner_descriptor<'a, A: ArenaStore>(
 ) -> ParseResult<'a, NodeId> {
     // Longer names checked before shorter to avoid premature prefix matches.
     if input.starts_with("sortedmulti_a(") {
-        return parse_threshold_kp_fragment(input, "sortedmulti_a", NodeTag::SortedmultiA, ctx, MAX_KEYS_MULTI_A, arena);
+        return parse_threshold_kp_fragment(
+            input,
+            "sortedmulti_a",
+            NodeTag::SortedmultiA,
+            ctx,
+            MAX_KEYS_MULTI_A,
+            arena,
+        );
     }
     if input.starts_with("sortedmulti(") {
-        return parse_threshold_kp_fragment(input, "sortedmulti", NodeTag::Sortedmulti, ctx, crate::MAX_KEYS_MULTI, arena);
+        return parse_threshold_kp_fragment(
+            input,
+            "sortedmulti",
+            NodeTag::Sortedmulti,
+            ctx,
+            crate::MAX_KEYS_MULTI,
+            arena,
+        );
     }
     if input.starts_with("multi_a(") {
-        return parse_threshold_kp_fragment(input, "multi_a", NodeTag::MultiA, ctx, MAX_KEYS_MULTI_A, arena);
+        return parse_threshold_kp_fragment(
+            input,
+            "multi_a",
+            NodeTag::MultiA,
+            ctx,
+            MAX_KEYS_MULTI_A,
+            arena,
+        );
     }
     if input.starts_with("multi(") {
-        return parse_threshold_kp_fragment(input, "multi", NodeTag::Multi, ctx, crate::MAX_KEYS_MULTI, arena);
+        return parse_threshold_kp_fragment(
+            input,
+            "multi",
+            NodeTag::Multi,
+            ctx,
+            crate::MAX_KEYS_MULTI,
+            arena,
+        );
     }
     if input.starts_with("thresh(") {
         return parse_thresh(input, ctx, depth, arena);
@@ -261,15 +311,20 @@ fn parse_inner_descriptor<'a, A: ArenaStore>(
             _ => return Err(ParseError::InvalidScriptContext),
         };
         let (rest, [script]) = parse_n_subscripts::<1, A>(&input[4..], inner_ctx, depth, arena)?;
-        let id = arena.push_node(Node::with_a(NodeTag::Wsh, script.0)).map_err(full)?;
+        let id = arena
+            .push_node(Node::with_a(NodeTag::Wsh, script.0))
+            .map_err(full)?;
         return Ok((rest, id));
     }
     if input.starts_with("sh(") {
         if !ctx.sh_allowed() {
             return Err(ParseError::InvalidScriptContext);
         }
-        let (rest, [script]) = parse_n_subscripts::<1, A>(&input[3..], ParseContext::Legacy, depth, arena)?;
-        let id = arena.push_node(Node::with_a(NodeTag::Sh, script.0)).map_err(full)?;
+        let (rest, [script]) =
+            parse_n_subscripts::<1, A>(&input[3..], ParseContext::Legacy, depth, arena)?;
+        let id = arena
+            .push_node(Node::with_a(NodeTag::Sh, script.0))
+            .map_err(full)?;
         return Ok((rest, id));
     }
     if input.starts_with("wpkh(") {
@@ -626,7 +681,9 @@ fn parse_tap_tree<'a, A: ArenaStore>(
         Ok((&rest[1..], id))
     } else {
         let (rest, desc) = parse_descriptor(input, ParseContext::Taproot, depth, arena)?;
-        let id = arena.push_node(Node::with_a(NodeTag::TapLeaf, desc.0)).map_err(full)?;
+        let id = arena
+            .push_node(Node::with_a(NodeTag::TapLeaf, desc.0))
+            .map_err(full)?;
         Ok((rest, id))
     }
 }

--- a/apps/bitcoin/bip388/src/parser.rs
+++ b/apps/bitcoin/bip388/src/parser.rs
@@ -4,8 +4,6 @@
 //! the *same* parser serves both the `alloc` (`VecArena`) and the future
 //! no-alloc (`SliceArena`) backings. No `Box`/`Vec`/`String` is used here.
 
-use hex::FromHex;
-
 use crate::arena::{ArenaFull, ArenaStore, KeyExprRec, ListBuilder, Node, NodeId, NodeTag, NONE};
 use crate::{
     ParseContext, ParseError, HARDENED_INDEX, MAX_KEYS_MULTI_A, MAX_OLDER_AFTER, MAX_PARSE_DEPTH,
@@ -17,6 +15,29 @@ pub(crate) type ParseResult<'a, T> = Result<(&'a str, T), ParseError>;
 #[inline]
 fn full(_: ArenaFull) -> ParseError {
     ParseError::ArenaFull
+}
+
+/// Decode exactly `N` bytes from a `2*N`-char lowercase/uppercase hex string.
+/// Allocation-free replacement for `hex::FromHex` (so the parser needs no `hex`
+/// dependency in the minimal build).
+fn decode_hex<const N: usize>(s: &str) -> Option<[u8; N]> {
+    fn nibble(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            b'A'..=b'F' => Some(b - b'A' + 10),
+            _ => None,
+        }
+    }
+    let bytes = s.as_bytes();
+    if bytes.len() != 2 * N {
+        return None;
+    }
+    let mut out = [0u8; N];
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = (nibble(bytes[2 * i])? << 4) | nibble(bytes[2 * i + 1])?;
+    }
+    Some(out)
 }
 
 // ── Pure (allocation-free) scalar helpers ──────────────────────────────────
@@ -397,7 +418,7 @@ fn parse_hex20_fragment<'a, A: ArenaStore>(
     if rest.len() < 40 {
         return Err(ParseError::InvalidLength);
     }
-    let bytes = <[u8; 20]>::from_hex(&rest[..40]).map_err(|_| ParseError::InvalidHex)?;
+    let bytes = decode_hex::<20>(&rest[..40]).ok_or(ParseError::InvalidHex)?;
     let rest = &rest[40..];
     if !rest.starts_with(')') {
         return Err(ParseError::InvalidSyntax);
@@ -418,7 +439,7 @@ fn parse_hex32_fragment<'a, A: ArenaStore>(
     if rest.len() < 64 {
         return Err(ParseError::InvalidLength);
     }
-    let bytes = <[u8; 32]>::from_hex(&rest[..64]).map_err(|_| ParseError::InvalidHex)?;
+    let bytes = decode_hex::<32>(&rest[..64]).ok_or(ParseError::InvalidHex)?;
     let rest = &rest[64..];
     if !rest.starts_with(')') {
         return Err(ParseError::InvalidSyntax);

--- a/apps/bitcoin/bip388/src/time.rs
+++ b/apps/bitcoin/bip388/src/time.rs
@@ -27,7 +27,11 @@ pub(super) fn write_utc_date(sink: &mut dyn fmt::Write, timestamp: u32) -> fmt::
         let h = time_of_day / 3600;
         let min = (time_of_day % 3600) / 60;
         let sec = time_of_day % 60;
-        write!(sink, "{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, m, d, h, min, sec)
+        write!(
+            sink,
+            "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+            y, m, d, h, min, sec
+        )
     }
 }
 
@@ -296,7 +300,10 @@ mod tests {
         assert_eq!(parse_relative_time_to_seconds("1 minute"), Some(60));
         assert_eq!(parse_relative_time_to_seconds("1 hour"), Some(3600));
         assert_eq!(parse_relative_time_to_seconds("1 day"), Some(86400));
-        assert_eq!(parse_relative_time_to_seconds("8 minutes 32 seconds"), Some(512));
+        assert_eq!(
+            parse_relative_time_to_seconds("8 minutes 32 seconds"),
+            Some(512)
+        );
         assert_eq!(
             parse_relative_time_to_seconds("1 day 1 hour 36 minutes"),
             Some(92160)
@@ -309,7 +316,10 @@ mod tests {
             parse_relative_time_to_seconds("1 day 2 hours 3 minutes 4 seconds"),
             Some(93784)
         );
-        assert_eq!(parse_relative_time_to_seconds("1 hour 1 second"), Some(3601));
+        assert_eq!(
+            parse_relative_time_to_seconds("1 hour 1 second"),
+            Some(3601)
+        );
         // Singular/plural spellings are interchangeable regardless of the number.
         assert_eq!(parse_relative_time_to_seconds("2 day"), Some(172800));
         assert_eq!(parse_relative_time_to_seconds("1 seconds"), Some(1));

--- a/apps/bitcoin/bip388/src/time.rs
+++ b/apps/bitcoin/bip388/src/time.rs
@@ -1,9 +1,10 @@
-use alloc::{format, string::String, string::ToString, vec::Vec};
+use alloc::string::String;
+use core::fmt;
 
-/// Formats a Unix timestamp as a UTC date or datetime string.
-/// When the time component is midnight (00:00:00 UTC), returns `"YYYY-MM-DD"`.
-/// Otherwise returns `"YYYY-MM-DD HH:MM:SS"`.
-pub(super) fn format_utc_date(timestamp: u32) -> String {
+/// Writes a Unix timestamp as a UTC date or datetime into `sink` (allocation-free).
+/// Midnight (00:00:00 UTC) renders as `"YYYY-MM-DD"`, otherwise
+/// `"YYYY-MM-DD HH:MM:SS"`.
+pub(super) fn write_utc_date(sink: &mut dyn fmt::Write, timestamp: u32) -> fmt::Result {
     // Uses Howard Hinnant's civil-from-days algorithm.
     let days = timestamp / 86400;
     let time_of_day = timestamp % 86400;
@@ -18,13 +19,20 @@ pub(super) fn format_utc_date(timestamp: u32) -> String {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
     if time_of_day == 0 {
-        format!("{:04}-{:02}-{:02}", y, m, d)
+        write!(sink, "{:04}-{:02}-{:02}", y, m, d)
     } else {
         let h = time_of_day / 3600;
         let min = (time_of_day % 3600) / 60;
         let sec = time_of_day % 60;
-        format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, m, d, h, min, sec)
+        write!(sink, "{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, m, d, h, min, sec)
     }
+}
+
+/// `String`-returning wrapper over [`write_utc_date`].
+pub(super) fn format_utc_date(timestamp: u32) -> String {
+    let mut s = String::new();
+    let _ = write_utc_date(&mut s, timestamp);
+    s
 }
 
 /// Parses a UTC date/datetime string as produced by [`format_utc_date`].
@@ -84,12 +92,12 @@ pub(super) fn parse_utc_date_to_timestamp(s: &str) -> Option<u32> {
 /// spelled-out units (so a non-technical reader can't mistake "m" for months).
 /// Units are pluralized; returns `"0 seconds"` for zero.
 /// Example: `"1 day 2 hours 30 minutes"`.
-pub(super) fn format_seconds(secs: u32) -> String {
+pub(super) fn write_seconds(sink: &mut dyn fmt::Write, secs: u32) -> fmt::Result {
     let days = secs / 86400;
     let hours = (secs % 86400) / 3600;
     let minutes = (secs % 3600) / 60;
     let seconds = secs % 60;
-    let mut parts: Vec<String> = Vec::new();
+    let mut wrote = false;
     for (value, singular, plural) in [
         (days, "day", "days"),
         (hours, "hour", "hours"),
@@ -97,15 +105,25 @@ pub(super) fn format_seconds(secs: u32) -> String {
         (seconds, "second", "seconds"),
     ] {
         if value > 0 {
+            if wrote {
+                sink.write_char(' ')?;
+            }
             let unit = if value == 1 { singular } else { plural };
-            parts.push(format!("{} {}", value, unit));
+            write!(sink, "{} {}", value, unit)?;
+            wrote = true;
         }
     }
-    if parts.is_empty() {
-        "0 seconds".to_string()
-    } else {
-        parts.join(" ")
+    if !wrote {
+        sink.write_str("0 seconds")?;
     }
+    Ok(())
+}
+
+/// `String`-returning wrapper over [`write_seconds`].
+pub(super) fn format_seconds(secs: u32) -> String {
+    let mut s = String::new();
+    let _ = write_seconds(&mut s, secs);
+    s
 }
 
 /// Parses a human-readable duration string as produced by [`format_seconds`].

--- a/apps/bitcoin/bip388/src/time.rs
+++ b/apps/bitcoin/bip388/src/time.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "alloc")]
 use alloc::string::String;
+#[cfg(any(test, feature = "cleartext-decode"))]
+use alloc::vec::Vec;
 use core::fmt;
 
 /// Writes a Unix timestamp as a UTC date or datetime into `sink` (allocation-free).
@@ -29,6 +32,7 @@ pub(super) fn write_utc_date(sink: &mut dyn fmt::Write, timestamp: u32) -> fmt::
 }
 
 /// `String`-returning wrapper over [`write_utc_date`].
+#[cfg(feature = "alloc")]
 pub(super) fn format_utc_date(timestamp: u32) -> String {
     let mut s = String::new();
     let _ = write_utc_date(&mut s, timestamp);
@@ -120,6 +124,7 @@ pub(super) fn write_seconds(sink: &mut dyn fmt::Write, secs: u32) -> fmt::Result
 }
 
 /// `String`-returning wrapper over [`write_seconds`].
+#[cfg(feature = "alloc")]
 pub(super) fn format_seconds(secs: u32) -> String {
     let mut s = String::new();
     let _ = write_seconds(&mut s, secs);

--- a/apps/bitcoin/common/Cargo.toml
+++ b/apps/bitcoin/common/Cargo.toml
@@ -24,7 +24,7 @@ minicbor = { version = "2.2", default-features = false, features = ["alloc", "de
 sdk = { package = "vanadium-app-sdk", path = "../../../app-sdk", default-features = false }
 subtle = { version="2.6.1", default-features = false }
 zeroize = { version = "1.8.1", default-features = false }
-bip388 = { path = "../bip388", default-features = false }
+bip388 = { path = "../bip388", default-features = false, features = ["wallet-policy"] }
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/apps/bitcoin/common/src/psbt/account.rs
+++ b/apps/bitcoin/common/src/psbt/account.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::{AccountCoordinates, WalletPolicy, WalletPolicyCoordinates},
-    bip388::KeyExpression,
+    bip388::{keyview_to_owned, KeyExpression},
 };
 
 use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
@@ -540,9 +540,9 @@ pub fn prepare_psbt(
     assert!(named_accounts.len() == 1);
     for (wallet_policy, account_name, por) in named_accounts {
         let placeholders: Vec<KeyExpression> = wallet_policy
-            .descriptor_template()
+            .descriptor_cursor()
             .placeholders()
-            .map(|(k, _)| k.clone())
+            .map(|(kv, _)| keyview_to_owned(kv))
             .collect();
 
         for key_placeholder in &placeholders {
@@ -691,9 +691,9 @@ mod tests {
         let mut psbt = psbt_from_str(psbt_str).unwrap();
 
         let placeholders: Vec<KeyExpression> = wallet_policy
-            .descriptor_template()
+            .descriptor_cursor()
             .placeholders()
-            .map(|(k, _)| k.clone())
+            .map(|(kv, _)| keyview_to_owned(kv))
             .collect();
         assert!(placeholders.len() == 1);
         let key_placeholder = &placeholders[0];
@@ -775,13 +775,14 @@ mod tests {
             .tap_key_origins
             .insert(xonly, (vec![], (xpub1.fingerprint(), path)));
 
-        let key_placeholder = wallet_policy
-            .descriptor_template()
-            .placeholders()
-            .next()
-            .unwrap()
-            .0
-            .clone();
+        let key_placeholder = keyview_to_owned(
+            wallet_policy
+                .descriptor_cursor()
+                .placeholders()
+                .next()
+                .unwrap()
+                .0,
+        );
 
         fill_psbt_with_bip388_coordinates(&mut psbt, &wallet_policy, None, None, &key_placeholder, 0)
             .unwrap();

--- a/apps/bitcoin/common/src/script.rs
+++ b/apps/bitcoin/common/src/script.rs
@@ -1082,13 +1082,16 @@ mod tests {
                 .collect();
             let wp = WalletPolicy::new(template, key_info)
                 .unwrap_or_else(|e| panic!("failed to parse {template}: {e:?}"));
+            // Owned reference AST (oracle), parsed independently of the policy.
+            let owned_tmpl: DescriptorTemplate = template
+                .parse()
+                .unwrap_or_else(|e| panic!("failed to parse owned {template}: {e:?}"));
 
             for &(is_change, address_index) in &coords {
                 // Compare the full Result (success bytes *and* rejection variant)
                 // via Debug, so the cursor path matches the owned path on both
                 // valid scripts and rejected contexts.
-                let owned = wp
-                    .descriptor_template()
+                let owned = owned_tmpl
                     .to_script(
                         wp.key_information(),
                         is_change,

--- a/apps/bitcoin/common/src/script.rs
+++ b/apps/bitcoin/common/src/script.rs
@@ -7,6 +7,8 @@ use bitcoin::opcodes::{all::*, OP_0};
 use bitcoin::script::Builder;
 use bitcoin::{PubkeyHash, ScriptBuf, ScriptHash, TapNodeHash, WPubkeyHash, WScriptHash};
 
+use bip388::arena::{ArenaRead, Cursor, DescriptorNode, KeyListView, KeyView};
+
 use crate::errors::Error;
 use crate::taproot::GetTapTreeHash;
 
@@ -492,9 +494,516 @@ impl ToScriptWithKeyInfo for DescriptorTemplate {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Cursor-based script derivation (arena form).
+//
+// This mirrors the owned `to_script_inner` above arm-for-arm, but recurses over
+// arena `Cursor`s instead of the owned `DescriptorTemplate` tree. It is the path
+// used in production (`WalletPolicy::to_script` below); the owned path is kept
+// during the migration and exercised by the differential test in this module.
+// Both must produce byte-identical scripts.
+// ---------------------------------------------------------------------------
+
+/// Resolves a key expression cursor to its derived `Xpub` at the given
+/// coordinates (mirrors the `derive` closure in the owned `to_script_inner`).
+fn derive_key<A: ArenaRead>(
+    kv: KeyView<'_, A>,
+    key_information: &[KeyInformation],
+    is_change: bool,
+    address_index: u32,
+) -> Result<Xpub, Error> {
+    let change_step = ChildNumber::from(if is_change { kv.num2() } else { kv.num1() });
+    let path = [change_step, ChildNumber::from(address_index)];
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+
+    // Resolve the root xpub of the key expression: either a single participant's
+    // xpub (plain) or the BIP-388 aggregate of several participants' (musig).
+    let root_xpub: Xpub = if let Some(idx) = kv.plain_key_index() {
+        key_information
+            .get(idx as usize)
+            .ok_or(Error::InvalidKeyIndex)?
+            .pubkey
+    } else if let Some(indices) = kv.musig_key_indices() {
+        let participant_xpubs: Vec<Xpub> = indices
+            .iter()
+            .map(|&i| {
+                key_information
+                    .get(i as usize)
+                    .map(|ki| ki.pubkey)
+                    .ok_or(Error::InvalidKeyIndex)
+            })
+            .collect::<Result<_, _>>()?;
+        crate::musig::aggregate_xpub(&participant_xpubs).map_err(|_| Error::InvalidKey)?
+    } else {
+        return Err(Error::UnsupportedWalletPolicy);
+    };
+
+    root_xpub
+        .derive_pub(&secp, &path)
+        .map_err(|_| Error::InvalidKey)
+}
+
+/// `pk_k(key)`: push the (x-only in taproot) serialized public key.
+fn push_pk_k<A: ArenaRead>(
+    builder: Builder,
+    kv: KeyView<'_, A>,
+    key_information: &[KeyInformation],
+    is_change: bool,
+    address_index: u32,
+    ctx: ScriptContext,
+) -> Result<Builder, Error> {
+    let key = derive_key(kv, key_information, is_change, address_index)?;
+    Ok(if ctx == ScriptContext::Tr {
+        builder.push_slice(key.to_x_only_pub().serialize())
+    } else {
+        builder.push_slice(key.to_pub().to_bytes())
+    })
+}
+
+/// `multi`/`sortedmulti` (legacy/segwit-v0 `OP_CHECKMULTISIG`).
+fn push_multi<A: ArenaRead>(
+    mut builder: Builder,
+    k: u32,
+    keys: KeyListView<'_, A>,
+    sorted: bool,
+    ctx: ScriptContext,
+    key_information: &[KeyInformation],
+    is_change: bool,
+    address_index: u32,
+) -> Result<Builder, Error> {
+    if ctx == ScriptContext::Tr {
+        return Err(Error::InvalidScriptContext);
+    }
+    if keys.len() > MAX_PUBKEYS_PER_MULTISIG {
+        return Err(Error::TooManyKeys);
+    }
+    if k == 0 || (k as usize) > keys.len() {
+        return Err(Error::InvalidMultisigQuorum);
+    }
+
+    builder = builder.push_int(k as i64);
+
+    let mut derived = keys
+        .iter()
+        .map(|kv| {
+            derive_key(kv, key_information, is_change, address_index)
+                .map(|extended_pub_key| extended_pub_key.to_pub().to_bytes())
+        })
+        .collect::<Result<Vec<[u8; 33]>, Error>>()?;
+
+    if sorted {
+        // O(n^2) sorting, better for small arrays
+        derived.bubble_sort();
+    }
+
+    for key in derived {
+        builder = builder.push_slice(&key);
+    }
+
+    Ok(builder
+        .push_int(keys.len() as i64)
+        .push_opcode(OP_CHECKMULTISIG))
+}
+
+/// `multi_a`/`sortedmulti_a` (taproot `OP_CHECKSIGADD`).
+fn push_multi_a<A: ArenaRead>(
+    mut builder: Builder,
+    k: u32,
+    keys: KeyListView<'_, A>,
+    sorted: bool,
+    ctx: ScriptContext,
+    key_information: &[KeyInformation],
+    is_change: bool,
+    address_index: u32,
+) -> Result<Builder, Error> {
+    if ctx != ScriptContext::Tr {
+        return Err(Error::InvalidScriptContext);
+    }
+    if keys.len() > MAX_PUBKEYS_PER_MULTI_A {
+        return Err(Error::TooManyKeys);
+    }
+    if k == 0 || (k as usize) > keys.len() {
+        return Err(Error::InvalidMultisigQuorum);
+    }
+
+    let mut derived = keys
+        .iter()
+        .map(|kv| {
+            derive_key(kv, key_information, is_change, address_index).map(|extended_pub_key| {
+                extended_pub_key.public_key.x_only_public_key().0.serialize()
+            })
+        })
+        .collect::<Result<Vec<[u8; 32]>, Error>>()?;
+
+    if sorted {
+        // O(n^2) sorting, better for small arrays
+        derived.bubble_sort();
+    }
+
+    for (idx, key) in derived.iter().enumerate() {
+        builder = builder.push_slice(key);
+
+        if idx == 0 {
+            builder = builder.push_opcode(OP_CHECKSIG);
+        } else {
+            builder = builder.push_opcode(OP_CHECKSIGADD);
+        }
+    }
+
+    Ok(builder.push_int(k as i64).push_opcode(OP_NUMEQUAL))
+}
+
+/// Builder-chaining helper mirroring `CanPushInnerScript` for arena cursors.
+trait CanPushCursorScript {
+    fn push_cursor<A: ArenaRead>(
+        self,
+        c: Cursor<'_, A>,
+        key_information: &[KeyInformation],
+        is_change: bool,
+        address_index: u32,
+        ctx: ScriptContext,
+    ) -> Result<Builder, Error>;
+}
+
+impl CanPushCursorScript for Builder {
+    fn push_cursor<A: ArenaRead>(
+        self,
+        c: Cursor<'_, A>,
+        key_information: &[KeyInformation],
+        is_change: bool,
+        address_index: u32,
+        ctx: ScriptContext,
+    ) -> Result<Builder, Error> {
+        cursor_to_script_inner(c, key_information, is_change, address_index, self, ctx)
+    }
+}
+
+fn cursor_to_script_inner<A: ArenaRead>(
+    cursor: Cursor<'_, A>,
+    key_information: &[KeyInformation],
+    is_change: bool,
+    address_index: u32,
+    mut builder: Builder,
+    ctx: ScriptContext,
+) -> Result<Builder, Error> {
+    use DescriptorNode as DN;
+
+    builder = match cursor.view() {
+        DN::Sh(inner) => {
+            if ctx != ScriptContext::None && ctx != ScriptContext::Wsh {
+                return Err(Error::InvalidScriptContext);
+            }
+
+            let inner_builder = cursor_to_script_inner(
+                inner,
+                key_information,
+                is_change,
+                address_index,
+                Builder::new(),
+                ScriptContext::Sh,
+            )?;
+
+            let script_hash =
+                ScriptHash::from_raw_hash(hash160::Hash::hash(&inner_builder.as_bytes()));
+
+            builder
+                .push_opcode(OP_HASH160)
+                .push_slice(script_hash)
+                .push_opcode(OP_EQUAL)
+        }
+        DN::Wsh(inner) => {
+            if ctx != ScriptContext::None {
+                return Err(Error::InvalidScriptContext);
+            }
+
+            let inner_builder = cursor_to_script_inner(
+                inner,
+                key_information,
+                is_change,
+                address_index,
+                Builder::new(),
+                ScriptContext::Wsh,
+            )?;
+            let script_hash =
+                WScriptHash::from_raw_hash(sha256::Hash::hash(&inner_builder.as_bytes()));
+            builder.push_int(0).push_slice(script_hash)
+        }
+        DN::Pkh(kv) => {
+            let key = derive_key(kv, key_information, is_change, address_index)?;
+            let pubkey: Vec<u8> = if ctx == ScriptContext::Tr {
+                key.to_x_only_pub().serialize().to_vec()
+            } else {
+                key.to_pub().to_bytes().to_vec()
+            };
+
+            let pubkey_hash = PubkeyHash::from_raw_hash(hash160::Hash::hash(&pubkey));
+
+            builder
+                .push_opcode(OP_DUP)
+                .push_opcode(OP_HASH160)
+                .push_slice(pubkey_hash)
+                .push_opcode(OP_EQUALVERIFY)
+                .push_opcode(OP_CHECKSIG)
+        }
+        DN::Wpkh(kv) => {
+            if ctx != ScriptContext::None && ctx != ScriptContext::Sh {
+                return Err(Error::InvalidScriptContext);
+            }
+
+            let pubkey = derive_key(kv, key_information, is_change, address_index)?
+                .public_key
+                .serialize();
+            let pubkey_hash = WPubkeyHash::from_raw_hash(hash160::Hash::hash(&pubkey));
+            builder.push_int(0).push_slice(pubkey_hash)
+        }
+        DN::Multi(k, keys) => push_multi(
+            builder,
+            k,
+            keys,
+            false,
+            ctx,
+            key_information,
+            is_change,
+            address_index,
+        )?,
+        DN::Sortedmulti(k, keys) => push_multi(
+            builder,
+            k,
+            keys,
+            true,
+            ctx,
+            key_information,
+            is_change,
+            address_index,
+        )?,
+        DN::MultiA(k, keys) => push_multi_a(
+            builder,
+            k,
+            keys,
+            false,
+            ctx,
+            key_information,
+            is_change,
+            address_index,
+        )?,
+        DN::SortedmultiA(k, keys) => push_multi_a(
+            builder,
+            k,
+            keys,
+            true,
+            ctx,
+            key_information,
+            is_change,
+            address_index,
+        )?,
+        DN::Tr(kv, tree) => {
+            let secp = bitcoin::secp256k1::Secp256k1::new();
+            let internal_key: UntweakedPublicKey =
+                derive_key(kv, key_information, is_change, address_index)?.to_x_only_pub();
+
+            let tree_hash = tree
+                .map(|t| {
+                    t.get_taptree_hash(key_information, is_change, address_index)
+                        .map(TapNodeHash::from_byte_array)
+                        .map_err(|_| Error::InvalidKey)
+                })
+                .transpose()?;
+
+            let taproot_key = internal_key.tap_tweak(&secp, tree_hash).0;
+
+            builder
+                .push_int(1)
+                .push_slice(taproot_key.to_x_only_public_key().serialize())
+        }
+        DN::Zero => builder.push_opcode(OP_0),
+        DN::One => builder.push_opcode(OP_PUSHNUM_1),
+        DN::Pk(kv) => {
+            // c:pk_k(key)
+            push_pk_k(
+                builder,
+                kv,
+                key_information,
+                is_change,
+                address_index,
+                ctx,
+            )?
+            .push_opcode(OP_CHECKSIG)
+        }
+        DN::PkK(kv) => push_pk_k(
+            builder,
+            kv,
+            key_information,
+            is_change,
+            address_index,
+            ctx,
+        )?,
+        DN::PkH(kv) => {
+            let key = derive_key(kv, key_information, is_change, address_index)?;
+            let rip = if ctx == ScriptContext::Tr {
+                hash160::Hash::hash(&key.to_x_only_pub().serialize())
+            } else {
+                hash160::Hash::hash(&key.to_pub().to_bytes())
+            };
+
+            builder
+                .push_opcode(OP_DUP)
+                .push_opcode(OP_HASH160)
+                .push_slice(rip.to_byte_array())
+                .push_opcode(OP_EQUALVERIFY)
+        }
+        DN::Older(n) => builder.push_int(n as i64).push_opcode(OP_CSV),
+        DN::After(n) => builder.push_int(n as i64).push_opcode(OP_CLTV),
+        DN::Sha256(h) => builder
+            .push_opcode(OP_SIZE)
+            .push_int(32)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_SHA256)
+            .push_slice(<&[u8; 32]>::try_from(h).expect("sha256 fragment is 32 bytes"))
+            .push_opcode(OP_EQUAL),
+        DN::Hash256(h) => builder
+            .push_opcode(OP_SIZE)
+            .push_int(32)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_HASH256)
+            .push_slice(<&[u8; 32]>::try_from(h).expect("hash256 fragment is 32 bytes"))
+            .push_opcode(OP_EQUAL),
+        DN::Ripemd160(h) => builder
+            .push_opcode(OP_SIZE)
+            .push_int(32)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_RIPEMD160)
+            .push_slice(<&[u8; 20]>::try_from(h).expect("ripemd160 fragment is 20 bytes"))
+            .push_opcode(OP_EQUAL),
+        DN::Hash160(h) => builder
+            .push_opcode(OP_SIZE)
+            .push_int(32)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_HASH160)
+            .push_slice(<&[u8; 20]>::try_from(h).expect("hash160 fragment is 20 bytes"))
+            .push_opcode(OP_EQUAL),
+        DN::Andor(x, y, z) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_NOTIF)
+            .push_cursor(y, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ELSE)
+            .push_cursor(z, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::AndV(x, y) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_cursor(y, key_information, is_change, address_index, ctx)?,
+        DN::AndB(x, y) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_cursor(y, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_BOOLAND),
+        DN::AndN(x, y) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_NOTIF)
+            .push_opcode(OP_0)
+            .push_opcode(OP_ELSE)
+            .push_cursor(y, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::OrB(x, z) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_cursor(z, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_BOOLOR),
+        DN::OrC(x, z) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_NOTIF)
+            .push_cursor(z, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::OrD(x, z) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_IFDUP)
+            .push_opcode(OP_NOTIF)
+            .push_cursor(z, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::OrI(x, z) => builder
+            .push_opcode(OP_IF)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ELSE)
+            .push_cursor(z, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::Thresh(k, scripts) => {
+            for (i, x_i) in scripts.iter().enumerate() {
+                builder =
+                    builder.push_cursor(x_i, key_information, is_change, address_index, ctx)?;
+                if i > 0 {
+                    builder = builder.push_opcode(OP_ADD);
+                }
+            }
+
+            builder.push_int(k as i64).push_opcode(OP_EQUAL)
+        }
+
+        // wrappers
+        DN::A(x) => builder
+            .push_opcode(OP_TOALTSTACK)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_FROMALTSTACK),
+        DN::S(x) => builder
+            .push_opcode(OP_SWAP)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?,
+        DN::C(x) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_CHECKSIG),
+        DN::T(x) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_PUSHNUM_1),
+        DN::D(x) => builder
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_IF)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::V(x) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_verify(),
+        DN::J(x) => builder
+            .push_opcode(OP_SIZE)
+            .push_opcode(OP_0NOTEQUAL)
+            .push_opcode(OP_IF)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::N(x) => builder
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_0NOTEQUAL),
+        DN::L(x) => builder
+            .push_opcode(OP_IF)
+            .push_opcode(OP_0)
+            .push_opcode(OP_ELSE)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ENDIF),
+        DN::U(x) => builder
+            .push_opcode(OP_IF)
+            .push_cursor(x, key_information, is_change, address_index, ctx)?
+            .push_opcode(OP_ELSE)
+            .push_opcode(OP_0)
+            .push_opcode(OP_ENDIF),
+        DN::TapNode(_) => unreachable!("tap-tree node reached in script context"),
+    };
+
+    Ok(builder)
+}
+
+impl<'a, A: ArenaRead> ToScriptWithKeyInfo for Cursor<'a, A> {
+    fn to_script(
+        &self,
+        key_information: &[KeyInformation],
+        is_change: bool,
+        address_index: u32,
+        ctx: ScriptContext,
+    ) -> Result<ScriptBuf, Error> {
+        let builder = Builder::new();
+        Ok(
+            cursor_to_script_inner(*self, key_information, is_change, address_index, builder, ctx)?
+                .as_script()
+                .into(),
+        )
+    }
+}
+
 impl ToScript for WalletPolicy {
     fn to_script(&self, is_change: bool, address_index: u32) -> Result<ScriptBuf, Error> {
-        self.descriptor_template().to_script(
+        self.descriptor_cursor().to_script(
             self.key_information(),
             is_change,
             address_index,
@@ -508,6 +1017,102 @@ mod tests {
     use super::*;
     use crate::account::WalletPolicy;
     use hex_literal::hex;
+
+    // Four distinct, valid tpubs reused from elsewhere in the test corpus.
+    const K0: &str = "tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT";
+    const K1: &str = "tpubDCwYjpDhUdPGQWG6wG6hkBJuWFZEtrn7j3xwG3i8XcQabcGC53xWZm1hSXrUPFS5UvZ3QhdPSjXWNfWmFGTioARHuG5J7XguEjgg7p8PxAm";
+    const K2: &str = "tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P";
+    const K3: &str = "tpubDD7URPdwnhN6XNWRkMLhaGvhp1xaZNTAqgn8qULdENfMrUbCUcV4Kd4FQzVSHkKx9nmU7sNjBMPa96b9g3KTSJTAvTsTcT5mYDz97fUppvd";
+
+    /// The cursor-based `to_script` (production path) must produce byte-identical
+    /// scripts to the owned `DescriptorTemplate::to_script` reference across a
+    /// broad corpus of templates and coordinates. This guards the consensus
+    /// rewrite of `to_script`/taproot hashing onto arena cursors.
+    #[test]
+    fn cursor_to_script_matches_owned() {
+        let keys = [K0, K1, K2, K3];
+        // (template, number of @i keys referenced)
+        let corpus: &[(&str, usize)] = &[
+            ("pkh(@0/**)", 1),
+            ("wpkh(@0/**)", 1),
+            ("sh(wpkh(@0/**))", 1),
+            ("sh(wsh(multi(2,@0/**,@1/**)))", 2),
+            ("wsh(multi(2,@0/**,@1/**,@2/**))", 3),
+            ("wsh(sortedmulti(2,@0/**,@1/**))", 2),
+            ("sh(sortedmulti(2,@0/**,@1/**))", 2),
+            ("sh(wsh(sortedmulti(2,@0/**,@1/**,@2/**)))", 3),
+            ("tr(@0/**)", 1),
+            ("tr(@0/**,pk(@1/**))", 2),
+            ("tr(@0/**,{pk(@1/**),pk(@2/**)})", 3),
+            ("tr(@0/**,{pk(@1/**),{pk(@2/**),pk(@3/**)}})", 4),
+            ("tr(@0/**,multi_a(2,@1/**,@2/**))", 3),
+            ("tr(@0/**,sortedmulti_a(2,@1/**,@2/**))", 3),
+            ("wsh(and_v(v:pk(@0/**),older(144)))", 1),
+            ("wsh(and_v(v:pk(@0/**),after(1000000)))", 1),
+            ("wsh(or_d(pk(@0/**),and_v(v:pk(@1/**),older(65535))))", 2),
+            ("wsh(andor(pk(@0/**),older(144),pk(@1/**)))", 2),
+            ("wsh(thresh(2,pk(@0/**),s:pk(@1/**),s:pk(@2/**)))", 3),
+            ("wsh(or_i(pk(@0/**),pk(@1/**)))", 2),
+            (
+                "wsh(and_v(v:pk(@0/**),sha256(00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff)))",
+                1,
+            ),
+            (
+                "wsh(and_v(v:pk(@0/**),hash160(0011223344556677889900112233445566778899)))",
+                1,
+            ),
+            (
+                "wsh(and_v(v:pk(@0/**),hash256(00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff)))",
+                1,
+            ),
+            (
+                "wsh(and_v(v:pk(@0/**),ripemd160(0011223344556677889900112233445566778899)))",
+                1,
+            ),
+            ("tr(musig(@0,@1)/**)", 2),
+            ("tr(@0/**,pk(musig(@1,@2)/**))", 3),
+        ];
+
+        let coords = [(false, 0u32), (false, 5), (true, 0), (true, 99)];
+
+        for (template, n_keys) in corpus {
+            let key_info: Vec<_> = keys[..*n_keys]
+                .iter()
+                .map(|k| (*k).try_into().unwrap())
+                .collect();
+            let wp = WalletPolicy::new(template, key_info)
+                .unwrap_or_else(|e| panic!("failed to parse {template}: {e:?}"));
+
+            for &(is_change, address_index) in &coords {
+                // Compare the full Result (success bytes *and* rejection variant)
+                // via Debug, so the cursor path matches the owned path on both
+                // valid scripts and rejected contexts.
+                let owned = wp
+                    .descriptor_template()
+                    .to_script(
+                        wp.key_information(),
+                        is_change,
+                        address_index,
+                        ScriptContext::None,
+                    )
+                    .map(|s| s.as_bytes().to_vec());
+                let cursor = wp
+                    .descriptor_cursor()
+                    .to_script(
+                        wp.key_information(),
+                        is_change,
+                        address_index,
+                        ScriptContext::None,
+                    )
+                    .map(|s| s.as_bytes().to_vec());
+                assert_eq!(
+                    format!("{owned:?}"),
+                    format!("{cursor:?}"),
+                    "script mismatch for {template} @ (is_change={is_change}, index={address_index})"
+                );
+            }
+        }
+    }
 
     /// `tr(musig(@0,@1)/**)` script derivation.
     ///

--- a/apps/bitcoin/common/src/taproot.rs
+++ b/apps/bitcoin/common/src/taproot.rs
@@ -3,6 +3,8 @@
 use bitcoin::{hashes::Hash, taproot::LeafVersion};
 use bitcoin::{TapLeafHash, TapNodeHash};
 
+use bip388::arena::{ArenaRead, Cursor, TapCursor};
+
 use crate::{
     account::{DescriptorTemplate, KeyInformation, TapTree},
     errors::Error,
@@ -54,6 +56,55 @@ pub trait GetTapLeafHash {
 }
 
 impl GetTapLeafHash for DescriptorTemplate {
+    fn get_tapleaf_hash(
+        &self,
+        key_information: &[KeyInformation],
+        is_change: bool,
+        address_index: u32,
+    ) -> Result<TapLeafHash, Error> {
+        let script =
+            self.to_script(key_information, is_change, address_index, ScriptContext::Tr)?;
+        Ok(TapLeafHash::from_script(
+            script.as_script(),
+            LeafVersion::TapScript,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cursor-based taproot hashing (arena form).
+//
+// Mirrors the owned implementations above but walks arena `TapCursor`/`Cursor`s.
+// Used by the cursor `to_script` path; must produce identical hashes.
+// ---------------------------------------------------------------------------
+
+impl<'a, A: ArenaRead> GetTapTreeHash for TapCursor<'a, A> {
+    fn get_taptree_hash(
+        &self,
+        key_information: &[KeyInformation],
+        is_change: bool,
+        address_index: u32,
+    ) -> Result<[u8; 32], Error> {
+        if let Some(leaf_script) = self.leaf_script() {
+            Ok(leaf_script
+                .get_tapleaf_hash(key_information, is_change, address_index)?
+                .as_raw_hash()
+                .to_byte_array())
+        } else {
+            let (l, r) = self.branch().expect("tap node is leaf or branch");
+            let l_bytes = l.get_taptree_hash(key_information, is_change, address_index)?;
+            let r_bytes = r.get_taptree_hash(key_information, is_change, address_index)?;
+            let l_hash = TapNodeHash::from_slice(&l_bytes).map_err(|_| Error::InvalidKey)?;
+            let r_hash = TapNodeHash::from_slice(&r_bytes).map_err(|_| Error::InvalidKey)?;
+
+            Ok(TapNodeHash::from_node_hashes(l_hash, r_hash)
+                .as_raw_hash()
+                .to_byte_array())
+        }
+    }
+}
+
+impl<'a, A: ArenaRead> GetTapLeafHash for Cursor<'a, A> {
     fn get_tapleaf_hash(
         &self,
         key_information: &[KeyInformation],

--- a/vanadium.code-workspace
+++ b/vanadium.code-workspace
@@ -55,6 +55,10 @@
       "name": "₿ bip388"
     },
     {
+      "path": "apps/bitcoin/bip388-c",
+      "name": "₿ bip388-c"
+    },
+    {
       "path": "apps/bitcoin/client",
       "name": "₿ vnd-bitcoin-client"
     },


### PR DESCRIPTION
Rewrite the core parts of the bip388 crate, and the cleartext module (without the `cleartext-decode` feature) so that it:
- does not require an allocator
- does not depend on the `bitcoin` crate.

Then, implements portable C bindings for it.